### PR TITLE
Implement dir-level sync for push

### DIFF
--- a/oxen-rust/src/benches/oxen.rs
+++ b/oxen-rust/src/benches/oxen.rs
@@ -1,8 +1,12 @@
+// TODO: Split into separate files?
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use liboxen::error::OxenError;
-use liboxen::model::LocalRepository;
+use liboxen::model::{LocalRepository, RemoteRepository};
 use liboxen::repositories;
 use liboxen::util;
+use liboxen::api;
+use liboxen::command;
+use liboxen::test::create_remote_repo;
 use rand::distributions::Alphanumeric;
 use rand::{Rng, RngCore};
 use std::fs;
@@ -14,6 +18,26 @@ fn generate_random_string(len: usize) -> String {
         .take(len)
         .map(char::from)
         .collect()
+}
+
+fn write_file_for_push_benchmark(
+    file_path: &Path,
+    large_file_chance: f64,
+) -> Result<(), OxenError> {
+    if rand::thread_rng().gen_range(0.0..1.0) < large_file_chance {
+        // 10% of files are large
+        let large_content_size = 20 * 1024 * 1024 + 1; // > 20MB
+        let mut large_content = vec![0u8; large_content_size];
+        rand::thread_rng().fill_bytes(&mut large_content);
+        fs::write(file_path, &large_content)?;
+    } else {
+        // 90% of files are small
+        let small_content_size = 2 * 1024 - 1; // < 2KB
+        let mut small_content = vec![0u8; small_content_size];
+        rand::thread_rng().fill_bytes(&mut small_content);
+        fs::write(file_path, &small_content)?;
+    }
+    Ok(())
 }
 
 fn write_file_for_add_benchmark(
@@ -108,8 +132,102 @@ async fn setup_repo_for_add_benchmark(
             "this is a new test file to be added",
         )?;
     }
+
     Ok((repo, dirs, files_dir))
 }
+
+async fn setup_repo_for_push_benchmark(
+    base_dir: &Path,
+    repo_size: usize,
+    num_files_to_push_in_benchmark: usize,
+    dir_size: usize,
+) -> Result<(LocalRepository, RemoteRepository), OxenError> {
+    let repo_dir = base_dir.join(format!("repo_{}", num_files_to_push_in_benchmark));
+    if repo_dir.exists() {
+        util::fs::remove_dir_all(&repo_dir)?;
+    }
+
+    let mut repo = repositories::init(&repo_dir)?;
+    let remote_repo = create_remote_repo(&repo).await?;
+
+    // Set remote
+    command::config::set_remote(
+        &mut repo,
+        
+        format!("repo_{}", num_files_to_push_in_benchmark).as_ref(),
+        &remote_repo.remote.url,
+    )?;
+
+    let files_dir = repo_dir.join("files");
+    util::fs::create_dir_all(&files_dir)?;
+
+    let mut rng = rand::thread_rng();
+
+    // Create a number of directories up to 4 levels deep
+    let mut dirs: Vec<PathBuf> = (0..dir_size)
+        .map(|_| {
+            let mut path = files_dir.clone();
+            let depth = rng.gen_range(1..=4);
+            for _ in 0..depth {
+                path = path.join(generate_random_string(10));
+            }
+            path
+        })
+        .collect();
+    dirs.push(files_dir.clone());
+
+    // Calculate large_file_percentage based on repo_size
+    let large_file_percentage: f64;
+    let min_repo_size_for_scaling = 1000.0;
+    let max_repo_size_for_scaling = 100000.0;
+    let max_large_file_ratio = 0.5; // 50% for smallest repo
+    let min_large_file_ratio = 0.01; // 1% for largest repo
+
+    if (repo_size as f64) <= min_repo_size_for_scaling {
+        large_file_percentage = max_large_file_ratio;
+    } else if (repo_size as f64) >= max_repo_size_for_scaling {
+        large_file_percentage = min_large_file_ratio;
+    } else {
+        let log_repo_size = (repo_size as f64).log10();
+        let log_min_repo_size = min_repo_size_for_scaling.log10();
+        let log_max_repo_size = max_repo_size_for_scaling.log10();
+
+        let normalized_log_repo_size =
+            (log_repo_size - log_min_repo_size) / (log_max_repo_size - log_min_repo_size);
+
+        large_file_percentage = max_large_file_ratio
+            - (max_large_file_ratio - min_large_file_ratio) * normalized_log_repo_size;
+    }
+
+    for i in 0..repo_size {
+        let dir_idx = rng.gen_range(0..dirs.len());
+        let dir = &dirs[dir_idx];
+        util::fs::create_dir_all(dir)?;
+        let file_path = dir.join(format!("file_{}.txt", i));
+        write_file_for_push_benchmark(&file_path, large_file_percentage)?;
+    }
+    repositories::add(&repo, black_box(&files_dir)).await?;
+    repositories::commit(&repo, "Init")?;
+    repositories::push(&repo).await?;
+
+
+    for i in repo_size..(repo_size + num_files_to_push_in_benchmark) {
+        let dir_idx = rng.gen_range(0..dirs.len());
+        let dir = &dirs[dir_idx];
+        util::fs::create_dir_all(dir)?;
+        let file_path = dir.join(format!("file_{}.txt", i));
+        write_file_for_push_benchmark(
+            &file_path,
+            large_file_percentage,
+        )?;
+    }
+
+    repositories::add(&repo, black_box(&files_dir)).await?;
+    repositories::commit(&repo, "Prepare test files for push benchmark")?;
+
+    Ok((repo, remote_repo))
+}
+
 
 fn add_benchmark(c: &mut Criterion) {
     let base_dir = PathBuf::from("data/test/benches/add");
@@ -164,6 +282,61 @@ fn add_benchmark(c: &mut Criterion) {
     util::fs::remove_dir_all(base_dir).unwrap();
 }
 
+fn push_benchmark(c: &mut Criterion) {
+    let base_dir = PathBuf::from("data/test/benches/push");
+    if base_dir.exists() {
+        util::fs::remove_dir_all(&base_dir).unwrap();
+    }
+    util::fs::create_dir_all(&base_dir).unwrap();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut group = c.benchmark_group("add");
+    group.sample_size(10);
+    let params = [
+        (1000, 20),
+        (10000, 20),
+        (100000, 20),
+        (100000, 100),
+        (100000, 1000),
+        (1000000, 1000),
+    ];
+    for &(repo_size, dir_size) in params.iter() {
+        let num_files_to_push = repo_size / 1000;
+        let (repo, remote_repo) = rt
+            .block_on(setup_repo_for_push_benchmark(
+                &base_dir,
+                repo_size,
+                num_files_to_push,
+                dir_size,
+            ))
+            .unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::new(
+                format!("{}k_files_in_{}dirs", num_files_to_push, dir_size),
+                format!("{:?}", (num_files_to_push, dir_size)),
+            ),
+            &(num_files_to_push, dir_size),
+            |b, _| {
+                // Run in async executor
+                b.to_async(&rt).iter(|| async {
+                    // TODO: Black box?
+                    repositories::push(&repo)
+                        .await
+                        .unwrap();
+
+                    // Cleanup remote repo
+                    let _ = api::client::repositories::delete(&remote_repo).await.unwrap();
+                })
+            },
+        );
+    }
+    group.finish();
+
+    // Cleanup
+    util::fs::remove_dir_all(base_dir).unwrap();
+}
+
 // Register Benchmark functions
-criterion_group!(benches, add_benchmark);
+criterion_group!(benches, add_benchmark, push_benchmark);
 criterion_main!(benches);

--- a/oxen-rust/src/lib/src/api/client/commits.rs
+++ b/oxen-rust/src/lib/src/api/client/commits.rs
@@ -1227,7 +1227,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_list_missing_commit_hashes() -> Result<(), OxenError> {
+    async fn test_list_unsynced_commit_hashes() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|local_repo, remote_repo| async move {
             let commit = repositories::commits::head_commit(&local_repo)?;
             let commit_hash = MerkleHash::from_str(&commit.id)?;

--- a/oxen-rust/src/lib/src/api/client/tree.rs
+++ b/oxen-rust/src/lib/src/api/client/tree.rs
@@ -496,6 +496,30 @@ pub async fn list_missing_file_hashes_from_nodes(
     }
 }
 
+pub async fn mark_nodes_as_synced(
+    remote_repo: &RemoteRepository,
+    commit_hashes: HashSet<MerkleHash>,
+) -> Result<(), OxenError> {
+    let uri = "/tree/nodes/mark_nodes_as_synced".to_string();
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+    let client = client::new_for_url(&url)?;
+    let res = client
+        .post(&url)
+        .json(&MerkleHashes {
+            hashes: commit_hashes,
+        })
+        .send()
+        .await?;
+    let body = client::parse_json_body(&url, res).await?;
+    let response: Result<MerkleHashesResponse, serde_json::Error> = serde_json::from_str(&body);
+    match response {
+        Ok(_response) => Ok(()),
+        Err(err) => Err(OxenError::basic_str(format!(
+            "api::client::tree::list_missing_hashes() Could not deserialize response [{err}]\n{body}"
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::api;

--- a/oxen-rust/src/lib/src/core.rs
+++ b/oxen-rust/src/lib/src/core.rs
@@ -5,6 +5,7 @@ pub mod commit_sync_status;
 pub mod db;
 pub mod df;
 pub mod merge;
+pub mod node_sync_status;
 pub mod oxenignore;
 pub mod progress;
 pub mod refs;

--- a/oxen-rust/src/lib/src/core/node_sync_status.rs
+++ b/oxen-rust/src/lib/src/core/node_sync_status.rs
@@ -1,0 +1,57 @@
+use crate::constants;
+use crate::core::db::merkle_node::merkle_node_db::node_db_prefix;
+use crate::error::OxenError;
+use crate::model::LocalRepository;
+use crate::model::MerkleHash;
+use crate::util;
+use std::path::PathBuf;
+
+pub fn node_is_synced(repo: &LocalRepository, node_hash: &MerkleHash) -> bool {
+    let is_synced_path = node_is_synced_file_path(repo, node_hash);
+    log::debug!("Checking if node is synced: {is_synced_path:?}");
+    match std::fs::read_to_string(&is_synced_path) {
+        Ok(value) => {
+            log::debug!("Is synced value: {value}");
+            "true" == value
+        }
+        Err(err) => {
+            log::debug!("Could not read is_synced file {is_synced_path:?}: {}", err);
+            false
+        }
+    }
+}
+
+pub fn mark_node_as_synced(
+    repo: &LocalRepository,
+    node_hash: &MerkleHash,
+) -> Result<(), OxenError> {
+    let is_synced_path = node_is_synced_file_path(repo, node_hash);
+    if let Some(parent) = is_synced_path.parent() {
+        log::debug!("Creating parent directory: {parent:?}");
+        util::fs::create_dir_all(parent)?;
+    }
+
+    log::debug!("Writing is synced: {is_synced_path:?}");
+
+    match std::fs::write(&is_synced_path, "true") {
+        Ok(_) => {
+            log::debug!("Wrote is synced file: {is_synced_path:?}");
+            Ok(())
+        }
+        Err(err) => Err(OxenError::basic_str(format!(
+            "Could not write is_synced file: {}",
+            err
+        ))),
+    }
+}
+
+fn node_is_synced_file_path(repo: &LocalRepository, node_hash: &MerkleHash) -> PathBuf {
+    let dir_prefix = node_db_prefix(node_hash);
+    repo.path
+        .join(constants::OXEN_HIDDEN_DIR)
+        .join(constants::TREE_DIR)
+        .join(constants::SYNC_STATUS_DIR)
+        .join(constants::NODES_DIR)
+        .join(dir_prefix)
+        .join(constants::IS_SYNCED)
+}

--- a/oxen-rust/src/lib/src/core/v_latest/push.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/push.rs
@@ -1,7 +1,8 @@
 use futures::prelude::*;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::time::Duration;
 
@@ -16,6 +17,14 @@ use crate::model::merkle_tree::node::{EMerkleTreeNode, MerkleTreeNode};
 use crate::model::{Branch, Commit, CommitEntry, LocalRepository, MerkleHash, RemoteRepository};
 use crate::util::{self, concurrency};
 use crate::{api, repositories};
+use derive_more::FromStr;
+
+// Struct to track node parents for dir-level sync
+#[derive(Eq, Hash, PartialEq)]
+pub struct EntryWithParent {
+    pub commit_entry: Entry,
+    pub parent_id: MerkleHash,
+}
 
 pub async fn push(repo: &LocalRepository) -> Result<Branch, OxenError> {
     let Some(current_branch) = repositories::branches::current_branch(repo)? else {
@@ -117,8 +126,9 @@ async fn push_to_new_branch(
 fn collect_missing_files(
     node: &MerkleTreeNode,
     hashes: &HashSet<MerkleHash>,
-    entries: &mut HashSet<Entry>,
+    entries: &mut HashSet<EntryWithParent>,
     total_bytes: &mut u64,
+    total_children: &mut usize,
 ) -> Result<(), OxenError> {
     log::debug!(
         "collect_missing_files node: {} children: {}",
@@ -126,20 +136,26 @@ fn collect_missing_files(
         node.children.len()
     );
     for child in &node.children {
-        // println!("Child: {child:?}");
         if let EMerkleTreeNode::File(file_node) = &child.node {
             if !hashes.contains(&child.hash) {
                 continue;
             }
             *total_bytes += file_node.num_bytes();
-            entries.insert(Entry::CommitEntry(CommitEntry {
-                commit_id: file_node.last_commit_id().to_string(),
-                path: PathBuf::from(file_node.name()),
-                hash: child.hash.to_string(),
-                num_bytes: file_node.num_bytes(),
-                last_modified_seconds: file_node.last_modified_seconds(),
-                last_modified_nanoseconds: file_node.last_modified_nanoseconds(),
-            }));
+            // Empty entries aren't pushed to the remote, so don't count them in total children
+            if file_node.num_bytes() > 0 {
+                *total_children += 1;
+            }
+            entries.insert(EntryWithParent {
+                commit_entry: Entry::CommitEntry(CommitEntry {
+                    commit_id: file_node.last_commit_id().to_string(),
+                    path: PathBuf::from(file_node.name()),
+                    hash: child.hash.to_string(),
+                    num_bytes: file_node.num_bytes(),
+                    last_modified_seconds: file_node.last_modified_seconds(),
+                    last_modified_nanoseconds: file_node.last_modified_nanoseconds(),
+                }),
+                parent_id: node.hash,
+            });
         }
     }
     Ok(())
@@ -272,7 +288,7 @@ async fn push_commits(
         candidate_node_hashes.len()
     ));
 
-    log::debug!("Candidate Hashes: {candidate_node_hashes:?}");
+    // log::debug!("Candidate Hashes: {candidate_node_hashes:?}");
     let missing_node_hashes =
         api::client::tree::list_missing_node_hashes(remote_repo, candidate_node_hashes).await?;
     log::debug!(
@@ -292,11 +308,6 @@ async fn push_commits(
         }
     }
 
-    // As well, don't collect anything in the
-    log::debug!(
-        "push_commits missing_nodes count: {:?}",
-        missing_nodes.len()
-    );
     progress.set_message(format!("Pushing {} nodes...", missing_nodes.len()));
     api::client::tree::create_nodes(repo, remote_repo, missing_nodes.clone(), &progress).await?;
 
@@ -315,32 +326,83 @@ async fn push_commits(
     )
     .await?;
     progress.set_message(format!("Pushing {} files...", missing_file_hashes.len()));
-    let mut missing_files: HashSet<Entry> = HashSet::new();
+    let mut missing_files: HashSet<EntryWithParent> = HashSet::new();
     let mut total_bytes = 0;
+
+    // Tracking variables for dir-level sync
+    let mut node_parents: HashMap<MerkleHash, MerkleHash> = HashMap::new();
+    let mut node_child_count: HashMap<MerkleHash, AtomicUsize> = HashMap::new();
+    let mut total_files: usize = 0;
+
     for node in missing_nodes {
         collect_missing_files(
             &node,
             &missing_file_hashes,
             &mut missing_files,
             &mut total_bytes,
+            &mut total_files,
         )?;
+
+        log::debug!(
+            "children for node {:?}: {:?}",
+            node.hash,
+            node.children.len()
+        );
+
+        // Track each dir/vnode's parents and children to determine when to mark as synced
+        node_child_count.insert(node.hash, AtomicUsize::new(total_files));
+        if let Some(parent_hash) = node.parent_id {
+            node_parents.insert(node.hash, parent_hash);
+        }
+
+        total_files = 0;
     }
 
-    let missing_files: Vec<Entry> = missing_files.into_iter().collect();
+    // Add nodes with files to push to their parents' child count
+    // Mark nodes without files to push as synced immediately
+
+    // Note: This logic relies on all children appearing before their parents in missing_nodes
+    // This should always happen with the current walk_tree_without_leaves implementation
+
+    let mut empty_nodes: HashSet<MerkleHash> = HashSet::new();
+    for (node_hash, parent_hash) in &node_parents {
+        if let Some(child_count) = node_child_count.get(node_hash) {
+            if child_count.load(Ordering::SeqCst) > 0 {
+                if let Some(parent_count) = node_child_count.get(parent_hash) {
+                    parent_count.fetch_add(1, Ordering::SeqCst);
+                }
+            } else {
+                empty_nodes.insert(*node_hash);
+            }
+        }
+    }
+
+    api::client::tree::mark_nodes_as_synced(remote_repo, empty_nodes).await?;
+
+    let missing_files: Vec<EntryWithParent> = missing_files.into_iter().collect();
     progress.finish();
     let progress = Arc::new(PushProgress::new_with_totals(
         missing_files.len() as u64,
         total_bytes,
     ));
     log::debug!("pushing {} entries", missing_files.len());
+
     let commit = &history.last().unwrap();
-    push_entries(repo, remote_repo, &missing_files, commit, &progress).await?;
+    let node_child_count = Arc::new(node_child_count);
+
+    push_entries(
+        repo,
+        remote_repo,
+        &node_child_count,
+        &node_parents,
+        &missing_files,
+        commit,
+        &progress,
+    )
+    .await?;
 
     // Mark commits as synced on the server
     api::client::commits::mark_commits_as_synced(remote_repo, missing_commit_hashes).await?;
-
-    // Mark dirs/vnodes as synced on the server
-    // TODO
 
     progress.finish();
 
@@ -350,7 +412,9 @@ async fn push_commits(
 pub async fn push_entries(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    entries: &[Entry],
+    node_child_count: &Arc<HashMap<MerkleHash, AtomicUsize>>,
+    node_parents: &HashMap<MerkleHash, MerkleHash>,
+    entries: &[EntryWithParent],
     commit: &Commit,
     progress: &Arc<PushProgress>,
 ) -> Result<(), OxenError> {
@@ -360,57 +424,246 @@ pub async fn push_entries(
         commit.id,
         commit.message
     );
-    // Some files may be much larger than others....so we can't just zip them up and send them
-    // since bodies will be too big. Hence we chunk and send the big ones, and bundle and send the small ones
 
-    // For files smaller than AVG_CHUNK_SIZE, we are going to group them, zip them up, and transfer them
-    let smaller_entries: Vec<Entry> = entries
-        .iter()
-        .filter(|e| e.num_bytes() <= AVG_CHUNK_SIZE)
-        .map(|e| e.to_owned())
-        .collect();
-
-    // For files larger than AVG_CHUNK_SIZE, we are going break them into chunks and send the chunks in parallel
-    let larger_entries: Vec<Entry> = entries
-        .iter()
-        .filter(|e| e.num_bytes() > AVG_CHUNK_SIZE)
-        .map(|e| e.to_owned())
-        .collect();
-
-    let large_entries_sync = chunk_and_send_large_entries(
-        local_repo,
-        remote_repo,
-        larger_entries,
-        commit,
-        AVG_CHUNK_SIZE,
-        progress,
-    );
-    let small_entries_sync = bundle_and_send_small_entries(
-        local_repo,
-        remote_repo,
-        smaller_entries,
-        commit,
-        AVG_CHUNK_SIZE,
-        progress,
+    use tokio::time::sleep;
+    type PieceOfWork = (
+        Entry,
+        MerkleHash,
+        LocalRepository,
+        Commit,
+        RemoteRepository,
+        Arc<reqwest::Client>,
     );
 
-    match tokio::join!(large_entries_sync, small_entries_sync) {
-        (Ok(_), Ok(_)) => {
-            log::debug!("Moving on to post-push validation");
-            Ok(())
-        }
-        (Err(err), Ok(_)) => {
-            let err = format!("Error syncing large entries: {err}");
-            Err(OxenError::basic_str(err))
-        }
-        (Ok(_), Err(err)) => {
-            let err = format!("Error syncing small entries: {err}");
-            Err(OxenError::basic_str(err))
-        }
-        _ => Err(OxenError::basic_str("Unknown error syncing entries")),
+    type TaskQueue = deadqueue::limited::Queue<PieceOfWork>;
+    type FinishedTaskQueue = deadqueue::limited::Queue<bool>;
+
+    // Create a client for uploading chunks
+    let client = Arc::new(api::client::builder_for_remote_repo(remote_repo)?.build()?);
+
+    log::debug!(
+        "Splitting {} entries into pieces of work for upload",
+        entries.len()
+    );
+    let entries: Vec<PieceOfWork> = entries
+        .iter()
+        .map(|e| {
+            (
+                e.commit_entry.to_owned(),
+                e.parent_id.to_owned(),
+                local_repo.to_owned(),
+                commit.to_owned(),
+                remote_repo.to_owned(),
+                client.clone(),
+            )
+        })
+        .collect();
+
+    if entries.is_empty() {
+        log::debug!("No entries to push. Exiting immediately");
+        return Ok(());
     }
+
+    let queue = Arc::new(TaskQueue::new(entries.len()));
+    let finished_queue = Arc::new(FinishedTaskQueue::new(entries.len()));
+    for entry in entries.iter() {
+        queue.try_push(entry.to_owned()).unwrap();
+        finished_queue.try_push(false).unwrap();
+    }
+
+    let worker_count = concurrency::num_threads_for_items(entries.len());
+    log::debug!(
+        "worker_count {} entries len {}",
+        worker_count,
+        entries.len()
+    );
+
+    for worker in 0..worker_count {
+        let queue = queue.clone();
+        let finished_queue = finished_queue.clone();
+        let bar = Arc::clone(progress);
+        let node_parents = node_parents.clone();
+
+        let node_child_count_copy = Arc::clone(node_child_count);
+        let mut small_entries_chunk: Vec<Entry> = vec![];
+        let mut files_to_push: Vec<(MerkleHash, MerkleHash)> = vec![];
+        let mut current_size: u64 = 0;
+        let mut synced_nodes: HashSet<MerkleHash> = HashSet::new();
+
+        let local_repo_copy = local_repo.clone();
+        let remote_repo_copy = remote_repo.clone();
+        let client_copy = client.clone();
+
+        tokio::spawn(async move {
+            loop {
+                let Some((entry, parent_id, repo, commit, remote_repo, client)) = queue.try_pop()
+                else {
+                    break;
+                };
+
+                log::debug!("worker[{}] processing task...", worker);
+
+                if entry.num_bytes() >= AVG_CHUNK_SIZE {
+                    upload_large_file_chunks(
+                        entry.clone(),
+                        repo,
+                        commit,
+                        remote_repo,
+                        AVG_CHUNK_SIZE,
+                        &bar,
+                    )
+                    .await;
+
+                    // Decrement child count for parent hash
+
+                    let entry_hash = match MerkleHash::from_str(&entry.hash()) {
+                        Ok(hash) => hash,
+                        Err(_) => {
+                            log::error!("{}", format_args!("Error: cannot get hash from entry {entry:?}. Skipping decrement"));
+                            continue;
+                        }
+                    };
+
+                    let to_decrement = vec![(entry_hash, parent_id)];
+                    match decrement_child_count(
+                        &node_child_count_copy,
+                        &node_parents,
+                        &to_decrement,
+                        &mut synced_nodes,
+                    ) {
+                        Ok(_) => {}
+                        // TODO: How to handle errors with this?
+                        Err(e) => log::debug!("Error updating count: {}", e),
+                    }
+
+                    finished_queue.pop().await;
+                    // synced_nodes.clear();
+                } else {
+                    // If the next entry would breach the average chunk size, push the current chunk
+                    if current_size + entry.num_bytes() > AVG_CHUNK_SIZE {
+                        match api::client::versions::multipart_batch_upload_with_retry(
+                            &repo,
+                            &remote_repo,
+                            &small_entries_chunk,
+                            &client,
+                            &synced_nodes,
+                        )
+                        .await
+                        {
+                            Ok(_err_files) => {
+                                // TODO: return err files info to the user
+                                log::debug!("Successfully uploaded data!")
+                            }
+                            Err(e) => {
+                                // TODO: Surface the error to the user
+                                log::error!("Error uploading chunk: {:?}", e)
+                            }
+                        }
+
+                        // Decrement child count for each parent hash
+                        // TODO: Handle err_files differently; probably shouldn't decrement their parents' count until they're actually uploaded
+                        synced_nodes.clear();
+                        match decrement_child_count(
+                            &node_child_count_copy,
+                            &node_parents,
+                            &files_to_push,
+                            &mut synced_nodes,
+                        ) {
+                            Ok(_) => {}
+                            // TODO: How to handle errors with this?
+                            Err(e) => log::debug!("Error updating count: {}", e),
+                        }
+
+                        // Update progress bar
+                        bar.add_bytes(current_size);
+                        bar.add_files(small_entries_chunk.len() as u64);
+
+                        // Update finished queue
+                        for _ in 0..small_entries_chunk.len() {
+                            finished_queue.pop().await;
+                        }
+
+                        // Reset tracking variables
+                        small_entries_chunk.clear();
+                        files_to_push.clear();
+                        current_size = 0;
+                    }
+
+                    // Add the current entry
+                    small_entries_chunk.push(entry.clone());
+                    let entry_hash = match MerkleHash::from_str(&entry.hash()) {
+                        Ok(hash) => hash,
+                        Err(_) => {
+                            log::error!("{}", format_args!("Error: cannot get hash from entry {entry:?}. Skipping decrement"));
+                            continue;
+                        }
+                    };
+
+                    files_to_push.push((entry_hash, parent_id));
+                    current_size += entry.num_bytes();
+                }
+            }
+
+            // Upload the remaining small entries
+            if !small_entries_chunk.is_empty() || !synced_nodes.is_empty() {
+                log::debug!(
+                    "Worker[{}] uploading remaining small entries chunk...",
+                    worker
+                );
+
+                // Decrement child_count before pushing to ensure all nodes get marked as synced
+                match decrement_child_count(
+                    &node_child_count_copy,
+                    &node_parents,
+                    &files_to_push,
+                    &mut synced_nodes,
+                ) {
+                    Ok(_) => {}
+                    Err(e) => log::debug!("Error updating count: {}", e),
+                }
+                log::debug!("synced_nodes for final upload: {synced_nodes:?}");
+                match api::client::versions::multipart_batch_upload_with_retry(
+                    &local_repo_copy,
+                    &remote_repo_copy,
+                    &small_entries_chunk,
+                    &client_copy,
+                    &synced_nodes.clone(),
+                )
+                .await
+                {
+                    Ok(_err_files) => {
+                        log::debug!("Successfully uploaded remaining data!");
+                    }
+                    Err(e) => {
+                        log::error!("Error uploading remaining chunk: {:?}", e);
+                    }
+                }
+
+                // Update progress bar
+                bar.add_bytes(current_size);
+                bar.add_files(small_entries_chunk.len() as u64);
+
+                // Update finished queue
+                for _ in 0..small_entries_chunk.len() {
+                    finished_queue.pop().await;
+                }
+            }
+        });
+    }
+
+    while !finished_queue.is_empty() {
+        // log::debug!("Before waiting for {} workers to finish...", queue.len());
+        sleep(Duration::from_secs(1)).await;
+    }
+    log::debug!("All file tasks done. :-)");
+
+    // Sleep again to let things sync...
+    sleep(Duration::from_millis(100)).await;
+
+    Ok(())
 }
 
+/*
 async fn chunk_and_send_large_entries(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
@@ -481,6 +734,7 @@ async fn chunk_and_send_large_entries(
 
     Ok(())
 }
+    */
 
 /// Chunk and send large file in parallel
 async fn upload_large_file_chunks(
@@ -645,6 +899,7 @@ async fn upload_large_file_chunks(
                 };
 
                 let is_compressed = false;
+
                 match api::client::commits::upload_data_chunk_to_server_with_retry(
                     &client,
                     &remote_repo,
@@ -691,6 +946,7 @@ async fn upload_large_file_chunks(
     progress.add_files(1);
 }
 
+/*
 /// Sends entries in tarballs of size ~chunk size
 async fn bundle_and_send_small_entries(
     local_repo: &LocalRepository,
@@ -704,7 +960,7 @@ async fn bundle_and_send_small_entries(
         return Ok(());
     }
 
-    // Compute size for this subset of entries
+
     let total_size = repositories::entries::compute_generic_entries_size(&entries)?;
     let num_chunks = ((total_size / avg_chunk_size) + 1) as usize;
 
@@ -769,11 +1025,13 @@ async fn bundle_and_send_small_entries(
                     }
                 };
 
+                let _synced_nodes = HashSet::new();
                 match api::client::versions::multipart_batch_upload_with_retry(
                     &repo,
                     &remote_repo,
                     &chunk,
                     &client,
+                    &_synced_nodes,
                 )
                 .await
                 {
@@ -804,6 +1062,7 @@ async fn bundle_and_send_small_entries(
 
     Ok(())
 }
+*/
 
 async fn find_latest_remote_commit(
     repo: &LocalRepository,
@@ -840,4 +1099,41 @@ async fn find_latest_remote_commit(
         // No branches found
         Ok(None)
     }
+}
+
+fn decrement_child_count(
+    node_child_count: &Arc<HashMap<MerkleHash, AtomicUsize>>,
+    parent_map: &HashMap<MerkleHash, MerkleHash>,
+    pushed_files: &Vec<(MerkleHash, MerkleHash)>,
+    synced_nodes: &mut HashSet<MerkleHash>,
+) -> Result<(), OxenError> {
+    for (_, dir_hash) in pushed_files {
+        if let Some(count) = node_child_count.get(dir_hash) {
+            // Atomically fetch and subtract from count
+            let prev_count = count.fetch_sub(1, Ordering::SeqCst);
+            // If prev_count is one, all the node's children have been pushed
+            if prev_count == 1 {
+                log::debug!("Dir node {:?} fully synced", dir_hash);
+                synced_nodes.insert(*dir_hash);
+
+                if let Some(dir_parent) = parent_map.get(dir_hash) {
+                    let synced_dir: Vec<(MerkleHash, MerkleHash)> =
+                        vec![(dir_hash.to_owned(), dir_parent.to_owned())];
+                    return decrement_child_count(
+                        node_child_count,
+                        parent_map,
+                        &synced_dir,
+                        synced_nodes,
+                    );
+                }
+            }
+        } else {
+            return Err(OxenError::basic_str(format!(
+                "Parent hash {:?} not found in node_child_count",
+                dir_hash
+            )));
+        }
+    }
+
+    Ok(())
 }

--- a/oxen-rust/src/server/src/controllers/commits.rs
+++ b/oxen-rust/src/server/src/controllers/commits.rs
@@ -166,7 +166,7 @@ pub async fn list_missing(
         merkle_hashes.hashes.len()
     );
     let missing_commits =
-        repositories::tree::list_missing_commit_hashes(&repo, &merkle_hashes.hashes)?;
+        repositories::tree::list_unsynced_commit_hashes(&repo, &merkle_hashes.hashes)?;
     log::debug!(
         "list_missing found {} missing commits",
         missing_commits.len()

--- a/oxen-rust/src/server/src/controllers/versions.rs
+++ b/oxen-rust/src/server/src/controllers/versions.rs
@@ -8,8 +8,10 @@ use actix_multipart::Multipart;
 use actix_web::{Error, HttpRequest, HttpResponse};
 use flate2::read::GzDecoder;
 use futures_util::TryStreamExt as _;
+use liboxen::core::node_sync_status;
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
+use liboxen::model::MerkleHash;
 use liboxen::view::versions::{VersionFile, VersionFileResponse};
 use liboxen::view::{ErrorFileInfo, ErrorFilesResponse, StatusMessage};
 use mime;
@@ -69,7 +71,7 @@ pub async fn batch_upload(
     let repo_name = path_param(&req, "repo_name")?;
     let repo = get_repo(&app_data.path, namespace, &repo_name)?;
 
-    log::debug!("batch upload file for repo: {:?}", repo.path);
+    println!("batch upload file for repo: {:?}", repo.path);
     let files = save_multiparts(payload, &repo).await?;
 
     Ok(HttpResponse::Ok().json(ErrorFilesResponse {
@@ -88,8 +90,10 @@ pub async fn save_multiparts(
         actix_web::error::ErrorInternalServerError(oxen_err.to_string())
     })?;
     let gzip_mime: mime::Mime = "application/gzip".parse().unwrap();
+    let json_mime: mime::Mime = "application/json".parse().unwrap();
 
     let mut err_files: Vec<ErrorFileInfo> = vec![];
+    // let mut synced_nodes: Option<ReceivedMetadata> = None
 
     while let Some(mut field) = payload.try_next().await? {
         let Some(content_disposition) = field.content_disposition().cloned() else {
@@ -199,9 +203,43 @@ pub async fn save_multiparts(
                         continue;
                     }
                 }
+            } else if name == "synced_nodes"
+                && field.content_type().is_some_and(|mime| {
+                    mime.type_() == json_mime.type_() && mime.subtype() == json_mime.subtype()
+                })
+            {
+                let mut field_bytes = Vec::new();
+                while let Some(chunk) = field.try_next().await? {
+                    field_bytes.extend_from_slice(&chunk);
+                }
+
+                let json_string = String::from_utf8(field_bytes.to_vec()).map_err(|e| {
+                    actix_web::error::ErrorBadRequest(format!("Invalid UTF-8 in JSON part: {}", e))
+                })?;
+
+                log::debug!("Received synced_nodes JSON: {}", json_string);
+
+                match serde_json::from_str::<Vec<MerkleHash>>(&json_string) {
+                    Ok(synced_nodes) => {
+                        log::debug!("Successfully parsed synced_nodes: {:?}", synced_nodes);
+
+                        for node_hash in synced_nodes {
+                            // TODO: log::error! with the error if this fails
+                            let _ = node_sync_status::mark_node_as_synced(repo, &node_hash);
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Failed to parse synced_nodes JSON: {}", e);
+                        return Err(actix_web::error::ErrorBadRequest(format!(
+                            "Invalid JSON for synced_nodes: {}",
+                            e
+                        )));
+                    }
+                }
             }
         }
     }
+
     Ok(err_files)
 }
 

--- a/oxen-rust/src/server/src/services/tree.rs
+++ b/oxen-rust/src/server/src/services/tree.rs
@@ -24,6 +24,10 @@ pub fn tree() -> Scope {
                     "/missing_file_hashes_from_nodes",
                     web::post().to(controllers::tree::list_missing_file_hashes_from_nodes),
                 )
+                .route(
+                    "/mark_nodes_as_synced",
+                    web::post().to(controllers::tree::mark_nodes_as_synced),
+                )
                 .service(
                     web::scope("/hash/{hash}")
                         .route("", web::get().to(controllers::tree::get_node_by_id))


### PR DESCRIPTION
Oxen push now marks nodes as synced while uploading file contents to version store in push_entries. The uploads for large and small files are now consolidated into one loop. Prior to the upload, each node's parents and children are collected and tracked to determine when to mark each node as synced. The hashes of nodes with all their children uploaded are included with outgoing payloads of file contents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to track and mark directory nodes as synced, improving synchronization accuracy and reliability.
  * Introduced a new endpoint and client support to mark nodes as synced on the server.
  * Enhanced push operations with parallel uploads and hierarchical sync tracking for faster and more robust data transfers.
  * Added multipart upload support to include synced nodes information during file uploads.
  * Introduced benchmarking tools to measure push performance with varied repository sizes and file distributions.

* **Bug Fixes**
  * Improved detection of unsynced nodes and commits for more accurate synchronization status.

* **Refactor**
  * Renamed functions and updated logic to clarify the distinction between missing and unsynced nodes/commits.
  * Updated internal data structures for more efficient sync state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->