### PR TITLE
OXB214 OXB216 Refactor workspace non tabular file download 

### DIFF
--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -4383,6 +4383,8 @@ dependencies = [
  "serde_json",
  "tar",
  "tokio",
+ "tokio-stream",
+ "tokio-util",
  "url",
  "uuid",
 ]
@@ -6782,9 +6784,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -61,6 +61,7 @@ pub async fn get_file(
     let client = client::new_for_url(&url)?;
     let res = client.get(&url).send().await?;
 
+    let res = res.error_for_status()?;
     let mut stream = res.bytes_stream();
     let mut buffer = BytesMut::new();
     while let Some(chunk_result) = stream.next().await {

--- a/oxen-rust/src/lib/src/core/v_latest/commits.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/commits.rs
@@ -80,7 +80,7 @@ pub fn latest_commit(repo: &LocalRepository) -> Result<Commit, OxenError> {
     latest_commit.ok_or(OxenError::no_commits_found())
 }
 
-fn head_commit_id(repo: &LocalRepository) -> Result<MerkleHash, OxenError> {
+pub fn head_commit_id(repo: &LocalRepository) -> Result<MerkleHash, OxenError> {
     let commit_id = with_ref_manager(repo, |manager| manager.head_commit_id())?;
     match commit_id {
         Some(commit_id) => MerkleHash::from_str(&commit_id),

--- a/oxen-rust/src/lib/src/core/v_latest/commits.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/commits.rs
@@ -80,7 +80,7 @@ pub fn latest_commit(repo: &LocalRepository) -> Result<Commit, OxenError> {
     latest_commit.ok_or(OxenError::no_commits_found())
 }
 
-pub fn head_commit_id(repo: &LocalRepository) -> Result<MerkleHash, OxenError> {
+fn head_commit_id(repo: &LocalRepository) -> Result<MerkleHash, OxenError> {
     let commit_id = with_ref_manager(repo, |manager| manager.head_commit_id())?;
     match commit_id {
         Some(commit_id) => MerkleHash::from_str(&commit_id),

--- a/oxen-rust/src/lib/src/storage/local.rs
+++ b/oxen-rust/src/lib/src/storage/local.rs
@@ -131,22 +131,14 @@ impl VersionStore for LocalVersionStore {
     async fn get_version_stream(
         &self,
         hash: &str,
-    ) -> Result<
-        (
-            Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>,
-            u64,
-        ),
-        OxenError,
-    > {
+    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
+    {
         let path = self.version_path(hash);
-        let metadata = fs::metadata(&path).await?;
-        let file_len = metadata.len();
-
         let file = File::open(&path).await?;
         let reader = BufReader::new(file);
         let stream = ReaderStream::new(reader);
 
-        Ok((Box::new(stream), file_len))
+        Ok(Box::new(stream))
     }
 
     fn get_version_path(&self, hash: &str) -> Result<PathBuf, OxenError> {

--- a/oxen-rust/src/lib/src/storage/s3.rs
+++ b/oxen-rust/src/lib/src/storage/s3.rs
@@ -76,13 +76,8 @@ impl VersionStore for S3VersionStore {
     async fn get_version_stream(
         &self,
         _hash: &str,
-    ) -> Result<
-        (
-            Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>,
-            u64,
-        ),
-        OxenError,
-    > {
+    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
+    {
         // TODO: Implement S3 version stream retrieval
         Err(OxenError::basic_str("S3VersionStore not yet implemented"))
     }

--- a/oxen-rust/src/lib/src/storage/s3.rs
+++ b/oxen-rust/src/lib/src/storage/s3.rs
@@ -1,7 +1,9 @@
 use crate::error::OxenError;
 use async_trait::async_trait;
+use bytes::Bytes;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use tokio_stream::Stream;
 
 use super::version_store::VersionStore;
 use crate::storage::version_store::ReadSeek;
@@ -71,6 +73,20 @@ impl VersionStore for S3VersionStore {
         Err(OxenError::basic_str("S3VersionStore not yet implemented"))
     }
 
+    async fn get_version_stream(
+        &self,
+        _hash: &str,
+    ) -> Result<
+        (
+            Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>,
+            u64,
+        ),
+        OxenError,
+    > {
+        // TODO: Implement S3 version stream retrieval
+        Err(OxenError::basic_str("S3VersionStore not yet implemented"))
+    }
+
     fn get_version_path(&self, _hash: &str) -> Result<PathBuf, OxenError> {
         // TODO: Implement S3 version path retrieval
         Err(OxenError::basic_str("S3VersionStore not yet implemented"))
@@ -98,6 +114,17 @@ impl VersionStore for S3VersionStore {
         _size: u64,
     ) -> Result<Vec<u8>, OxenError> {
         // TODO: Implement S3 version chunk retrieval
+        Err(OxenError::basic_str("S3VersionStore not yet implemented"))
+    }
+
+    async fn get_version_chunk_stream(
+        &self,
+        _hash: &str,
+        _offset: u64,
+        _size: u64,
+    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
+    {
+        // TODO: Implement S3 version chunk stream retrieval
         Err(OxenError::basic_str("S3VersionStore not yet implemented"))
     }
 

--- a/oxen-rust/src/lib/src/storage/version_store.rs
+++ b/oxen-rust/src/lib/src/storage/version_store.rs
@@ -142,13 +142,7 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     async fn get_version_stream(
         &self,
         hash: &str,
-    ) -> Result<
-        (
-            Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>,
-            u64,
-        ),
-        OxenError,
-    >;
+    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>;
 
     /// Get the path to a version file (sync operation)
     ///

--- a/oxen-rust/src/server/Cargo.toml
+++ b/oxen-rust/src/server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.36.3"
 edition = "2021"
 
 [dependencies]
-actix-files = "0.6.0"
+actix-files = "0.6.6"
 actix-http = "3.0.4"
 async-compression = { version = "0.4.0", features = ["tokio", "gzip"] }
 astral-tokio-tar = "0.5"
@@ -38,6 +38,8 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
 tar = "0.4.44"
 tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1.17"
+tokio-util = "0.7.16"
 uuid = { version = "1.3.3", features = ["serde", "v4"] }
 
 [dev-dependencies]

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -40,11 +40,7 @@ pub async fn get(
     let version_store = repo.version_store()?;
     let resource = parse_resource(&req, &repo)?;
     let workspace_ref = resource.workspace.as_ref();
-    let commit = if let Some(workspace) = workspace_ref {
-        &workspace.commit.clone()
-    } else {
-        &resource.clone().commit.unwrap()
-    };
+
     let repo = if let Some(workspace) = workspace_ref {
         &workspace.workspace_repo
     } else {
@@ -74,26 +70,30 @@ pub async fn get(
         }),
         None => {
             // Otherwise get file node from commit tree
-            let file_node = repositories::tree::get_file_by_path(repo, commit, &path)?
+            let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
+            let file_node = repositories::tree::get_file_by_path(repo, &commit, &path)?
                 .ok_or(OxenError::path_does_not_exist(path.clone()))?;
             Ok(file_node)
         }
     }?;
 
     let file_hash = entry.hash();
+    let hash_str = file_hash.to_string();
     let mime_type = entry.mime_type();
     let last_commit_id = entry.last_commit_id().to_string();
-    let version_path = version_store.get_version_path(&file_hash.to_string())?;
+    let version_path = version_store.get_version_path(&hash_str)?;
 
     // TODO: refactor out of here and check for type,
     // but seeing if it works to resize the image and cache it to disk if we have a resize query
     let img_resize = query.into_inner();
-    if img_resize.width.is_some() || img_resize.height.is_some() {
+    if (img_resize.width.is_some() || img_resize.height.is_some())
+        && mime_type.starts_with("image/")
+    {
         log::debug!("img_resize {:?}", img_resize);
 
         let resized_path = util::fs::handle_image_resize(
             Arc::clone(&version_store),
-            file_hash.to_string(),
+            hash_str,
             &path,
             &version_path,
             img_resize,
@@ -114,9 +114,7 @@ pub async fn get(
     }
 
     // Stream the file
-    let stream = version_store
-        .get_version_stream(&file_hash.to_string())
-        .await?;
+    let stream = version_store.get_version_stream(&hash_str).await?;
 
     Ok(HttpResponse::Ok()
         .content_type(mime_type)

--- a/oxen-rust/src/server/src/controllers/versions.rs
+++ b/oxen-rust/src/server/src/controllers/versions.rs
@@ -54,9 +54,13 @@ pub async fn download(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
 
     let version_store = repo.version_store()?;
 
-    // TODO: stream the file
-    let file_data = version_store.get_version(&version_id).await?;
-    Ok(HttpResponse::Ok().body(file_data))
+    // Stream the file for better memory efficiency
+    let (stream, file_size) = version_store.get_version_stream(&version_id).await?;
+
+    Ok(HttpResponse::Ok()
+        .content_type("application/octet-stream")
+        .append_header(("Content-Length", file_size.to_string()))
+        .streaming(stream))
 }
 
 pub async fn batch_upload(

--- a/oxen-rust/src/server/src/controllers/versions.rs
+++ b/oxen-rust/src/server/src/controllers/versions.rs
@@ -59,8 +59,7 @@ pub async fn download(
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.clone().commit.unwrap();
     let path = resource.path.clone();
-    println!("{}", repo_name);
-    println!("{:?}", path);
+
     log::debug!("Download resource {namespace}/{repo_name}/{resource} version file");
 
     let entry = repositories::entries::get_file(&repo, &commit, &path)?

--- a/oxen-rust/src/server/src/controllers/versions/chunks.rs
+++ b/oxen-rust/src/server/src/controllers/versions/chunks.rs
@@ -130,6 +130,8 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
     Ok(HttpResponse::BadRequest().json(StatusMessage::error("Invalid request body")))
 }
 
+// TODO: Add content-type and oxen-revision-id in the response header
+// Currently, this endpoint is not used anywhere.
 pub async fn download(
     req: HttpRequest,
     query: web::Query<ChunkQuery>,
@@ -153,7 +155,6 @@ pub async fn download(
 
     let version_store = repo.version_store()?;
 
-    // TODO: Stream the chunk data
     let chunk_data = version_store
         .get_version_chunk(&version_id, offset, size)
         .await?;

--- a/oxen-rust/src/server/src/controllers/workspaces/files.rs
+++ b/oxen-rust/src/server/src/controllers/workspaces/files.rs
@@ -80,7 +80,7 @@ pub async fn get(
     }
 
     // Stream the file
-    let (stream, _file_size) = version_store
+    let stream = version_store
         .get_version_stream(&file_hash.to_string())
         .await?;
 

--- a/oxen-rust/src/server/src/services/versions.rs
+++ b/oxen-rust/src/server/src/services/versions.rs
@@ -25,11 +25,11 @@ pub fn versions() -> Scope {
             web::post().to(controllers::versions::chunks::complete),
         )
         .route(
-            "/{version_id}/chunks/download",
+            "/chunks/{resource:.*}/download",
             web::get().to(controllers::versions::chunks::download),
         )
         .route(
-            "/{version_id}",
+            "/{resource:.*}",
             web::get().to(controllers::versions::download),
         )
         .route(

--- a/oxen-rust/src/server/src/services/versions.rs
+++ b/oxen-rust/src/server/src/services/versions.rs
@@ -25,12 +25,15 @@ pub fn versions() -> Scope {
             web::post().to(controllers::versions::chunks::complete),
         )
         .route(
-            "/chunks/{resource:.*}/download",
-            web::get().to(controllers::versions::chunks::download),
-        )
-        .route(
+            // TODO: change the endpoint to /{version_id} for consistency and a more efficient download when client has the file hash
+            // For this change, a easy mapping from file_hash to file_node is needed.
             "/{resource:.*}",
             web::get().to(controllers::versions::download),
+        )
+        .route(
+            //TODO: The versions chunk download endpoint is not functional now. Needs the same changes mentioned above.
+            "/{version_id}/chunks/download",
+            web::get().to(controllers::versions::chunks::download),
         )
         .route(
             "/{version_id}/create",


### PR DESCRIPTION
1. Added `get_version_stream()` and `get_version_chunk_stream()` in the version store interface.
2. Refactored the endpoint `GET /workspaces/{workspace_id}/files/{path:.*}` to use version store
3. Also modified the versions download endpoint from 
`GET /versions/{version_id}`, `GET /versions/{version_id}/chunks/download`
to 
`GET /versions/{resource:.*}`, `GET /versions/chunks/{resource:.*}/download`
Because the client is not able to know the file version_id when making a download request. 
4. Modified the versions download controller function with similar logic as `GET /file/{resource:.*}`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage-backed streaming reads and on-demand server-side image resizing via width/height query.

* **Performance**
  * Reduced memory usage and improved throughput through chunked/streamed transfers and incremental disk writes.

* **API Changes**
  * Routes moved to resource-style paths; download handlers accept resize params. Client get_file now streams responses; client put_file adds a directory argument. Storage interfaces gain async streaming methods for full files and chunks.

* **Chores**
  * Updated server dependencies (actix-files, tokio-stream, tokio-util).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->