### PR TITLE
Api 77/refactor restore module

### DIFF
--- a/oxen-rust/src/lib/src/core/v_latest/restore.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/restore.rs
@@ -4,24 +4,25 @@ use crate::model::LocalRepository;
 use crate::opts::{GlobOpts, RestoreOpts};
 use crate::util;
 
-pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), OxenError> {
-    let path = &opts.path;
+// TODO: Deprecate this module
+// Not sure why we have seperate core and core::index modules for restore
+pub async fn restore(repo: &LocalRepository, restore_opts: RestoreOpts) -> Result<(), OxenError> {
+    let paths = restore_opts.paths.iter().map(|p| p.to_owned()).collect();
 
     let glob_opts = GlobOpts {
-        paths: vec![path.to_path_buf()],
-        staged_db: opts.staged,
-        merkle_tree: !opts.staged,
+        paths,
+        staged_db: restore_opts.staged,
+        merkle_tree: !restore_opts.staged,
         working_dir: false,
         walk_dirs: false,
     };
 
     let expanded_paths = util::glob::parse_glob_paths(&glob_opts, Some(repo))?;
 
-    for path in expanded_paths {
-        let mut opts = opts.clone();
-        opts.path = path;
-        index::restore::restore(repo, opts).await?;
-    }
+    let mut restore_opts = restore_opts.clone();
+    restore_opts.paths = expanded_paths;
+
+    index::restore::restore(repo, restore_opts).await?;
 
     Ok(())
 }

--- a/oxen-rust/src/lib/src/opts/restore_opts.rs
+++ b/oxen-rust/src/lib/src/opts/restore_opts.rs
@@ -1,8 +1,9 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 #[derive(Clone, Debug)]
 pub struct RestoreOpts {
-    pub path: PathBuf,
+    pub paths: HashSet<PathBuf>,
     pub staged: bool,
     pub is_remote: bool,
     pub source_ref: Option<String>, // commit id or branch name
@@ -10,8 +11,11 @@ pub struct RestoreOpts {
 
 impl RestoreOpts {
     pub fn from_path<P: AsRef<Path>>(path: P) -> RestoreOpts {
+        let mut paths = HashSet::new();
+        paths.insert(path.as_ref().to_owned());
+
         RestoreOpts {
-            path: path.as_ref().to_owned(),
+            paths,
             staged: false,
             is_remote: false,
             source_ref: None,
@@ -19,8 +23,11 @@ impl RestoreOpts {
     }
 
     pub fn from_staged_path<P: AsRef<Path>>(path: P) -> RestoreOpts {
+        let mut paths = HashSet::new();
+        paths.insert(path.as_ref().to_owned());
+
         RestoreOpts {
-            path: path.as_ref().to_owned(),
+            paths,
             staged: true,
             is_remote: false,
             source_ref: None,
@@ -28,8 +35,11 @@ impl RestoreOpts {
     }
 
     pub fn from_path_ref<P: AsRef<Path>, S: AsRef<str>>(path: P, source_ref: S) -> RestoreOpts {
+        let mut paths = HashSet::new();
+        paths.insert(path.as_ref().to_owned());
+
         RestoreOpts {
-            path: path.as_ref().to_owned(),
+            paths,
             staged: false,
             is_remote: false,
             source_ref: Some(source_ref.as_ref().to_owned()),

--- a/oxen-rust/src/lib/src/repositories/restore.rs
+++ b/oxen-rust/src/lib/src/repositories/restore.rs
@@ -55,6 +55,7 @@ pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), Ox
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::path::Path;
     use std::path::PathBuf;
 
@@ -544,9 +545,12 @@ mod tests {
             assert_eq!(status.staged_files.len(), 7);
             assert_eq!(status.removed_files.len(), 0);
 
+            let mut paths = HashSet::new();
+            paths.insert(PathBuf::from("images/*"));
+
             // Restore staged with wildcard
             let restore_opts = RestoreOpts {
-                path: PathBuf::from("images/*"),
+                paths,
                 staged: true,
                 source_ref: None,
                 is_remote: false,
@@ -560,8 +564,11 @@ mod tests {
             assert_eq!(status.removed_files.len(), 7);
             assert_eq!(status.staged_files.len(), 0);
 
+            let mut paths = HashSet::new();
+            paths.insert(PathBuf::from("images/*"));
+
             let restore_opts = RestoreOpts {
-                path: PathBuf::from("images/*"),
+                paths,
                 staged: false,
                 source_ref: None,
                 is_remote: false,
@@ -593,9 +600,12 @@ mod tests {
             let status = repositories::status(&repo)?;
             assert_eq!(status.staged_files.len(), 7); // 3 cats, 4 dogs
 
+            let mut paths = HashSet::new();
+            paths.insert(PathBuf::from("train/dog_*.jpg"));
+
             // Restore just the dogs from the stage
             let restore_opts = RestoreOpts {
-                path: PathBuf::from("train/dog_*.jpg"),
+                paths,
                 staged: true,
                 source_ref: None,
                 is_remote: false,
@@ -652,8 +662,11 @@ mod tests {
             assert_eq!(status.staged_schemas.len(), 2);
 
             // Restore *.csv
+            let mut paths = HashSet::new();
+            paths.insert(PathBuf::from("new_annotations").join(PathBuf::from("*.csv")));
+
             let restore_opts = RestoreOpts {
-                path: PathBuf::from("new_annotations").join(PathBuf::from("*.csv")),
+                paths,
                 staged: true,
                 source_ref: None,
                 is_remote: false,

--- a/oxen-rust/src/lib/src/storage/local.rs
+++ b/oxen-rust/src/lib/src/storage/local.rs
@@ -362,7 +362,7 @@ impl VersionStore for LocalVersionStore {
                 fs::remove_dir_all(&chunks_dir).await?;
             }
         }
-        
+
         Ok(version_path)
     }
 

--- a/oxen-rust/src/lib/src/storage/local.rs
+++ b/oxen-rust/src/lib/src/storage/local.rs
@@ -345,6 +345,7 @@ impl VersionStore for LocalVersionStore {
 
         // Get list of chunks and sort them to ensure correct order
         let mut chunks = self.list_version_chunks(hash).await?;
+        log::debug!("combine_version_chunks found {:?} chunks", chunks.len());
         chunks.sort();
 
         // Process each chunk
@@ -352,12 +353,6 @@ impl VersionStore for LocalVersionStore {
             let chunk_path = self.version_chunk_file(hash, chunk_offset);
             let mut chunk_file = File::open(&chunk_path).await?;
             tokio::io::copy(&mut chunk_file, &mut output_file).await?;
-
-            // Cleanup chunk if requested
-            if cleanup {
-                let chunk_dir = self.version_chunk_dir(hash, chunk_offset);
-                fs::remove_dir_all(&chunk_dir).await?;
-            }
         }
 
         // Cleanup the chunks directory if requested
@@ -367,7 +362,7 @@ impl VersionStore for LocalVersionStore {
                 fs::remove_dir_all(&chunks_dir).await?;
             }
         }
-
+        
         Ok(version_path)
     }
 


### PR DESCRIPTION
This is the same as the API/76 PR, but also includes a small refactor of the restore module.

This refactor solves a glob pathing issue I ran into with restore (restoring a file in a directory from within that directory, i.e., the CWD is 'dir', and you're restoring the subfile 'file' with 'oxen restore file'

It also simplifies the restore logic and possibly improves performance for restoring many files as well, although I didn't really benchmark it. I don't think it's possible that this worsens performance

To test this, I'd recommend doing restores with glob paths on different directory structures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restore operations now support multiple paths and wildcard patterns for batch restoration.

* **Improvements**
  * Enhanced path handling with automatic canonicalization and fallback logic.
  * Improved error handling for per-path restoration failures that continue processing remaining paths.
  * Added enhanced logging for storage chunk operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->