### PR TITLE
Create a dataframe from dir

### DIFF
--- a/oxen-rust/src/lib/src/api/client/data_frames.rs
+++ b/oxen-rust/src/lib/src/api/client/data_frames.rs
@@ -574,6 +574,7 @@ mod tests {
             .await?;
 
             let p_df = df.data_frame.view.to_df().await;
+            println!("{:?}", p_df);
 
             // Original DF
             assert_eq!(df.data_frame.source.size.height, 1024);

--- a/oxen-rust/src/lib/src/api/client/data_frames.rs
+++ b/oxen-rust/src/lib/src/api/client/data_frames.rs
@@ -6,6 +6,8 @@ use crate::error::OxenError;
 use crate::model::RemoteRepository;
 use crate::opts::DFOpts;
 use crate::util;
+use crate::view::commit::CommitResponse;
+use crate::view::data_frames::FromDirectoryRequest;
 use crate::view::{JsonDataFrameViewResponse, StatusMessage};
 
 pub async fn get(
@@ -62,6 +64,41 @@ pub async fn index(
     }
 }
 
+pub async fn from_directory(
+    remote_repo: &RemoteRepository,
+    commit_or_branch: &str,
+    path: impl AsRef<Path>,
+    request: FromDirectoryRequest,
+) -> Result<CommitResponse, OxenError> {
+    let path_str = util::fs::to_unix_str(path);
+    let uri = format!("/data_frames/from_directory/{commit_or_branch}/{path_str}");
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+
+    let client = client::new_for_url(&url)?;
+    let json_body = serde_json::to_string(&request)?;
+
+    let res = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .body(json_body)
+        .send()
+        .await?;
+
+    let body = client::parse_json_body(&url, res).await?;
+    log::debug!("got body: {}", body);
+
+    let response: Result<CommitResponse, serde_json::Error> = serde_json::from_str(&body);
+    match response {
+        Ok(val) => {
+            log::debug!("got CommitResponse: {:?}", val);
+            Ok(val)
+        }
+        Err(err) => Err(OxenError::basic_str(format!(
+            "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -77,6 +114,8 @@ mod tests {
     use crate::repositories;
     use crate::test;
     use crate::util;
+    use crate::view::data_frames::columns::NewColumn;
+    use crate::view::data_frames::FromDirectoryRequest;
 
     use serde_json::json;
 
@@ -535,7 +574,6 @@ mod tests {
             .await?;
 
             let p_df = df.data_frame.view.to_df().await;
-            println!("{:?}", p_df);
 
             // Original DF
             assert_eq!(df.data_frame.source.size.height, 1024);
@@ -558,7 +596,6 @@ mod tests {
                 constants::DEFAULT_PAGE_SIZE
             );
 
-            println!("{}", df.data_frame.view.data[0]["title"]);
             assert_eq!(df.data_frame.view.data[0]["title"], "Anarchism");
 
             Ok(())
@@ -680,6 +717,97 @@ mod tests {
 
             println!("{}", df.data_frame.view.data[0]["title"]);
             assert_eq!(df.data_frame.view.data[0]["title"], "April 26");
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_from_directory() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|mut local_repo| async move {
+            let repo_dir = &local_repo.path;
+
+            // Create test directory structure
+            let test_dir = repo_dir.join("test_files");
+            util::fs::create_dir_all(&test_dir)?;
+
+            let subdir = test_dir.join("subdir");
+            util::fs::create_dir_all(&subdir)?;
+
+            // Create some test files
+            let file1 = test_dir.join("file1.txt");
+            std::fs::write(&file1, "content1")?;
+
+            let file2 = test_dir.join("file2.txt");
+            std::fs::write(&file2, "content2")?;
+
+            let file3 = subdir.join("file3.txt");
+            std::fs::write(&file3, "content3")?;
+
+            // Add and commit the files
+            repositories::add(&local_repo, &test_dir).await?;
+            repositories::commit(&local_repo, "add test files")?;
+
+            // Set the proper remote
+            let remote = test::repo_remote_url_from(&local_repo.dirname());
+            command::config::set_remote(&mut local_repo, DEFAULT_REMOTE_NAME, &remote)?;
+
+            // Create the repo
+            let remote_repo = test::create_remote_repo(&local_repo).await?;
+
+            // Push the repo
+            repositories::push(&local_repo).await?;
+
+            // Create request for from_directory
+            let request = FromDirectoryRequest {
+                output_path: Some("file_listing.parquet".to_string()),
+                extra_columns: Some(vec![
+                    NewColumn {
+                        name: "file_size".to_string(),
+                        data_type: "float".to_string(),
+                    },
+                    NewColumn {
+                        name: "file_type".to_string(),
+                        data_type: "float".to_string(),
+                    },
+                ]),
+                commit_message: Some("Generated directory listing".to_string()),
+                user_name: Some("test_user".to_string()),
+                user_email: Some("test@example.com".to_string()),
+                recursive: Some(true),
+            };
+
+            // Call from_directory
+            let response = api::client::data_frames::from_directory(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                "test_files",
+                request,
+            )
+            .await?;
+
+            let files = api::client::data_frames::get(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                "file_listing.parquet",
+                DFOpts::empty(),
+            )
+            .await?;
+            let p_df = files.data_frame.view.to_df().await;
+            assert_eq!(p_df.height(), 3);
+            assert_eq!(p_df.width(), 3);
+
+            let file_path_col = p_df.column("file_path").unwrap();
+            let file_paths: Vec<&str> = file_path_col.str().unwrap().into_no_null_iter().collect();
+            assert!(file_paths.contains(&"test_files/file1.txt"));
+            assert!(file_paths.contains(&"test_files/subdir/file3.txt"));
+            assert!(file_paths.contains(&"test_files/file2.txt"));
+
+            // Verify response
+            assert!(response.status.status_message == "resource_created");
+            assert!(response.commit.id.len() > 0);
+            assert_eq!(response.commit.message, "Generated directory listing");
 
             Ok(())
         })

--- a/oxen-rust/src/lib/src/api/client/data_frames.rs
+++ b/oxen-rust/src/lib/src/api/client/data_frames.rs
@@ -806,7 +806,7 @@ mod tests {
 
             // Verify response
             assert!(response.status.status_message == "resource_created");
-            assert!(response.commit.id.len() > 0);
+            assert!(!response.commit.id.is_empty());
             assert_eq!(response.commit.message, "Generated directory listing");
 
             Ok(())

--- a/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
+++ b/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
@@ -285,6 +285,7 @@ pub fn full_diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DiffRe
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn from_directory(
     repo: &LocalRepository,
     workspace: &Workspace,
@@ -321,7 +322,7 @@ pub async fn from_directory(
         .map(|file_with_dir| {
             file_with_dir
                 .dir
-                .join(&file_with_dir.file_node.name())
+                .join(file_with_dir.file_node.name())
                 .to_string_lossy()
                 .to_string()
         })

--- a/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
+++ b/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
@@ -1,3 +1,5 @@
+use crate::core::df::tabular::write_df_parquet;
+use crate::view::data_frames::columns::NewColumn;
 use polars::frame::DataFrame;
 
 use sql_query_builder::Select;
@@ -11,7 +13,8 @@ use crate::core::db::data_frames::{df_db, workspace_df_db};
 use crate::core::df::sql;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::{Commit, LocalRepository, Workspace};
+use crate::model::merkle_tree::node::EMerkleTreeNode;
+use crate::model::{Commit, LocalRepository, NewCommitBody, Workspace};
 use crate::opts::DFOpts;
 use crate::{repositories, util};
 
@@ -21,6 +24,8 @@ use crate::model::diff::tabular_diff::{
 };
 use crate::model::diff::{AddRemoveModifyCounts, DiffResult, TabularDiff};
 
+use crate::core::db::data_frames::columns::polar_insert_column;
+use duckdb::arrow::array::RecordBatch;
 use std::path::{Path, PathBuf};
 
 pub mod columns;
@@ -279,6 +284,93 @@ pub fn full_diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DiffRe
             Ok(DiffResult::Tabular(diff_result))
         })
     })
+}
+
+pub async fn from_directory(
+    repo: &LocalRepository,
+    workspace: &Workspace,
+    path: impl AsRef<Path>,
+    output_path: impl AsRef<Path>,
+    extra_columns: &[NewColumn],
+    recursive: bool,
+    new_commit: &NewCommitBody,
+) -> Result<Commit, OxenError> {
+    let Some(_dir_node) =
+        repositories::tree::get_dir_with_children(repo, &workspace.commit, path.as_ref())?
+    else {
+        return Err(OxenError::basic_str(format!(
+            "Directory not found: {:?}",
+            path.as_ref()
+        )));
+    };
+
+    let depth = if recursive { -1 } else { 1 };
+
+    let subtree = repositories::tree::get_subtree_by_depth(
+        repo,
+        &workspace.commit,
+        &Some(path.as_ref().to_path_buf()),
+        &Some(depth),
+    )?;
+
+    let dirs_and_files = subtree.unwrap().list_files_and_dirs()?;
+
+    // Extract only file paths (not directories)
+    let file_paths: Vec<String> = dirs_and_files
+        .iter()
+        .filter_map(|(path, node)| match &node.node {
+            EMerkleTreeNode::File(_) => Some(path.to_string_lossy().to_string()),
+            _ => None,
+        })
+        .collect();
+
+    let db_path = workspace.dir().join("temp_file_listing.db");
+
+    let mut df = with_df_db_manager(&db_path, |manager| {
+        manager.with_conn(|conn| {
+            // Create initial table with just file_path column
+            conn.execute("CREATE TABLE file_listing (file_path VARCHAR);", [])?;
+
+            // Insert file paths
+            for file_path in &file_paths {
+                conn.execute(
+                    "INSERT INTO file_listing (file_path) VALUES (?);",
+                    [file_path],
+                )?;
+            }
+
+            // Add each extra column using the existing function
+            for new_column in extra_columns {
+                polar_insert_column(conn, "file_listing", new_column)?;
+            }
+
+            // Get the final DataFrame
+            let sql_query = "SELECT * FROM file_listing";
+            let result_set: Vec<RecordBatch> = conn.prepare(sql_query)?.query_arrow([])?.collect();
+            df_db::record_batches_to_polars_df(result_set)
+        })
+    })?;
+
+    // Write the DataFrame as a parquet file
+    let output_path = workspace.dir().join(output_path);
+
+    // Create parent directories if they don't exist
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    write_df_parquet(&mut df, &output_path)?;
+
+    repositories::workspaces::files::add(workspace, &output_path).await?;
+
+    let commit = repositories::workspaces::commit(workspace, new_commit, "main")?;
+    println!(
+        "Created parquet file with {} file paths at: {:?}",
+        file_paths.len(),
+        output_path
+    );
+
+    Ok(commit)
 }
 
 pub fn duckdb_path(workspace: &Workspace, path: impl AsRef<Path>) -> PathBuf {

--- a/oxen-rust/src/lib/src/view/data_frames.rs
+++ b/oxen-rust/src/lib/src/view/data_frames.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::view::data_frames::columns::NewColumn;
+
 pub mod columns;
 pub mod embeddings;
 
@@ -28,4 +30,14 @@ pub struct DataFrameRowChange {
     pub operation: String,
     pub value: Value,
     pub new_value: Option<Value>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct FromDirectoryRequest {
+    pub output_path: Option<String>,
+    pub extra_columns: Option<Vec<NewColumn>>,
+    pub commit_message: Option<String>,
+    pub user_name: Option<String>,
+    pub user_email: Option<String>,
+    pub recursive: Option<bool>,
 }

--- a/oxen-rust/src/server/src/controllers/data_frames.rs
+++ b/oxen-rust/src/server/src/controllers/data_frames.rs
@@ -149,6 +149,7 @@ pub async fn from_directory(
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
+    let branch = resource.clone().branch.ok_or(OxenHttpError::NotFound)?;
     let path = resource.path.clone();
     let data: Result<FromDirectoryRequest, serde_json::Error> = serde_json::from_str(&body);
     let data = match data {
@@ -179,6 +180,7 @@ pub async fn from_directory(
         &extra_columns,
         recursive,
         &new_commit,
+        &branch,
     )
     .await?;
     Ok(HttpResponse::Ok().json(CommitResponse {

--- a/oxen-rust/src/server/src/controllers/data_frames.rs
+++ b/oxen-rust/src/server/src/controllers/data_frames.rs
@@ -5,15 +5,17 @@ use crate::params::{app_data, parse_resource, path_param};
 
 use liboxen::constants;
 use liboxen::error::PathBufError;
-use liboxen::model::DataFrameSize;
+use liboxen::model::{DataFrameSize, NewCommitBody};
 use liboxen::opts::df_opts::DFOptsView;
 use liboxen::repositories;
+use liboxen::view::data_frames::FromDirectoryRequest;
 use liboxen::view::entries::ResourceVersion;
 
 use actix_web::{web, HttpRequest, HttpResponse};
 use liboxen::opts::{DFOpts, PaginateOpts};
 use liboxen::view::{
-    JsonDataFrameView, JsonDataFrameViewResponse, JsonDataFrameViews, Pagination, StatusMessage,
+    CommitResponse, JsonDataFrameView, JsonDataFrameViewResponse, JsonDataFrameViews, Pagination,
+    StatusMessage,
 };
 
 use uuid::Uuid;
@@ -135,4 +137,52 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     }
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_updated()))
+}
+
+pub async fn from_directory(
+    req: HttpRequest,
+    body: String,
+) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let repo_name = path_param(&req, "repo_name")?;
+    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let resource = parse_resource(&req, &repo)?;
+    let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
+    let path = resource.path.clone();
+    let data: Result<FromDirectoryRequest, serde_json::Error> = serde_json::from_str(&body);
+    let data = match data {
+        Ok(data) => data,
+        Err(err) => {
+            log::error!("Unable to parse body. Err: {}\n{}", err, body);
+            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
+        }
+    };
+
+    let output_path = data.output_path.unwrap_or("".to_string());
+    let extra_columns = data.extra_columns.unwrap_or(vec![]);
+    let commit_message = data.commit_message.unwrap_or("".to_string());
+    let user_email = data.user_email.unwrap_or("".to_string());
+    let recursive = data.recursive.unwrap_or(false);
+    let temp_workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
+    let user_name = data.user_name.unwrap_or("".to_string());
+    let new_commit = NewCommitBody {
+        author: user_name,
+        email: user_email,
+        message: commit_message,
+    };
+    let commit = repositories::workspaces::data_frames::from_directory(
+        &repo,
+        &temp_workspace,
+        &path,
+        &output_path,
+        &extra_columns,
+        recursive,
+        &new_commit,
+    )
+    .await?;
+    Ok(HttpResponse::Ok().json(CommitResponse {
+        status: StatusMessage::resource_created(),
+        commit,
+    }))
 }

--- a/oxen-rust/src/server/src/services/data_frames.rs
+++ b/oxen-rust/src/server/src/services/data_frames.rs
@@ -10,6 +10,10 @@ pub fn data_frames() -> Scope {
             web::post().to(controllers::data_frames::index),
         )
         .route(
+            "/from_directory/{resource:.*}",
+            web::post().to(controllers::data_frames::from_directory),
+        )
+        .route(
             "/{resource:.*}",
             web::get().to(controllers::data_frames::get),
         )


### PR DESCRIPTION
This endpoint will create a df of the file paths on any dir in a repo.

(Tests pending)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a POST endpoint to generate a parquet-backed data frame from a repository directory (optional recursive), with support for extra columns and commit metadata (author, email, message).
  * Endpoint writes the parquet into the repo and returns creation status with the resulting commit; client tooling can call this API using a FromDirectoryRequest.

* **Tests**
  * End-to-end tests added covering directory→data-frame creation, parquet retrieval, and response/commit validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->