### PR TITLE
Fix documentation typo: "it's" (it is) to "its" (possessive)

### DIFF
--- a/DataPointLevelVersionControl.md
+++ b/DataPointLevelVersionControl.md
@@ -122,7 +122,7 @@ shape: (202599, 41)
 
 The real power is when you stage and commit a DataFrame. Oxen processes and hashes each row and tracks the data schema over time, so that we can detect changes. Instead of seeing line by line changes on a diff, you can tell the individual rows and columns that changed. 
 
-Committing DataFrames is no different than committing any other file. Behind the scenes Oxen works it's magic to track all the changes.
+Committing DataFrames is no different than committing any other file. Behind the scenes Oxen works its magic to track all the changes.
 
 Let's stage and commit the list_attr_celeba.csv file so that we have the original version tracked.
 

--- a/Indices.md
+++ b/Indices.md
@@ -62,7 +62,7 @@ $ oxen schemas
 +------+----------------------------------+-----------------------------------+
 ```
 
-You'll see that each schema has a hash that is generated from the combination of it's field names and data types.
+You'll see that each schema has a hash that is generated from the combination of its field names and data types.
 
 To see a more expanded view of a schema you can run the `schema show` subcommand.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ repo.commit("Adding a new dog")
 
 The latest documentation can be found at [https://docs.oxen.ai](https://docs.oxen.ai).
 
-### ⭐️ Every GitHub Star Gives an Ox it's Wings
+### ⭐️ Every GitHub Star Gives an Ox its Wings
 
 No really.
 
@@ -654,7 +654,7 @@ If you use the `--combine` flag, oxen will concatenate the data frames and uniqu
 
 ## Content Hashing and Core Metadata Extraction
 
-Oxen uses some core metadata around the file to be able to version and transfer the data efficiently. Any time a file gets versioned, it's hash is computed and the contents is put into a content addressable filesystem. These files can be found in the hidden `.oxen` directory. For example a file with the hash `7f65e0e4bda0acc99c56ecacbe092141` will be stored in `.oxen/versions/files/7f/65e0e4bda0acc99c56ecacbe092141/` for fast random access given the hash.
+Oxen uses some core metadata around the file to be able to version and transfer the data efficiently. Any time a file gets versioned, its hash is computed and the contents is put into a content addressable filesystem. These files can be found in the hidden `.oxen` directory. For example a file with the hash `7f65e0e4bda0acc99c56ecacbe092141` will be stored in `.oxen/versions/files/7f/65e0e4bda0acc99c56ecacbe092141/` for fast random access given the hash.
 
 To find out more info about a file with the CLI you can use the `oxen info` command. For example:
 


### PR DESCRIPTION
This PR fixes a few instances in the documentation where the contraction "it's" (it is) has been incorrectly used in place of the possessive pronoun "its".

The code that creates the commits in https://www.oxen.ai/ox/FlyingOxen would also need to be updated from "[user] gave an Ox **it's** wings" to "[user] gave an Ox **its** wings".

I haven't discussed these changes, but I saw a small opportunity to improve this promising project and decided to take it. If this isn't the correct process for submitting changes like this, please let me know.