### PR TITLE
Fixes for image classification loader dtypes

### DIFF
--- a/oxen/python/oxen/ops/read_image_dir.py
+++ b/oxen/python/oxen/ops/read_image_dir.py
@@ -20,7 +20,9 @@ class ReadImageDir(oxen.Op):
     def call(self, args):
         image_data = []
         prefix = args[0]
+        print("Reading images...")
         for path in tqdm(args[1]):
             img = cv2.imread(f"{prefix}/{path}", cv2.IMREAD_UNCHANGED)
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
             image_data.append(img)
         return image_data

--- a/oxen/python/oxen/ops/resize_images.py
+++ b/oxen/python/oxen/ops/resize_images.py
@@ -1,6 +1,7 @@
 import oxen
 import numpy as np
 import cv2
+from tqdm import tqdm
 
 
 class ResizeImages(oxen.Op):
@@ -88,9 +89,12 @@ class ResizeImages(oxen.Op):
             return np.array(args[0])
 
         n_channels = args[0][0].shape[2]
-        result = np.zeros((len(args[0]), args[1], args[1], n_channels))
+        out_dtype = args[0][0].dtype
+        result = np.zeros((len(args[0]), args[1], args[1],
+                            n_channels,), dtype=out_dtype,)
 
-        for i in range(len(args[0])):
+        print("Resizing images...")
+        for i in tqdm(range(len(args[0]))):
             if args[2] == "crop":
                 modified = self.crop(args[0][i], args[1])
             elif args[2] == "pad":

--- a/oxen/tests/test_image_classification_loader.py
+++ b/oxen/tests/test_image_classification_loader.py
@@ -24,7 +24,8 @@ def test_image_classification_dataloader_local(
         label_name="hair_color",
     )
     data, labels, mapper = loader.run()
-    print("dtype is", data.dtype)
+    
+    assert data.dtype == np.uint8
 
     assert data.shape == (5, 218, 178, 3), "Data not returned in expected shape"
     assert labels.shape == (5,)
@@ -80,7 +81,12 @@ def test_image_loader_resize_crop(
         resize_to=512,
         resize_method="crop",
     )
+
+
     data, labels, mapper = loader.run()
+
+    assert data.dtype == np.uint8
+    
     np.save(tmp_path / "imgs.npy", data)
     assert data.shape == (5, 512, 512, 3), "Data not returned in expected shape"
 


### PR DESCRIPTION
`np.zeros` was converting all images to float64, which was blowing up RAM on colab even for reasonably sized datasets. 

Also fixed `cv2`'s `BGR` formatting, which is inconsistent with all other python libs which expect `RGB`