### PR TITLE
Fix issue of downloading files with same hash and different paths

### DIFF
--- a/oxen-rust/src/lib/src/api/client/entries.rs
+++ b/oxen-rust/src/lib/src/api/client/entries.rs
@@ -18,7 +18,6 @@ use async_tar::Archive;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use futures_util::{StreamExt, TryStreamExt};
-use std::collections::HashMap;
 use std::fs::{self};
 use std::io::prelude::*;
 use std::io::Cursor;
@@ -811,7 +810,7 @@ async fn download_entry_chunk(
 
 pub async fn download_data_from_version_paths(
     remote_repo: &RemoteRepository,
-    content_ids: &HashMap<String, PathBuf>, // hashmap of file hash and entry path
+    content_ids: &[(String, PathBuf)], // tuple of content id and entry path
     dst: &Path,
 ) -> Result<u64, OxenError> {
     let total_retries = constants::NUM_HTTP_RETRIES;
@@ -845,7 +844,7 @@ pub async fn download_data_from_version_paths(
 
 pub async fn try_download_data_from_version_paths(
     remote_repo: &RemoteRepository,
-    content_ids: &HashMap<String, PathBuf>, // tuple of content id and entry path
+    content_ids: &[(String, PathBuf)], // tuple of content id and entry path
     dst: impl AsRef<Path>,
 ) -> Result<u64, OxenError> {
     let dst = dst.as_ref();
@@ -875,41 +874,26 @@ pub async fn try_download_data_from_version_paths(
         let archive = Archive::new(decoder);
 
         let mut size: u64 = 0;
+        let mut idx = 0;
         // Iterate over archive entries and unpack them to their entry paths
         let mut entries = archive.entries()?;
         while let Some(file) = entries.next().await {
+            let entry_path = &content_ids[idx].1;
+            let full_path = dst.join(entry_path);
+
             let mut file = match file {
                 Ok(file) => file,
                 Err(err) => {
-                    let err = format!("Could not unwrap file: {:?}", err);
+                    let err = format!("Could not unwrap file {:?} -> {:?}", entry_path, err);
                     return Err(OxenError::basic_str(err));
                 }
             };
 
-            let file_hash = match file.header().path() {
-                Ok(path) => path.to_string_lossy().to_string(),
-                Err(e) => {
-                    return Err(OxenError::basic_str(format!(
-                        "Invalid tar entry path: {}",
-                        e
-                    )))
-                }
-            };
-
-            let Some(entry_path) = content_ids.get(&file_hash) else {
-                log::warn!(
-                    "Skipping unexpected tar entry not in requested set: {}",
-                    file_hash
-                );
-                continue;
-            };
             log::debug!(
                 "download_data_from_version_paths Unpacking {:?} -> {:?}",
-                file_hash,
+                content_ids[idx].0,
                 entry_path
             );
-
-            let full_path = dst.join(entry_path);
 
             if let Some(parent) = full_path.parent() {
                 util::fs::create_dir_all(parent)?;
@@ -927,6 +911,7 @@ pub async fn try_download_data_from_version_paths(
 
             let metadata = util::fs::metadata(&full_path)?;
             size += metadata.len();
+            idx += 1;
             log::debug!("Unpacked {} bytes {:?}", metadata.len(), entry_path);
         }
         Ok(size)

--- a/oxen-rust/src/lib/src/core/v_latest/fetch.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/fetch.rs
@@ -731,7 +731,6 @@ async fn pull_small_entries(
     let chunks: Vec<PieceOfWork> = entries
         .chunks(chunk_size)
         .map(|chunk| {
-            // Create HashMap from hash -> path for this chunk
             let hashes = chunk.iter().map(|entry| entry.hash().to_string()).collect();
             (remote_repo.to_owned(), hashes, repo.to_owned())
         })
@@ -968,16 +967,16 @@ async fn download_small_entries(
     );
 
     // Split into chunks, zip up, and post to server
-    type PieceOfWork = (RemoteRepository, HashMap<String, PathBuf>, PathBuf);
+    type PieceOfWork = (RemoteRepository, Vec<(String, PathBuf)>, PathBuf);
     type TaskQueue = deadqueue::limited::Queue<PieceOfWork>;
 
     let chunks: Vec<PieceOfWork> = entries
         .chunks(chunk_size)
         .map(|chunk| {
-            let content_ids: HashMap<String, PathBuf> = chunk
-                .iter()
-                .map(|e| (e.hash(), e.path().to_owned()))
-                .collect();
+            let mut content_ids: Vec<(String, PathBuf)> = vec![];
+            for e in chunk {
+                content_ids.push((e.hash(), e.path().to_owned()));
+            }
             (remote_repo.to_owned(), content_ids, dst.as_ref().to_owned())
         })
         .collect();

--- a/oxen-rust/src/lib/src/repositories/checkout.rs
+++ b/oxen-rust/src/lib/src/repositories/checkout.rs
@@ -818,10 +818,12 @@ mod tests {
                 for file in test_dir_files.iter() {
                     println!("file: {:?}", file);
                 }
-                assert_eq!(test_dir_files.len(), 2);
+                assert_eq!(test_dir_files.len(), 4);
 
                 assert!(test_dir_path.join("1.jpg").exists());
                 assert!(test_dir_path.join("2.jpg").exists());
+                assert!(test_dir_path.join("3.jpg").exists());
+                assert!(test_dir_path.join("4.jpg").exists());
 
                 Ok(())
             })

--- a/oxen-rust/src/lib/src/repositories/clone.rs
+++ b/oxen-rust/src/lib/src/repositories/clone.rs
@@ -405,10 +405,12 @@ mod tests {
                 for file in test_dir_files.iter() {
                     println!("file: {:?}", file);
                 }
-                assert_eq!(test_dir_files.len(), 2);
+                assert_eq!(test_dir_files.len(), 4);
 
                 assert!(test_dir_path.join("1.jpg").exists());
                 assert!(test_dir_path.join("2.jpg").exists());
+                assert!(test_dir_path.join("3.jpg").exists());
+                assert!(test_dir_path.join("4.jpg").exists());
 
                 Ok(())
             })
@@ -574,8 +576,8 @@ mod tests {
                 )
                 .await?;
                 let cloned_num_files = util::fs::rcount_files_in_dir(&cloned_repo.path);
-                // 2 test, 5 train, 1 labels
-                assert_eq!(8, cloned_num_files);
+                // 4 test, 7 train, 1 labels
+                assert_eq!(12, cloned_num_files);
 
                 api::client::repositories::delete(&remote_repo).await?;
 

--- a/oxen-rust/src/lib/src/repositories/entries.rs
+++ b/oxen-rust/src/lib/src/repositories/entries.rs
@@ -516,8 +516,8 @@ mod tests {
             let dir_entries = paginated.entries;
             let size = paginated.total_entries;
 
-            assert_eq!(size, 5);
-            assert_eq!(dir_entries.len(), 5);
+            assert_eq!(size, 7);
+            assert_eq!(dir_entries.len(), 7);
 
             Ok(())
         })
@@ -561,7 +561,7 @@ mod tests {
                 Path::new("train"),
                 &commit.id,
                 &PaginateOpts {
-                    page_num: 2,
+                    page_num: 3,
                     page_size: 3,
                 },
             )?;
@@ -573,8 +573,8 @@ mod tests {
                 println!("{entry:?}");
             }
 
-            assert_eq!(total_entries, 5);
-            assert_eq!(dir_entries.len(), 2);
+            assert_eq!(total_entries, 7);
+            assert_eq!(dir_entries.len(), 1);
 
             Ok(())
         })

--- a/oxen-rust/src/lib/src/repositories/pull.rs
+++ b/oxen-rust/src/lib/src/repositories/pull.rs
@@ -288,7 +288,7 @@ mod tests {
                     repositories::clone_url(&remote_repo.remote.url, &new_repo_dir).await?;
 
                 let cloned_num_files = util::fs::rcount_files_in_dir(&cloned_repo.path);
-                assert_eq!(6, cloned_num_files);
+                assert_eq!(8, cloned_num_files);
                 let og_commits = repositories::commits::list(&repo)?;
                 let cloned_commits = repositories::commits::list(&cloned_repo)?;
                 assert_eq!(og_commits.len(), cloned_commits.len());
@@ -351,8 +351,8 @@ mod tests {
                 )
                 .await?;
                 let cloned_num_files = util::fs::rcount_files_in_dir(&cloned_repo.path);
-                // Now there should be 7 train/ files and 1 in large_files/
-                assert_eq!(8, cloned_num_files);
+                // Now there should be 9 train/ files and 1 in large_files/
+                assert_eq!(10, cloned_num_files);
 
                 api::client::repositories::delete(&remote_repo).await?;
 
@@ -1238,8 +1238,8 @@ mod tests {
                 let cloned_repo =
                     repositories::clone_url(&remote_repo.remote.url, &new_repo_dir).await?;
                 let cloned_num_files = util::fs::rcount_files_in_dir(&cloned_repo.path);
-                // 2 test, 5 train, 1 labels
-                assert_eq!(8, cloned_num_files);
+                // 4 test, 7 train, 1 labels
+                assert_eq!(12, cloned_num_files);
 
                 api::client::repositories::delete(&remote_repo).await?;
 

--- a/oxen-rust/src/lib/src/repositories/status.rs
+++ b/oxen-rust/src/lib/src/repositories/status.rs
@@ -592,16 +592,16 @@ mod tests {
             // repositories::add(&repo, &new_dir)?;
 
             let status = repositories::status(&repo)?;
-            // No moved files, 5 staged (the removals)
+            // No moved files, 7 staged (the removals)
             assert_eq!(status.moved_files.len(), 0);
-            assert_eq!(status.staged_files.len(), 5);
+            assert_eq!(status.staged_files.len(), 7);
             assert_eq!(status.staged_dirs.len(), 1);
 
             // Complete the pairs
             repositories::add(&repo, &new_dir).await?;
             let status = repositories::status(&repo)?;
-            assert_eq!(status.moved_files.len(), 5);
-            assert_eq!(status.staged_files.len(), 10);
+            assert_eq!(status.moved_files.len(), 7);
+            assert_eq!(status.staged_files.len(), 14);
             assert_eq!(status.staged_dirs.len(), 2);
             Ok(())
         })

--- a/oxen-rust/src/lib/src/test.rs
+++ b/oxen-rust/src/lib/src/test.rs
@@ -1828,6 +1828,14 @@ pub fn populate_train_dir(repo_dir: &Path) -> Result<(), OxenError> {
             .join("dog_3.jpg"),
         train_dir.join("dog_3.jpg"),
     )?;
+    // Add file with same content and different names to test edge cases
+    util::fs::copy(
+        Path::new("data")
+            .join("test")
+            .join("images")
+            .join("dog_3.jpg"),
+        train_dir.join("dog_4.jpg"),
+    )?;
     util::fs::copy(
         Path::new("data")
             .join("test")
@@ -1841,6 +1849,13 @@ pub fn populate_train_dir(repo_dir: &Path) -> Result<(), OxenError> {
             .join("images")
             .join("cat_2.jpg"),
         train_dir.join("cat_2.jpg"),
+    )?;
+    util::fs::copy(
+        Path::new("data")
+            .join("test")
+            .join("images")
+            .join("cat_2.jpg"),
+        train_dir.join("cat_3.jpg"),
     )?;
 
     Ok(())
@@ -1862,6 +1877,20 @@ pub fn populate_test_dir(repo_dir: &Path) -> Result<(), OxenError> {
             .join("images")
             .join("cat_3.jpg"),
         test_dir.join("2.jpg"),
+    )?;
+    util::fs::copy(
+        Path::new("data")
+            .join("test")
+            .join("images")
+            .join("dog_4.jpg"),
+        test_dir.join("3.jpg"),
+    )?;
+    util::fs::copy(
+        Path::new("data")
+            .join("test")
+            .join("images")
+            .join("cat_3.jpg"),
+        test_dir.join("4.jpg"),
     )?;
 
     Ok(())


### PR DESCRIPTION
Fixed the issue and added duplicate images within the test directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for edge cases involving files with identical content but different names.
  * Updated test validations across clone, checkout, and pull operations to verify correct handling of larger file datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->