### PR TITLE
Refactor CommitMerkleTree and repositories::tree

### DIFF
--- a/oxen-rust/src/cli/src/cmd/ls.rs
+++ b/oxen-rust/src/cli/src/cmd/ls.rs
@@ -114,7 +114,8 @@ impl RunCmd for LsCmd {
             .collect();
 
         // Get directory children from latest commit
-        let Some(dir_node) = repositories::tree::get_dir_with_children(&repo, &commit, &directory)?
+        let Some(dir_node) =
+            repositories::tree::get_dir_with_children(&repo, &commit, &directory, None)?
         else {
             return Ok(());
         };

--- a/oxen-rust/src/cli/src/cmd/node.rs
+++ b/oxen-rust/src/cli/src/cmd/node.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use clap::{Arg, Command};
-use liboxen::core::v_latest::index::CommitMerkleTree;
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
@@ -70,8 +69,7 @@ impl RunCmd for NodeCmd {
         let node_hash = args.get_one::<String>("node").expect("Must supply node");
         let node_hash = node_hash.parse()?;
 
-        // REFACTOR: Get through repositories::tree
-        let node = CommitMerkleTree::read_node(&repository, &node_hash, false)?;
+        let node = repositories::tree::get_node_by_id(&repository, &node_hash)?;
 
         println!("{:?}", node);
         if args.get_flag("verbose") {

--- a/oxen-rust/src/cli/src/cmd/node.rs
+++ b/oxen-rust/src/cli/src/cmd/node.rs
@@ -69,6 +69,8 @@ impl RunCmd for NodeCmd {
         // otherwise, get the node based on the node hash
         let node_hash = args.get_one::<String>("node").expect("Must supply node");
         let node_hash = node_hash.parse()?;
+
+        // REFACTOR: Get through repositories::tree
         let node = CommitMerkleTree::read_node(&repository, &node_hash, false)?;
 
         println!("{:?}", node);

--- a/oxen-rust/src/cli/src/cmd/push.rs
+++ b/oxen-rust/src/cli/src/cmd/push.rs
@@ -115,7 +115,7 @@ impl RunCmd for PushCmd {
                     Err(OxenError::basic_str(msg))
                 }
                 Err(e) => {
-                    eprintln!("Error pushing: {e}");
+                    println!("Error pushing: {e}");
                     Err(e)
                 }
             }

--- a/oxen-rust/src/cli/src/cmd/push.rs
+++ b/oxen-rust/src/cli/src/cmd/push.rs
@@ -115,7 +115,7 @@ impl RunCmd for PushCmd {
                     Err(OxenError::basic_str(msg))
                 }
                 Err(e) => {
-                    println!("Error pushing: {e}");
+                    eprintln!("Error pushing: {e}");
                     Err(e)
                 }
             }

--- a/oxen-rust/src/cli/src/cmd/tree.rs
+++ b/oxen-rust/src/cli/src/cmd/tree.rs
@@ -95,6 +95,7 @@ impl RunCmd for TreeCmd {
 impl TreeCmd {
     fn print_node(&self, repo: &LocalRepository, node: &str, depth: i32) -> Result<(), OxenError> {
         let node_hash = node.parse()?;
+        // REFACTOR: Get through repositories::tree
         let tree = CommitMerkleTree::read_node(repo, &node_hash, true)?.unwrap();
         CommitMerkleTree::print_node_depth(&tree, depth);
 

--- a/oxen-rust/src/lib/src/api/client/tree.rs
+++ b/oxen-rust/src/lib/src/api/client/tree.rs
@@ -124,6 +124,7 @@ pub async fn download_node(
     log::debug!("unpacked node {node_hash_str}");
 
     // We just downloaded, so unwrap is safe
+
     let node = CommitMerkleTree::read_node(local_repo, node_id, false)?.unwrap();
 
     log::debug!("read node {node}");
@@ -148,6 +149,7 @@ pub async fn download_node_with_children(
     log::debug!("unpacked node {node_hash_str}");
 
     // We just downloaded, so unwrap is safe
+    // REFACTOR: Get through repositories::tree
     let node = CommitMerkleTree::read_node(local_repo, node_id, true)?.unwrap();
 
     log::debug!("read node {node}");

--- a/oxen-rust/src/lib/src/api/client/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/api/client/workspaces/files.rs
@@ -1098,8 +1098,12 @@ pub async fn rm_files(
             let parent_path = relative_path.parent().unwrap_or(&root_path);
 
             // If dir not found in tree, skip glob path
-            let Some(dir_node) =
-                repositories::tree::get_dir_with_children(local_repo, head_commit, parent_path)?
+            let Some(dir_node) = repositories::tree::get_dir_with_children(
+                local_repo,
+                head_commit,
+                parent_path,
+                None,
+            )?
             else {
                 continue;
             };
@@ -1184,8 +1188,12 @@ pub async fn rm_files_from_staged(
             let parent_path = relative_path.parent().unwrap_or(&root_path);
 
             // If dir not found in tree, skip glob path
-            let Some(dir_node) =
-                repositories::tree::get_dir_with_children(local_repo, head_commit, parent_path)?
+            let Some(dir_node) = repositories::tree::get_dir_with_children(
+                local_repo,
+                head_commit,
+                parent_path,
+                None,
+            )?
             else {
                 continue;
             };

--- a/oxen-rust/src/lib/src/core/v_latest/branches.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/branches.rs
@@ -2,7 +2,6 @@ use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::core::v_latest::fetch;
 use crate::core::v_latest::index::restore::{self, FileToRestore};
-use crate::core::v_latest::index::CommitMerkleTree;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::{EMerkleTreeNode, MerkleTreeNode};
 use crate::model::{Commit, CommitEntry, LocalRepository, MerkleHash, PartialNode};
@@ -179,12 +178,14 @@ pub async fn checkout_subtrees(
         let mut progress = CheckoutProgressBar::new(to_commit.id.clone());
         let mut target_hashes = HashSet::new();
         let target_root = if let Some(target_root) =
-            CommitMerkleTree::from_path_depth_children_and_hashes(
+            repositories::tree::get_subtree_by_depth_with_unique_children(
                 repo,
                 to_commit,
                 subtree_path.clone(),
+                None,
+                Some(&mut target_hashes),
+                None,
                 depth,
-                &mut target_hashes,
             )? {
             target_root
         } else {
@@ -201,11 +202,12 @@ pub async fn checkout_subtrees(
         let from_root = if maybe_from_commit.is_some() {
             log::debug!("from id: {:?}", maybe_from_commit.as_ref().unwrap().id);
             log::debug!("to id: {:?}", to_commit.id);
-            CommitMerkleTree::root_with_unique_children(
+            repositories::tree::get_root_with_children_and_partial_nodes(
                 repo,
                 maybe_from_commit.as_ref().unwrap(),
-                &mut target_hashes,
-                &mut shared_hashes,
+                Some(&target_hashes),
+                None,
+                Some(&mut shared_hashes),
                 &mut partial_nodes,
             )
             .map_err(|e| {
@@ -312,8 +314,13 @@ pub async fn set_working_repo_to_commit(
 
     // Load in the target tree, collecting every dir and vnode hash for comparison with the from tree
     let mut target_hashes = HashSet::new();
-    let Some(target_tree) =
-        CommitMerkleTree::root_with_children_and_hashes(repo, to_commit, &mut target_hashes)?
+    let Some(target_tree) = repositories::tree::get_root_with_children_and_node_hashes(
+        repo,
+        to_commit,
+        None,
+        Some(&mut target_hashes),
+        None,
+    )?
     else {
         return Err(OxenError::basic_str(
             "Cannot get root node for target commit",
@@ -332,11 +339,12 @@ pub async fn set_working_repo_to_commit(
 
         log::debug!("from id: {:?}", from_commit.id);
         log::debug!("to id: {:?}", to_commit.id);
-        CommitMerkleTree::root_with_unique_children(
+        repositories::tree::get_root_with_children_and_partial_nodes(
             repo,
             from_commit,
-            &mut target_hashes,
-            &mut shared_hashes,
+            Some(&target_hashes),
+            None,
+            Some(&mut shared_hashes),
             &mut partial_nodes,
         )
         .map_err(|_| OxenError::basic_str("Cannot get root node for base commit"))?
@@ -368,7 +376,7 @@ pub async fn set_working_repo_to_commit(
         ));
     }
 
-    // Cleanup files if checking out from another commit
+    // Cleanup files if checking out fr om another commit
     if maybe_from_commit.is_some() {
         log::debug!("Cleanup_removed_files");
         cleanup_removed_files(repo, &from_tree.unwrap(), &mut progress, &mut hashes).await?;
@@ -577,29 +585,40 @@ fn r_restore_missing_or_modified_files(
 
                 progress.increment_restored();
             } else {
+                // TODO: Refactor this check into a separate module
+                // We don't have a module for a 3-way is_modified_from_node right now
+
                 // File exists, check whether it matches the target node or a from node
-                // First check last modified times
+                // First, check the metadata
                 let meta = util::fs::metadata(&full_path)?;
                 let last_modified = Some(FileTime::from_last_modification_time(&meta));
+                let size = Some(meta.len());
 
-                // If last_modified matches the target, do nothing
                 let target_last_modified = util::fs::last_modified_time(
                     file_node.last_modified_seconds(),
                     file_node.last_modified_nanoseconds(),
                 );
-                if last_modified == Some(target_last_modified) {
+
+                let target_size = file_node.num_bytes();
+
+                // If this matches the target, do nothing
+                if last_modified == Some(target_last_modified) && size == Some(target_size) {
                     return Ok(());
                 }
 
-                // If last_modified matches a corresponding from_node, stage it to be restored
-                let (from_node, from_last_modified) =
+                // If the metadata matches a corresponding from_node, stage it to be restored
+                let (from_node, from_last_modified, from_size) =
                     if let Some(from_node) = partial_nodes.get(&file_path) {
-                        (Some(from_node), Some(from_node.last_modified))
+                        (
+                            Some(from_node),
+                            Some(from_node.last_modified),
+                            Some(from_node.size),
+                        )
                     } else {
-                        (None, None)
+                        (None, None, None)
                     };
 
-                if last_modified == from_last_modified {
+                if last_modified == from_last_modified && size == from_size {
                     results.files_to_restore.push(FileToRestore {
                         file_node: file_node.clone(),
                         path: file_path.clone(),

--- a/oxen-rust/src/lib/src/core/v_latest/data_frames/schemas.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/data_frames/schemas.rs
@@ -358,7 +358,7 @@ pub fn add_column_metadata(
     let path = path.as_ref();
     let path = util::fs::path_relative_to_dir(path, &repo.path)?;
 
-    log::debug!("add_column_metadata: path: {path:?}");
+    println!("add_column_metadata: path: {path:?}");
 
     let column = column.as_ref();
 
@@ -380,9 +380,12 @@ pub fn add_column_metadata(
                 "Cannot add metadata, no commits found.",
             ));
         };
-        log::debug!("add_column_metadata: commit: {commit} path: {path:?}");
+        println!("add_column_metadata: commit: {commit} path: {path:?}");
         let Some(node) = repositories::tree::get_node_by_path(repo, &commit, &path)? else {
-            return Err(OxenError::path_does_not_exist(path));
+            return Err(OxenError::basic_str(format!(
+                "path {:?} not found in commit {:?}",
+                path, commit
+            )));
         };
         let mut parent_id = node.parent_id;
         let mut dir_path = path.clone();

--- a/oxen-rust/src/lib/src/core/v_latest/data_frames/schemas.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/data_frames/schemas.rs
@@ -358,7 +358,7 @@ pub fn add_column_metadata(
     let path = path.as_ref();
     let path = util::fs::path_relative_to_dir(path, &repo.path)?;
 
-    println!("add_column_metadata: path: {path:?}");
+    log::debug!("add_column_metadata: path: {path:?}");
 
     let column = column.as_ref();
 
@@ -380,11 +380,10 @@ pub fn add_column_metadata(
                 "Cannot add metadata, no commits found.",
             ));
         };
-        println!("add_column_metadata: commit: {commit} path: {path:?}");
+        log::debug!("add_column_metadata: commit: {commit} path: {path:?}");
         let Some(node) = repositories::tree::get_node_by_path(repo, &commit, &path)? else {
             return Err(OxenError::basic_str(format!(
-                "path {:?} not found in commit {:?}",
-                path, commit
+                "path {path:?} not found in commit {commit:?}"
             )));
         };
         let mut parent_id = node.parent_id;

--- a/oxen-rust/src/lib/src/core/v_latest/diff.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/diff.rs
@@ -29,8 +29,8 @@ pub async fn list_diff_entries(
         "list_diff_entries base_dir: '{base_path:?}', head_dir: '{head_path:?}' base_commit: '{base_commit}', head_commit: '{head_commit}'"
     );
 
-    let base_tree = CommitMerkleTree::node_from_path_maybe(repo, base_commit, &base_path, true)?;
-    let head_tree = CommitMerkleTree::node_from_path_maybe(repo, head_commit, &head_path, true)?;
+    let base_tree = CommitMerkleTree::read_from_path_maybe(repo, base_commit, &base_path, true)?;
+    let head_tree = CommitMerkleTree::read_from_path_maybe(repo, head_commit, &head_path, true)?;
 
     let mut base_files: HashSet<FileNodeWithDir> = HashSet::new();
     let mut head_files: HashSet<FileNodeWithDir> = HashSet::new();

--- a/oxen-rust/src/lib/src/core/v_latest/download.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/download.rs
@@ -69,7 +69,7 @@ pub async fn download_dir_entries(
     // Get tree from local repos
     let commit = &entry.latest_commit.as_ref().unwrap();
     let Some(dir_node) =
-        repositories::tree::get_dir_with_children_recursive(local_repo, commit, remote_path)?
+        repositories::tree::get_dir_with_children_recursive(local_repo, commit, remote_path, None)?
     else {
         log::warn!("Dir node not found for path {local_path:?}");
         return Ok(());

--- a/oxen-rust/src/lib/src/core/v_latest/entries.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/entries.rs
@@ -64,7 +64,7 @@ pub fn list_directory(
 
     log::debug!("list_directory commit {commit}");
 
-    let dir = repositories::tree::get_dir_with_children(repo, &commit, directory)?
+    let dir = repositories::tree::get_dir_with_children(repo, &commit, directory, None)?
         .ok_or(OxenError::resource_not_found(directory.to_str().unwrap()))?;
 
     log::debug!("list_directory dir {dir}");
@@ -131,7 +131,7 @@ pub fn get_meta_entry(
             parsed_resource.clone(),
         ))?;
     log::debug!("get_meta_entry path: {path:?} commit: {commit}");
-    let node = repositories::tree::get_dir_without_children(repo, &commit, path)?;
+    let node = repositories::tree::get_dir_without_children(repo, &commit, path, None)?;
     log::debug!("get_meta_entry node: {node:?}");
 
     if let Some(node) = node {

--- a/oxen-rust/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -612,7 +612,6 @@ impl CommitMerkleTree {
 
         let node_hash: Option<MerkleHash> = dir_hashes.get(node_path).cloned();
         if let Some(node_hash) = node_hash {
-            println!("Look up dir {node_path:?}");
             // Read the node at depth 1 to get VNodes and Sub-Files/Dirs
             // We don't count VNodes in the depth
             CommitMerkleTree::read_depth(repo, &node_hash, 1)

--- a/oxen-rust/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -727,25 +727,6 @@ impl CommitMerkleTree {
         Ok(children)
     }
 
-    // MODULARIZE: List_files_and_folders in repositories::tree
-    pub fn node_files_and_folders(node: &MerkleTreeNode) -> Result<Vec<MerkleTreeNode>, OxenError> {
-        if MerkleTreeNodeType::Dir != node.node.node_type() {
-            return Err(OxenError::basic_str(format!(
-                "node_files_and_folders Merkle tree node is not a directory: '{:?}'",
-                node.node.node_type()
-            )));
-        }
-
-        // The dir node will have vnode children
-        let mut children = Vec::new();
-        for child in &node.children {
-            if let EMerkleTreeNode::VNode(_) = &child.node {
-                children.extend(child.children.iter().cloned());
-            }
-        }
-        Ok(children)
-    }
-
     pub fn total_vnodes(&self) -> usize {
         self.root.total_vnodes()
     }

--- a/oxen-rust/src/lib/src/core/v_latest/index/restore.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/index/restore.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 
 use crate::constants::STAGED_DIR;
 use crate::core::db::{self};
-use crate::core::v_latest::index::CommitMerkleTree;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::{EMerkleTreeNode, FileNode, MerkleTreeNode};
 use crate::model::{Commit, LocalRepository, MerkleHash, PartialNode};
@@ -34,7 +33,7 @@ pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), Ox
     let commit: Commit = repositories::commits::get_commit_or_head(repo, opts.source_ref)?;
     log::debug!("restore::restore: got commit {:?}", commit.id);
 
-    let dir = CommitMerkleTree::dir_with_children_recursive(repo, &commit, &path)?;
+    let dir = repositories::tree::get_dir_with_children_recursive(repo, &commit, &path, None)?;
 
     match dir {
         Some(dir) => {
@@ -43,20 +42,21 @@ pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), Ox
         }
         None => {
             log::debug!("restore::restore: restoring file");
-            match CommitMerkleTree::from_path(repo, &commit, &path, false) {
-                Ok(merkle_tree) => {
-                    log::debug!(
-                        "restore::restore: got merkle tree {:?}",
-                        merkle_tree.root.node
-                    );
-                    if !matches!(&merkle_tree.root.node, EMerkleTreeNode::File(_)) {
+            match repositories::tree::get_node_by_path_with_children(repo, &commit, &path) {
+                Ok(Some(node)) => {
+                    log::debug!("restore::restore: got merkle tree {:?}", node.node);
+                    if !matches!(&node.node, EMerkleTreeNode::File(_)) {
                         return Err(OxenError::basic_str("Path is not a file"));
                     }
 
-                    let child_file = merkle_tree.root.file().unwrap();
+                    let child_file = node.file().unwrap();
 
                     restore_file(repo, &child_file, &path, &version_store).await
                 }
+                Ok(None) => Err(OxenError::basic_str(format!(
+                    "Merkle tree for commit {:?} not found",
+                    commit
+                ))),
                 Err(OxenError::Basic(msg))
                     if msg.to_string().contains("Merkle tree hash not found") =>
                 {
@@ -216,7 +216,7 @@ async fn restore_dir(
     Ok(())
 }
 
-pub fn should_restore_partial(
+pub fn should_restore_partial_node(
     repo: &LocalRepository,
     base_node: Option<PartialNode>,
     file_node: &FileNode,
@@ -230,12 +230,14 @@ pub fn should_restore_partial(
         // Check metadata for changes first
         let meta = util::fs::metadata(&working_path)?;
         let file_last_modified = filetime::FileTime::from_last_modification_time(&meta);
+        let file_size = meta.len();
 
         // If there are modifications compared to the base node, we should not restore the file
         if let Some(base_node) = base_node {
             let node_last_modified = base_node.last_modified;
+            let node_size = base_node.size;
 
-            if file_last_modified == node_last_modified {
+            if file_last_modified == node_last_modified && file_size == node_size {
                 return Ok(true);
             }
 

--- a/oxen-rust/src/lib/src/core/v_latest/index/restore.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/index/restore.rs
@@ -54,8 +54,7 @@ pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), Ox
                     restore_file(repo, &child_file, &path, &version_store).await
                 }
                 Ok(None) => Err(OxenError::basic_str(format!(
-                    "Merkle tree for commit {:?} not found",
-                    commit
+                    "Merkle tree for commit {commit:?} not found"
                 ))),
                 Err(OxenError::Basic(msg))
                     if msg.to_string().contains("Merkle tree hash not found") =>

--- a/oxen-rust/src/lib/src/core/v_latest/push.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/push.rs
@@ -259,7 +259,7 @@ async fn get_commit_missing_hashes(
         let mut dir_nodes: HashSet<MerkleHash> = HashSet::new();
 
         for path in paths {
-            log::debug!("push_commits adding candidate nodes for commit: {}", commit);
+            log::debug!("push_commits adding candidate nodes for commit: {commit}");
             let Some(root) = repositories::tree::get_subtree_by_depth_with_unique_children(
                 repo,
                 commit,
@@ -293,7 +293,7 @@ async fn get_commit_missing_hashes(
 
         dir_nodes.insert(commit.hash()?);
 
-        log::debug!("push_commits dir nodes: {:?}", dir_nodes);
+        log::debug!("push_commits dir nodes: {dir_nodes:?}");
         let total_bytes = files.iter().map(|e| e.num_bytes()).sum();
 
         let push_commit_info = PushCommitInfo {

--- a/oxen-rust/src/lib/src/core/v_latest/push.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/push.rs
@@ -9,12 +9,13 @@ use tokio::time::Duration;
 use crate::constants::AVG_CHUNK_SIZE;
 use crate::constants::DEFAULT_REMOTE_NAME;
 use crate::core::progress::push_progress::PushProgress;
-use crate::core::v_latest::index::CommitMerkleTree;
 use crate::error::OxenError;
 use crate::model::entry::commit_entry::Entry;
+use crate::model::merkle_tree::node::MerkleTreeNode;
 use crate::model::{
     Branch, Commit, CommitEntry, LocalRepository, MerkleHash, MerkleTreeNodeType, RemoteRepository,
 };
+
 use crate::opts::PushOpts;
 use crate::util::{self, concurrency};
 use crate::{api, repositories};
@@ -227,68 +228,72 @@ async fn get_commit_missing_hashes(
     latest_remote_commit: Option<Commit>,
     commits: &[Commit],
 ) -> Result<HashMap<MerkleHash, PushCommitInfo>, OxenError> {
-    let mut starting_node_hashes = HashMap::new();
-    let mut shared_hashes = HashMap::new();
+    let mut base_hashes = HashSet::new();
+    let paths = &repo.subtree_paths().unwrap_or(vec![PathBuf::new()]);
+
     if let Some(ref commit) = latest_remote_commit {
-        CommitMerkleTree::get_unique_children_for_commit(
-            repo,
-            commit,
-            &repo.subtree_paths().unwrap_or(vec![PathBuf::from("")]), //Should we default to root?
-            &mut shared_hashes,
-            &mut starting_node_hashes,
-        )?;
+        for path in paths {
+            let mut starting_node_hashes = HashSet::new();
+            repositories::tree::get_subtree_by_depth_with_unique_children(
+                repo,
+                commit,
+                path,
+                Some(&base_hashes),
+                Some(&mut starting_node_hashes),
+                None,
+                repo.depth().unwrap_or(-1),
+            )?;
+
+            base_hashes.extend(starting_node_hashes.clone());
+        }
     }
 
-    log::debug!("starting hashes: {:?}", starting_node_hashes.len());
-
-    let mut shared_hashes = starting_node_hashes.clone();
+    log::debug!("starting hashes: {:?}", base_hashes.len());
 
     let mut result = HashMap::new();
 
     for commit in commits.iter().rev() {
-        let mut unique_hashes_and_type = HashMap::new();
-        log::debug!("push_commits adding candidate nodes for commit: {commit}");
-        let Some(_) = CommitMerkleTree::get_unique_children_for_commit(
-            repo,
-            commit,
-            &repo.subtree_paths().unwrap_or(vec![PathBuf::from("")]), //Should we default to root?
-            &mut shared_hashes,
-            &mut unique_hashes_and_type,
-        )?
-        else {
-            log::error!("push_commits commit node not found for commit: {commit}");
-            continue;
-        };
+        let mut unique_hashes = HashSet::new();
 
-        log::debug!("push_commits unique hashes and type: {unique_hashes_and_type:?}");
+        let mut files: Vec<Entry> = Vec::new();
+        let mut dir_nodes: HashSet<MerkleHash> = HashSet::new();
 
-        // let (files, dir_nodes) = repositories::tree::list_files_and_dirs(&commit_node)?;
-        let files = unique_hashes_and_type
-            .iter()
-            .filter(|((_, t), _)| {
-                let t = t.node.node_type();
-                t == MerkleTreeNodeType::File || t == MerkleTreeNodeType::FileChunk
-            })
-            .map(|((_, node), _)| Entry::CommitEntry(CommitEntry::from_node(&node.node)))
-            .collect::<Vec<Entry>>();
+        for path in paths {
+            log::debug!("push_commits adding candidate nodes for commit: {}", commit);
+            let Some(root) = repositories::tree::get_subtree_by_depth_with_unique_children(
+                repo,
+                commit,
+                path,
+                Some(&base_hashes),
+                Some(&mut unique_hashes),
+                None,
+                repo.depth().unwrap_or(-1),
+            )?
+            else {
+                log::error!("push_commits commit node not found for commit: {commit}");
+                continue;
+            };
 
-        let mut dir_nodes = unique_hashes_and_type
-            .iter()
-            .filter(|((h, t), _)| {
-                let t = t.node.node_type();
-                log::debug!("push_commits dir node: {h} | type: {t:?}");
-                log::debug!(
-                    "push_commits dir node bool: {:?}",
-                    !(t == MerkleTreeNodeType::File || t == MerkleTreeNodeType::FileChunk)
-                );
-                !(t == MerkleTreeNodeType::File || t == MerkleTreeNodeType::FileChunk)
-            })
-            .map(|((h, _), _)| *h)
-            .collect::<HashSet<MerkleHash>>();
+            base_hashes.extend(unique_hashes.clone());
 
-        shared_hashes.extend(unique_hashes_and_type);
+            root.walk_tree(|node: &MerkleTreeNode| {
+                let t = node.node.node_type();
+
+                if t == MerkleTreeNodeType::File || t == MerkleTreeNodeType::FileChunk {
+                    files.push(Entry::CommitEntry(CommitEntry::from_node(&node.node)));
+                } else if !node.node.is_leaf() {
+                    let hash = node.node.hash();
+                    dir_nodes.insert(*hash);
+                }
+            });
+        }
+
+        // Add the ancestor dirs of each subtree path to dir_nodes
+        repositories::tree::get_ancestor_nodes(repo, commit, paths, &mut dir_nodes)?;
+
         dir_nodes.insert(commit.hash()?);
-        log::debug!("push_commits dir nodes: {dir_nodes:?}");
+
+        log::debug!("push_commits dir nodes: {:?}", dir_nodes);
         let total_bytes = files.iter().map(|e| e.num_bytes()).sum();
 
         let push_commit_info = PushCommitInfo {

--- a/oxen-rust/src/lib/src/core/v_latest/rm.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/rm.rs
@@ -486,7 +486,7 @@ fn remove_inner(
 
         let parent_path = path.parent().unwrap_or(Path::new(""));
         let parent_node: MerkleTreeNode = if let Some(dir_node) =
-            CommitMerkleTree::dir_with_children(repo, &head_commit, parent_path)?
+            CommitMerkleTree::dir_with_children(repo, &head_commit, parent_path, None)?
         {
             dir_node
         } else {
@@ -588,7 +588,7 @@ fn remove_dir_inner(
     path: &Path,
     staged_db: &DBWithThreadMode<MultiThreaded>,
 ) -> Result<CumulativeStats, OxenError> {
-    let dir_node = match CommitMerkleTree::dir_with_children_recursive(repo, commit, path)? {
+    let dir_node = match CommitMerkleTree::dir_with_children_recursive(repo, commit, path, None)? {
         Some(node) => node,
         None => {
             let error = format!("Error: {path:?} must be committed in order to use `oxen rm`");

--- a/oxen-rust/src/lib/src/core/v_latest/status.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/status.rs
@@ -597,7 +597,7 @@ fn find_changes(
                 // If the subtree is the root, we need to check for removed files in the root
                 let dir_node = CommitMerkleTree::read_depth(repo, dir_hash, 1)?;
                 if let Some(node) = dir_node {
-                    for child in CommitMerkleTree::node_files_and_folders(&node)? {
+                    for child in repositories::tree::list_files_and_folders(&node)? {
                         if let EMerkleTreeNode::File(file_node) = &child.node {
                             let file_path = full_path.join(file_node.name());
                             if !file_path.exists() {
@@ -612,7 +612,7 @@ fn find_changes(
 
         let dir_node = CommitMerkleTree::read_depth(repo, dir_hash, 1)?;
         if let Some(node) = dir_node {
-            for child in CommitMerkleTree::node_files_and_folders(&node)? {
+            for child in repositories::tree::list_files_and_folders(&node)? {
                 if let EMerkleTreeNode::File(file_node) = &child.node {
                     let file_path = full_path.join(file_node.name());
                     if !file_path.exists() {
@@ -808,7 +808,7 @@ fn find_local_changes(
                 // If the subtree is the root, we need to check for removed files in the root
                 let dir_node = CommitMerkleTree::read_depth(repo, dir_hash, 1)?;
                 if let Some(node) = dir_node {
-                    for child in CommitMerkleTree::node_files_and_folders(&node)? {
+                    for child in repositories::tree::list_files_and_folders(&node)? {
                         if let EMerkleTreeNode::File(file_node) = &child.node {
                             let file_path = full_path.join(file_node.name());
                             if !file_path.exists() && !unsynced.files.contains(&file_path) {
@@ -823,7 +823,7 @@ fn find_local_changes(
 
         let dir_node = CommitMerkleTree::read_depth(repo, dir_hash, 1)?;
         if let Some(node) = dir_node {
-            for child in CommitMerkleTree::node_files_and_folders(&node)? {
+            for child in repositories::tree::list_files_and_folders(&node)? {
                 if let EMerkleTreeNode::File(file_node) = &child.node {
                     let file_path = full_path.join(file_node.name());
 
@@ -878,7 +878,7 @@ fn count_removed_entries(
 
     let dir_node = CommitMerkleTree::read_depth(repo, dir_hash, 1)?;
     if let Some(ref node) = dir_node {
-        for child in CommitMerkleTree::node_files_and_folders(node)? {
+        for child in repositories::tree::list_files_and_folders(node)? {
             if let EMerkleTreeNode::File(_) = &child.node {
                 // Any files nodes accessed here are children of a removed dir, so they must also be removed
                 *removed_entries += 1;

--- a/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -4,7 +4,6 @@ use crate::constants::{DIFF_HASH_COL, DIFF_STATUS_COL, EXCLUDE_OXEN_COLS, TABLE_
 use crate::core::db::data_frames::df_db;
 use crate::core::db::data_frames::df_db::with_df_db_manager;
 use crate::core::staged::with_staged_db_manager;
-use crate::core::v_latest::index::CommitMerkleTree;
 use crate::core::v_latest::workspaces::files::{add, track_modified_data_frame};
 use parking_lot::Mutex;
 use sql_query_builder::Delete;
@@ -117,8 +116,16 @@ pub fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
 
     log::debug!("core::v_latest::workspaces::data_frames::index({path:?}) got commit {commit:?}");
 
-    let commit_merkle_tree = CommitMerkleTree::from_path(repo, commit, path, true)?;
-    let file_hash = commit_merkle_tree.root.hash;
+    let Ok(Some(commit_merkle_tree)) =
+        repositories::tree::get_node_by_path_with_children(repo, commit, path)
+    else {
+        return Err(OxenError::basic_str(format!(
+            "Merkle tree for commit {} not found",
+            commit
+        )));
+    };
+
+    let file_hash = commit_merkle_tree.hash;
 
     log::debug!(
         "core::v_latest::workspaces::data_frames::index({path:?}) got file hash {file_hash:?}"
@@ -139,7 +146,7 @@ pub fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
         "core::v_latest::index::workspaces::data_frames::index({path:?}) got version path: {version_path:?}"
     );
 
-    let extension = match &commit_merkle_tree.root.node {
+    let extension = match &commit_merkle_tree.node {
         EMerkleTreeNode::File(file_node) => file_node.extension(),
         _ => {
             return Err(OxenError::basic_str("File node is not a file node"));

--- a/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -120,8 +120,7 @@ pub fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
         repositories::tree::get_node_by_path_with_children(repo, commit, path)
     else {
         return Err(OxenError::basic_str(format!(
-            "Merkle tree for commit {} not found",
-            commit
+            "Merkle tree for commit {commit} not found"
         )));
     };
 

--- a/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -261,8 +261,7 @@ pub async fn prepare_modified_or_removed_row(
         repositories::tree::get_node_by_path_with_children(repo, commit, &path)?
     else {
         return Err(OxenError::basic_str(format!(
-            "Merkle tree for commit {:?} not found",
-            commit
+            "Merkle tree for commit {commit:?} not found"
         )));
     };
 

--- a/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -8,7 +8,6 @@ use serde_json::Value;
 
 use crate::constants::DIFF_STATUS_COL;
 use crate::core::db;
-use crate::core::v_latest::index::CommitMerkleTree;
 use crate::model::merkle_tree::node::EMerkleTreeNode;
 use crate::opts::DFOpts;
 
@@ -258,23 +257,28 @@ pub async fn prepare_modified_or_removed_row(
         .ok_or_else(|| OxenError::basic_str("Row index not found"))?;
     let row_idx_og = (row_idx - 1) as i64;
 
-    let commit_merkle_tree = CommitMerkleTree::from_path(repo, commit, &path, true)?;
-    let file_node = match commit_merkle_tree.root.node {
+    let Some(commit_merkle_tree) =
+        repositories::tree::get_node_by_path_with_children(repo, commit, &path)?
+    else {
+        return Err(OxenError::basic_str(format!(
+            "Merkle tree for commit {:?} not found",
+            commit
+        )));
+    };
+
+    let file_node = match commit_merkle_tree.node {
         EMerkleTreeNode::File(file_node) => file_node,
         _ => return Err(OxenError::basic_str("File node not found")),
     };
 
     log::debug!(
         "prepare_modified_or_removed_row() commit_merkle_tree: {:?}",
-        &commit_merkle_tree.root.hash.to_string()
+        &commit_merkle_tree.hash.to_string()
     );
 
     // let scan_rows = 10000 as usize;
-    let committed_df_path = util::fs::version_path_from_node(
-        repo,
-        commit_merkle_tree.root.hash.to_string(),
-        path.as_ref(),
-    );
+    let committed_df_path =
+        util::fs::version_path_from_node(repo, commit_merkle_tree.hash.to_string(), path.as_ref());
 
     log::debug!("prepare_modified_or_removed_row() committed_df_path: {committed_df_path:?}");
 

--- a/oxen-rust/src/lib/src/core/v_old/v0_19_0/entries.rs
+++ b/oxen-rust/src/lib/src/core/v_old/v0_19_0/entries.rs
@@ -60,7 +60,7 @@ pub fn get_meta_entry(
             parsed_resource.clone(),
         ))?;
     log::debug!("get_meta_entry path: {path:?} commit: {commit}");
-    let node = repositories::tree::get_dir_without_children(repo, &commit, path)?;
+    let node = repositories::tree::get_dir_without_children(repo, &commit, path, None)?;
     log::debug!("get_meta_entry node: {node:?}");
 
     if let Some(node) = node {

--- a/oxen-rust/src/lib/src/model/partial_node.rs
+++ b/oxen-rust/src/lib/src/model/partial_node.rs
@@ -7,6 +7,7 @@ use filetime::FileTime;
 pub struct PartialNode {
     pub hash: MerkleHash,
     pub last_modified: FileTime,
+    pub size: u64,
 }
 
 impl PartialNode {
@@ -14,12 +15,14 @@ impl PartialNode {
         hash: MerkleHash,
         last_modified_seconds: i64,
         last_modified_nanoseconds: u32,
+        size: u64,
     ) -> Self {
         let last_modified =
             util::fs::last_modified_time(last_modified_seconds, last_modified_nanoseconds);
         PartialNode {
             hash,
             last_modified,
+            size,
         }
     }
 }

--- a/oxen-rust/src/lib/src/repositories.rs
+++ b/oxen-rust/src/lib/src/repositories.rs
@@ -6,7 +6,6 @@
 use crate::constants;
 use crate::core;
 use crate::core::refs::with_ref_manager;
-use crate::core::v_latest::index::CommitMerkleTree;
 use crate::error::OxenError;
 use crate::error::NO_REPO_FOUND;
 use crate::model::file::FileContents;

--- a/oxen-rust/src/lib/src/repositories/commits/commit_writer.rs
+++ b/oxen-rust/src/lib/src/repositories/commits/commit_writer.rs
@@ -573,7 +573,7 @@ fn get_node_dir_children(
     base_dir: impl AsRef<Path>,
     node: &MerkleTreeNode,
 ) -> Result<HashSet<StagedMerkleTreeNode>, OxenError> {
-    let dir_children = CommitMerkleTree::node_files_and_folders(node)?;
+    let dir_children = repositories::tree::list_files_and_folders(node)?;
     let children = dir_children
         .into_iter()
         .flat_map(|child| node_data_to_staged_node(&base_dir, &child))

--- a/oxen-rust/src/lib/src/repositories/data_frames/schemas.rs
+++ b/oxen-rust/src/lib/src/repositories/data_frames/schemas.rs
@@ -569,6 +569,7 @@ mod tests {
                 "root": "images"
             });
 
+            println!("Here");
             repositories::add(&repo, &bbox_path).await?;
             repositories::data_frames::schemas::add_column_metadata(
                 &repo, &bbox_file, "file", &metadata,

--- a/oxen-rust/src/lib/src/repositories/data_frames/schemas.rs
+++ b/oxen-rust/src/lib/src/repositories/data_frames/schemas.rs
@@ -569,7 +569,6 @@ mod tests {
                 "root": "images"
             });
 
-            println!("Here");
             repositories::add(&repo, &bbox_path).await?;
             repositories::data_frames::schemas::add_column_metadata(
                 &repo, &bbox_file, "file", &metadata,

--- a/oxen-rust/src/lib/src/repositories/push.rs
+++ b/oxen-rust/src/lib/src/repositories/push.rs
@@ -1291,6 +1291,7 @@ A: Checkout Oxen.ai
                     Some(vec![PathBuf::from("nlp").join("classification")]);
                 clone_opts.fetch_opts.depth = Some(2);
                 let user_a_repo = repositories::clone(&clone_opts).await?;
+                println!("user_a_repo: {user_a_repo:?}");
 
                 // User adds a file and pushes
                 let new_file = PathBuf::from("nlp")
@@ -1319,6 +1320,7 @@ A: Checkout Oxen.ai
                     .any(|entry| entry.filename() == "new_data.tsv"));
 
                 // Make sure the root directory is in tact
+                // TODO: HERE'S THE ISSUE! And I think it has to do with push? I wasn't wholly sure what the point of the ancestor bs was before, but this is the best bet
                 let root_dir_entries =
                     api::client::dir::list(&remote_repo, &commit.id, &PathBuf::from(""), 1, 100)
                         .await?;

--- a/oxen-rust/src/lib/src/repositories/push.rs
+++ b/oxen-rust/src/lib/src/repositories/push.rs
@@ -1757,8 +1757,7 @@ A: Checkout Oxen.ai
                 let cloned_file_path = clone_repo.path.join("large_file.bin");
                 assert!(
                     cloned_file_path.exists(),
-                    "Cloned file should exist at {:?}",
-                    cloned_file_path
+                    "Cloned file should exist at {cloned_file_path:?}"
                 );
 
                 // Verify the file size matches

--- a/oxen-rust/src/lib/src/repositories/remote_mode/checkout.rs
+++ b/oxen-rust/src/lib/src/repositories/remote_mode/checkout.rs
@@ -485,7 +485,7 @@ mod tests {
                 // Create a new branch and checkout
                 let branch_name = "feature";
                 repositories::remote_mode::create_checkout(&mut cloned_repo, branch_name).await?;
-                println!("2");
+
                 // Modify the file content on the new branch and commit
                 let modified_content = "World";
                 test::modify_txt_file(&hello_file, modified_content)?;

--- a/oxen-rust/src/lib/src/repositories/remote_mode/restore.rs
+++ b/oxen-rust/src/lib/src/repositories/remote_mode/restore.rs
@@ -36,7 +36,7 @@ pub async fn restore(
 
             // If dir not found in tree, skip glob path
             let Some(dir_node) =
-                repositories::tree::get_dir_with_children(repo, head_commit, parent_path)?
+                repositories::tree::get_dir_with_children(repo, head_commit, parent_path, None)?
             else {
                 continue;
             };

--- a/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
+++ b/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
@@ -231,13 +231,9 @@ pub fn diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DataFrame, 
 
 pub fn full_diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DiffResult, OxenError> {
     let repo = &workspace.base_repo;
-    let commit = &workspace.commit;
     let path = path.as_ref();
     // Get commit for the branch head
     log::debug!("diff_workspace_df got repo at path {:?}", repo.path);
-
-    let load_recursive = true;
-    repositories::CommitMerkleTree::read_from_path(repo, commit, path, load_recursive)?;
 
     if !is_indexed(workspace, path)? {
         return Err(OxenError::basic_str("Dataset is not indexed"));

--- a/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
+++ b/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
@@ -236,7 +236,8 @@ pub fn full_diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DiffRe
     // Get commit for the branch head
     log::debug!("diff_workspace_df got repo at path {:?}", repo.path);
 
-    repositories::CommitMerkleTree::from_path_recursive(repo, commit, path)?;
+    let load_recursive = true;
+    repositories::CommitMerkleTree::read_from_path(repo, commit, path, load_recursive)?;
 
     if !is_indexed(workspace, path)? {
         return Err(OxenError::basic_str("Dataset is not indexed"));
@@ -306,7 +307,7 @@ pub async fn from_directory(
 
     let depth = if recursive { -1 } else { 1 };
 
-    let subtree = repositories::tree::get_subtree_by_depth(
+    let subtree = repositories::tree::get_subtree(
         repo,
         &workspace.commit,
         &Some(path.as_ref().to_path_buf()),

--- a/oxen-rust/src/lib/src/util/fs.rs
+++ b/oxen-rust/src/lib/src/util/fs.rs
@@ -597,7 +597,7 @@ pub fn parse_glob_path(
 
             // Otherwise, traverse the tree for files to restore
             if let Some(dir_node) =
-                repositories::tree::get_dir_with_children(repo, head_commit, parent_path)?
+                repositories::tree::get_dir_with_children(repo, head_commit, parent_path, None)?
             {
                 let dir_children = repositories::tree::list_files_and_folders(&dir_node)?;
                 for child in dir_children {


### PR DESCRIPTION
Refactor the merkle tree loading modules in CommitMerkleTree and repositories tree to deduplicate code and implement a consistent naming scheme. Functions that previously got but did not require a CommitMerkleTree object now instead get a root from repositories::tree. In general, all functions go through repositories::tree rather than directly accessing CommitMerkleTree where possible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restoration now checks file size in addition to modification time for more accurate restores.
  * Improved error messages when directory/tree data cannot be found in a commit.

* **Refactor**
  * Consolidated and simplified repository tree access for more reliable and maintainable directory/file lookups.
  * Optimized subtree and node retrieval paths to improve performance and consistency.<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->