### PR TITLE
Fix git-lfs track command in Performance

### DIFF
--- a/Performance.md
+++ b/Performance.md
@@ -42,7 +42,7 @@ Executed in   38.87 mins
 Compare this to a system like [git lfs](https://git-lfs.github.com/) on the same dataset
 
 ```
-git lfs track *.jpg
+git lfs track "*.jpg"
 git add images # ~136 sec
 git commit -m "adding images" # ~44 sec
 ```


### PR DESCRIPTION
There is a mistake in the `git-lfs track` command in the Performance: images are not properly tracked by Git LFS, thus resulting in a git remote error while pushing.

This PR fixes the `git-lfs track` command, so that all images are properly tracked by Git LFS.