### PR TITLE
fix(cli): add chrono dependency

### DIFF
--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -3112,7 +3112,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4429,6 +4429,7 @@ version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytesize",
+ "chrono",
  "clap",
  "colored 2.2.0",
  "dialoguer",
@@ -7468,7 +7469,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -7478,23 +7479,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
+ "windows-implement",
+ "windows-interface",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
- "windows-link",
- "windows-result 0.3.4",
- "windows-strings",
 ]
 
 [[package]]
@@ -7509,32 +7497,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/oxen-rust/src/cli/Cargo.toml
+++ b/oxen-rust/src/cli/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.80"
 bytesize = "1.3.0"
+chrono = "0.4.30"
 clap = { version = "4.2.7", features = ["cargo", "derive"] }
 colored = "2.0.0"
 dialoguer = "0.11.0"


### PR DESCRIPTION
add chrono dependency to fix oxen-cli build.

relates to https://github.com/Homebrew/homebrew-core/pull/236163

closes #139 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing features added in this release.

- Chores
  - Updated third-party dependencies.
  - Added a date/time utility dependency for internal use.
  - No changes to public interfaces or commands.

- Impact
  - No expected behavior changes for end-users.
  - Minor improvements to dependency footprint and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->