### PR TITLE
Update numpy and pyarrow to support Python 3.12

### DIFF
--- a/oxen/pyproject.toml
+++ b/oxen/pyproject.toml
@@ -14,9 +14,9 @@ classifiers = [
 dependencies = [
     "pandas==2.0.1", 
     "polars==0.17.11",
-    "pyarrow==12.0.0",
+    "pyarrow==15.0.*",
     "opencv-python-headless==4.7.0.72",
-    "numpy==1.24.3",
+    "numpy==1.26.4",
     "tqdm==4.65.0",
     "toml==0.10.2",
     "requests==2.31.0",

--- a/oxen/requirements.txt
+++ b/oxen/requirements.txt
@@ -3,9 +3,9 @@ pytest==7.3.1
 ruff==0.0.263
 pandas==2.0.1
 polars==0.17.11
-pyarrow==12.0.0
+pyarrow==15.0.*
 opencv-python-headless==4.7.0.72
-numpy==1.24.3
+numpy==1.26.4
 tqdm==4.65.0
 toml==0.10.2
 tensorflow==2.13.0rc1


### PR DESCRIPTION
The older version of numpy used ImpImporter which has been deprecated since python 3.3, and has was removed in python 3.12. I ran into errors with pyarrow and eventually figured out that using version 15.0.* (as suggested by https://arrow.apache.org/install/) solved the problem. I did some quick testing by creating a remote repo and pushing a local repo to the remote in a jupyter notebook running python 3.12 and found no bugs.