### PR TITLE
fix(cli): add missing deps and enable `clap` derive

### DIFF
--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -4387,11 +4387,14 @@ dependencies = [
  "glob",
  "jwalk",
  "liboxen",
+ "log",
  "minus",
  "rocksdb",
  "serde_json",
  "time",
  "tokio",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/oxen-rust/src/cli/Cargo.toml
+++ b/oxen-rust/src/cli/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.80"
 bytesize = "1.3.0"
-clap = { version = "4.2.7", features = ["cargo"] }
+clap = { version = "4.2.7", features = ["cargo", "derive"] }
 colored = "2.0.0"
 dialoguer = "0.11.0"
 dunce = "1"
@@ -14,6 +14,7 @@ env_logger = "0.11.3"
 jwalk = "0.8.1"
 glob = "0.3.1"
 liboxen = { path = "../lib" }
+log = "0.4.20"
 minus = { version = "5.3.1", features = ["static_output", "search"] }
 serde_json = "1.0.78"
 rocksdb = { version = "0.22.0", default-features = false, features = [
@@ -23,6 +24,8 @@ rocksdb = { version = "0.22.0", default-features = false, features = [
 ] }
 time = { version = "0.3.20", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
+url = "2.4.1"
+uuid = { version = "1.4.1", features = ["serde", "v4"] }
 
 [[bin]]
 name = "oxen"


### PR DESCRIPTION
adding some missing dependencies to address the build failure 

```
  error[E0432]: unresolved import `uuid`
    --> src/cli/src/cmd/remote_mode/checkout.rs:10:5
     |
  10 | use uuid::Uuid;
     |     ^^^^ use of unresolved module or unlinked crate `uuid`
     |
     = help: if you wanted to use a crate named `uuid`, use `cargo add uuid` to add it to your `Cargo.toml`
  
  error[E0432]: unresolved import `uuid`
    --> src/cli/src/cmd/workspace/create.rs:10:5
     |
  10 | use uuid::Uuid;
     |     ^^^^ use of unresolved module or unlinked crate `uuid`
     |
     = help: if you wanted to use a crate named `uuid`, use `cargo add uuid` to add it to your `Cargo.toml`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
    --> src/cli/src/helpers.rs:57:13
     |
  57 |             log::debug!("Err checking remote version:\n{err}")
     |             ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
    --> src/cli/src/cmd/workspace/df/index.rs:86:13
     |
  86 |             log::debug!("Data frame is already indexed.");
     |             ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
    --> src/cli/src/cmd/workspace/commit.rs:85:13
     |
  85 |             log::error!("Workspace commit No current branch found");
     |             ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/status.rs:128:13
      |
  128 |             log::error!("Err: {err:?}");
      |             ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
    --> src/cli/src/cmd/status.rs:94:9
     |
  94 |         log::debug!("status opts: {:?}", opts);
     |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
    --> src/cli/src/cmd/rm.rs:56:21
     |
  56 |                     log::warn!("Failed to get current directory: {}", e);
     |                     ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
    --> src/cli/src/cmd/remote_mode/commit.rs:60:13
     |
  60 |             log::error!("Remote-mode commit No current branch found");
     |             ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/notebook.rs:211:9
      |
  211 |         log::debug!("notebook opts: {:?}", opts);
      |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/notebook.rs:178:9
      |
  178 |         log::debug!("  Build Script: {:?}", build_script);
      |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/notebook.rs:177:9
      |
  177 |         log::debug!("  Timeout Secs: {}", timeout_secs);
      |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/notebook.rs:176:9
      |
  176 |         log::debug!("  Memory MB: {}", memory_mb);
      |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/notebook.rs:175:9
      |
  175 |         log::debug!("  CPU Cores: {}", cpu_cores);
      |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/notebook.rs:174:9
      |
  174 |         log::debug!("  GPU Model: {:?}", gpu_model);
      |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/notebook.rs:173:9
      |
  173 |         log::debug!("  Script Args: {:?}", args_vec);
      |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/notebook.rs:172:9
      |
  172 |         log::debug!("  Mode: {:?}", mode);
      |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/notebook.rs:171:9
      |
  171 |         log::debug!("  Base Image: {}", base_image);
      |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/notebook.rs:170:9
      |
  170 |         log::debug!("  Branch: {}", branch);
      |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/notebook.rs:169:9
      |
  169 |         log::debug!("  Notebook: {}", notebook);
      |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
     --> src/cli/src/cmd/notebook.rs:168:9
      |
  168 |         log::debug!("{:?} notebook with:", action);
      |         ^^^ use of unresolved module or unlinked crate `log`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `log`
    --> src/cli/src/cmd/add.rs:48:21
     |
  48 |                     log::warn!("Failed to get current directory: {}", e);
     |                     ^^^ use of unresolved module or unlinked crate `log`
  
  error: cannot find derive macro `ValueEnum` in this scope
    --> src/cli/src/cmd/notebook.rs:20:24
     |
  20 | #[derive(Clone, Debug, ValueEnum)]
     |                        ^^^^^^^^^
     |
  note: `ValueEnum` is imported here, but it is only a trait, without a derive macro
    --> src/cli/src/cmd/notebook.rs:2:26
     |
  2  | use clap::{Arg, Command, ValueEnum};
     |                          ^^^^^^^^^
  
  error: cannot find derive macro `ValueEnum` in this scope
    --> src/cli/src/cmd/notebook.rs:13:24
     |
  13 | #[derive(Clone, Debug, ValueEnum)]
     |                        ^^^^^^^^^
     |
  note: `ValueEnum` is imported here, but it is only a trait, without a derive macro
    --> src/cli/src/cmd/notebook.rs:2:26
     |
  2  | use clap::{Arg, Command, ValueEnum};
     |                          ^^^^^^^^^
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `url`
     --> src/cli/src/cmd/config.rs:146:16
      |
  146 |             Ok(url::Url::parse(host)?
      |                ^^^ use of unresolved module or unlinked crate `url`
      |
      = help: if you wanted to use a crate named `url`, use `cargo add url` to add it to your `Cargo.toml`
  help: consider importing this struct
      |
  1   + use liboxen::api::client::Url;
      |
  help: if you import `Url`, refer to it directly
      |
  146 -             Ok(url::Url::parse(host)?
  146 +             Ok(Url::parse(host)?
      |
  
  error[E0599]: the method `value_parser` exists for reference `&&&&&&_infer_ValueParser_for<NotebookAction>`, but its trait bounds were not satisfied
      --> src/cli/src/cmd/notebook.rs:42:35
       |
  14   | pub enum NotebookAction {
       | ----------------------- doesn't satisfy 7 bounds
  ...
  42   |                     .value_parser(clap::value_parser!(NotebookAction))
       |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `&&&&&&_infer_ValueParser_for<NotebookAction>` due to unsatisfied trait bounds
       |
      ::: /Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.40/src/builder/value_parser.rs:2439:1
       |
  2439 | pub struct _infer_ValueParser_for<T>(std::marker::PhantomData<T>);
       | ------------------------------------ doesn't satisfy `_: _impls_FromStr`
       |
       = note: the following trait bounds were not satisfied:
               `NotebookAction: ValueEnum`
               which is required by `&&&&&_infer_ValueParser_for<NotebookAction>: clap::builder::impl_prelude::_impls_ValueEnum`
               `NotebookAction: ValueParserFactory`
               which is required by `&&&&&&_infer_ValueParser_for<NotebookAction>: clap::builder::impl_prelude::_impls_ValueParserFactory`
               `NotebookAction: From<OsString>`
               which is required by `&&&&_infer_ValueParser_for<NotebookAction>: clap::builder::impl_prelude::_impls_From_OsString`
               `NotebookAction: From<&'s std::ffi::OsStr>`
               which is required by `&&&_infer_ValueParser_for<NotebookAction>: clap::builder::impl_prelude::_impls_From_OsStr`
               `NotebookAction: From<std::string::String>`
               which is required by `&&_infer_ValueParser_for<NotebookAction>: clap::builder::impl_prelude::_impls_From_String`
               `NotebookAction: From<&'s str>`
               which is required by `&_infer_ValueParser_for<NotebookAction>: clap::builder::impl_prelude::_impls_From_str`
               `NotebookAction: FromStr`
               which is required by `_infer_ValueParser_for<NotebookAction>: clap::builder::impl_prelude::_impls_FromStr`
  note: the traits `From`, `FromStr`, `ValueEnum`,  and `ValueParserFactory` must be implemented
      --> /private/tmp/rust-20250628-8349-ocddbc/rustc-1.88.0-src/library/core/src/convert/mod.rs:582:1
       |
      ::: /Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.40/src/builder/value_parser.rs:2276:1
       |
  2276 | pub trait ValueParserFactory {
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
      ::: /Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.40/src/derive.rs:292:1
       |
  292  | pub trait ValueEnum: Sized + Clone {
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      --> /private/tmp/rust-20250628-8349-ocddbc/rustc-1.88.0-src/library/core/src/str/traits.rs:798:1
       = note: this error originates in the macro `clap::value_parser` (in Nightly builds, run with -Z macro-backtrace for more info)
  
  error[E0599]: the method `value_parser` exists for reference `&&&&&&_infer_ValueParser_for<NotebookMode>`, but its trait bounds were not satisfied
      --> src/cli/src/cmd/notebook.rs:113:35
       |
  21   | pub enum NotebookMode {
       | --------------------- doesn't satisfy 7 bounds
  ...
  113  |                     .value_parser(clap::value_parser!(NotebookMode))
       |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `&&&&&&_infer_ValueParser_for<NotebookMode>` due to unsatisfied trait bounds
       |
      ::: /Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.40/src/builder/value_parser.rs:2439:1
       |
  2439 | pub struct _infer_ValueParser_for<T>(std::marker::PhantomData<T>);
       | ------------------------------------ doesn't satisfy `_: _impls_FromStr`
       |
       = note: the following trait bounds were not satisfied:
               `NotebookMode: ValueEnum`
               which is required by `&&&&&_infer_ValueParser_for<NotebookMode>: clap::builder::impl_prelude::_impls_ValueEnum`
               `NotebookMode: ValueParserFactory`
               which is required by `&&&&&&_infer_ValueParser_for<NotebookMode>: clap::builder::impl_prelude::_impls_ValueParserFactory`
               `NotebookMode: From<OsString>`
               which is required by `&&&&_infer_ValueParser_for<NotebookMode>: clap::builder::impl_prelude::_impls_From_OsString`
               `NotebookMode: From<&'s std::ffi::OsStr>`
               which is required by `&&&_infer_ValueParser_for<NotebookMode>: clap::builder::impl_prelude::_impls_From_OsStr`
               `NotebookMode: From<std::string::String>`
               which is required by `&&_infer_ValueParser_for<NotebookMode>: clap::builder::impl_prelude::_impls_From_String`
               `NotebookMode: From<&'s str>`
               which is required by `&_infer_ValueParser_for<NotebookMode>: clap::builder::impl_prelude::_impls_From_str`
               `NotebookMode: FromStr`
               which is required by `_infer_ValueParser_for<NotebookMode>: clap::builder::impl_prelude::_impls_FromStr`
  note: the traits `From`, `FromStr`, `ValueEnum`,  and `ValueParserFactory` must be implemented
      --> /private/tmp/rust-20250628-8349-ocddbc/rustc-1.88.0-src/library/core/src/convert/mod.rs:582:1
       |
      ::: /Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.40/src/builder/value_parser.rs:2276:1
       |
  2276 | pub trait ValueParserFactory {
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
      ::: /Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.40/src/derive.rs:292:1
       |
  292  | pub trait ValueEnum: Sized + Clone {
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      --> /private/tmp/rust-20250628-8349-ocddbc/rustc-1.88.0-src/library/core/src/str/traits.rs:798:1
       = note: this error originates in the macro `clap::value_parser` (in Nightly builds, run with -Z macro-backtrace for more info)
  
  Some errors have detailed explanations: E0432, E0433, E0599.
  For more information about an error, try `rustc --explain E0432`.
  error: could not compile `oxen-cli` (bin "oxen") due to 27 previous errors
  error: failed to compile `oxen-cli v0.36.2 (/private/tmp/oxen-20250730-8312-pyf2l1/Oxen-0.36.2/oxen-rust/src/cli)`, intermediate artifacts can be found at `/private/tmp/oxen-20250730-8312-pyf2l1/Oxen-0.36.2/oxen-rust/target`.
  To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
 
```

relates to https://github.com/Homebrew/homebrew-core/pull/231673