### PR TITLE
Add option for oxen restore to combine version chunks

### DIFF
--- a/oxen-rust/src/lib/src/core/v_latest/restore.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/restore.rs
@@ -1,8 +1,8 @@
 use crate::core::v_latest::index;
 use crate::error::OxenError;
-use crate::model::LocalRepository;
+use crate::model::{LocalRepository, MerkleHash};
 use crate::opts::{GlobOpts, RestoreOpts};
-use crate::util;
+use crate::{repositories, util};
 
 pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), OxenError> {
     let path = &opts.path;
@@ -22,6 +22,47 @@ pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), Ox
         opts.path = path;
         index::restore::restore(repo, opts).await?;
     }
+
+    Ok(())
+}
+
+/// Combine the version chunks for large files and restore the completed file to the working dir
+/// This can be used to recover files if this step fails during a fetch
+pub async fn combine_chunks(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), OxenError> {
+    let path = util::fs::path_relative_to_dir(&opts.path, &repo.path)?;
+    let commit = repositories::commits::get_commit_or_head(repo, opts.source_ref.clone())?;
+
+    // Find the file in the merkle tree
+    let Some(file_node) = repositories::tree::get_file_by_path(repo, &commit, &path)? else {
+        log::debug!(
+            "path {:?}not found in tree for commit {:?}",
+            path,
+            commit.id
+        );
+        return Ok(());
+    };
+
+    // Recombine the version chunks for this file
+    let hash = file_node.hash();
+    combine_chunks_for_hash(repo, hash).await?;
+
+    // Restore the completed file to the working directory
+    index::restore::restore(repo, opts).await?;
+
+    Ok(())
+}
+
+// Recombine file chunks for hash and delete the chunks dir
+async fn combine_chunks_for_hash(
+    repo: &LocalRepository,
+    hash: &MerkleHash,
+) -> Result<(), OxenError> {
+    let version_store = repo.version_store()?;
+    let hash_str = format!("{hash:?}");
+
+    version_store
+        .combine_version_chunks(&hash_str, true)
+        .await?;
 
     Ok(())
 }


### PR DESCRIPTION
This is low-priority, but I thought it was cool.

Adds an option to oxen restore to combine version chunks and restore the completed file. This would be useful to fix a repository where large files have their chunks fail to combine, like the issue Nex ran into pulling large files to a VFS.

Of course, that scenario should never actually happen, so it's a bit tricky to test. I'd say just replicate Nex's issue (pull a large file onto a repo on NFS with the uncorrected clone code) and then use oxen restore --combine-chunks to fix the repo 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--combine-chunks` flag to the restore command to combine file chunks into a complete file before restoration.

* **Tests**
  * Added tests for large-file chunk combination and restoration workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->