### PR TITLE
Fix merge for commits without an LCA

### DIFF
--- a/oxen-rust/src/lib/src/repositories/merge.rs
+++ b/oxen-rust/src/lib/src/repositories/merge.rs
@@ -9,14 +9,14 @@ use crate::model::{Branch, LocalRepository};
 
 #[derive(Debug)]
 pub struct MergeCommits {
-    pub lca: Commit,
+    pub lca: Option<Commit>,
     pub base: Commit,
     pub merge: Commit,
 }
 
 impl MergeCommits {
     pub fn is_fast_forward_merge(&self) -> bool {
-        self.lca.id == self.base.id
+        self.lca.is_some() && self.lca.as_ref().unwrap().id == self.base.id
     }
 }
 
@@ -192,7 +192,7 @@ pub fn lowest_common_ancestor_from_commits(
     repo: &LocalRepository,
     base_commit: &Commit,
     merge_commit: &Commit,
-) -> Result<Commit, OxenError> {
+) -> Result<Option<Commit>, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::merge::lowest_common_ancestor_from_commits(
@@ -437,7 +437,8 @@ mod tests {
 
             // Make sure the merger can detect the three way merge
             let guess =
-                repositories::merge::lowest_common_ancestor_from_commits(&repo, &lca, &lca)?;
+                repositories::merge::lowest_common_ancestor_from_commits(&repo, &lca, &lca)?
+                    .unwrap();
             assert_eq!(lca.id, guess.id);
 
             Ok(())

--- a/oxen-rust/src/lib/src/repositories/pull.rs
+++ b/oxen-rust/src/lib/src/repositories/pull.rs
@@ -1985,6 +1985,10 @@ mod tests {
                 assert!(hello_file.exists());
                 assert!(PathBuf::from("README.md").exists());
 
+                // There should be 3 total commits: The two divergent commits, and the merge commit
+                let commits = repositories::commits::list_all(&local_repo)?;
+                assert_eq!(commits.len(), 3);
+
                 Ok(())
             })
             .await?;


### PR DESCRIPTION
Refactors the merge logic to detect when commits have no lowest common ancestor. This can happen when we're pulling a non-empty remote to a non-empty repo. In this situation, we now do a 3-way merge, which preserves the files in both the merge and base commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Merge logic now tolerates missing common ancestors: LCA is optional, conflict detection and listings handle absent LCAs (returning empty results or specific errors) and fast‑forward checks avoid incorrect assumptions.
  * Logging updated to show absent LCA gracefully.

* **Tests**
  * Added test coverage for pull-and-merge scenarios with divergent/non-empty repositories (duplicate test blocks included).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->