### PR TITLE
Api 49/delete file api

### DIFF
--- a/oxen-python/python/oxen/remote_repo.py
+++ b/oxen-python/python/oxen/remote_repo.py
@@ -383,6 +383,8 @@ class RemoteRepo:
             branch = self.revision
         if commit_message is None:
             message = f"Removed '{file_path}'"
+        else:
+            message = commit_message
         user = oxen_user.current_user()
 
         self._repo.delete_file(branch, file_path, message, user)
@@ -407,7 +409,9 @@ class RemoteRepo:
         if branch is None:
             branch = self.revision
         if commit_message is None:
-            message = f"Removed {path}"
+            message = f"Removed {dir_path}"
+        else:
+            message = commit_message
         user = oxen_user.current_user()
 
         self._repo.delete_dir(branch, dir_path, message, user)
@@ -427,7 +431,7 @@ class RemoteRepo:
             src: `str`
                 The path to the local file to upload
             message: `str`
-                The message to commit with
+                The message to commit with. Defaults to "Uploaded '{src}'"
             file_name: `str | None`
                 The name of the file to upload. If None, will use the name of the file in `src`
             dst_dir: `str | None`
@@ -440,7 +444,7 @@ class RemoteRepo:
         if file_name is None:
             file_name = os.path.basename(src)
         if commit_message is None:
-            commit_message = f"Removed {os.path(src)}"
+            commit_message = f"Uploaded {src}"
         user = oxen_user.current_user()
 
         self._repo.put_file(branch, dst_dir, src, file_name, commit_message, user)

--- a/oxen-python/python/oxen/remote_repo.py
+++ b/oxen-python/python/oxen/remote_repo.py
@@ -367,8 +367,6 @@ class RemoteRepo:
         self,
         src: str,
         commit_message: str,
-        file_name: Optional[str] = None,
-        dst_dir: Optional[str] = "",
         branch: Optional[str] = None,
     ):
         """
@@ -377,8 +375,6 @@ class RemoteRepo:
         Args:
             src: `str`
                 The path to the local file to remove
-            dst_dir: `str | None`
-                The directory to remove the file from. Defaults to the root dir
             branch: `str | None`
                 The branch to remove the file from. Defaults to `self.revision`
         """
@@ -386,9 +382,9 @@ class RemoteRepo:
             branch = self.revision
         user = oxen_user.current_user()
 
-        self._repo.delete_file(branch, dst_dir, src, commit_message, user)
+        self._repo.delete_file(branch, src, commit_message, user)
 
-        def upload(
+    def upload(
         self,
         src: str,
         commit_message: str,

--- a/oxen-python/python/oxen/remote_repo.py
+++ b/oxen-python/python/oxen/remote_repo.py
@@ -374,7 +374,9 @@ class RemoteRepo:
 
         Args:
             src: `str`
-                The path to the local file to remove
+                The path to the remote file to remove
+            message: `str`
+                The message to commit with
             branch: `str | None`
                 The branch to remove the file from. Defaults to `self.revision`
         """
@@ -398,6 +400,8 @@ class RemoteRepo:
         Args:
             src: `str`
                 The path to the local file to upload
+            message: `str`
+                The message to commit with
             file_name: `str | None`
                 The name of the file to upload. If None, will use the name of the file in `src`
             dst_dir: `str | None`

--- a/oxen-python/python/oxen/remote_repo.py
+++ b/oxen-python/python/oxen/remote_repo.py
@@ -363,58 +363,31 @@ class RemoteRepo:
             self._workspace = None
         return commit
 
-    def delete_entry(
+    def delete_file(
         self,
-        file_path: str,
+        path: str,
         commit_message: Optional[str] = None,
         branch: Optional[str] = None,
     ):
         """
-        Delete a file from the remote repo
+        Delete from the remote repo. This can be used with a committed file or dir
         Args:
             path: `str`
                 The path to the remote file to remove
-            message: `str`
-                The message to commit with. Defaults to "Removed '{file_path}'"
+            commit_message: `str` | None
+                The message to commit with. Defaults to "Removed '{path}'"
             branch: `str | None`
                 The branch to remove the file from. Defaults to `self.revision`
         """
         if branch is None:
             branch = self.revision
         if commit_message is None:
-            message = f"Removed '{file_path}'"
+            message = f"Removed '{path}'"
         else:
             message = commit_message
         user = oxen_user.current_user()
 
-        self._repo.delete_file(branch, file_path, message, user)
-
-    def delete_dir(
-        self,
-        dir_path: str,
-        commit_message: Optional[str] = None,
-        branch: Optional[str] = None,
-    ):
-        """
-        Delete an entry from the remote repo. This can be a file or a dir
-
-        Args:
-            path: `str`
-                The path to the remote entry to remove
-            message: `str`
-                The message to commit with. Defaults to 'Removed {dir_path}'
-            branch: `str | None`
-                The branch to remove the entry from. Defaults to `self.revision`
-        """
-        if branch is None:
-            branch = self.revision
-        if commit_message is None:
-            message = f"Removed {dir_path}"
-        else:
-            message = commit_message
-        user = oxen_user.current_user()
-
-        self._repo.delete_dir(branch, dir_path, message, user)
+        self._repo.delete_file(branch, path, message, user)
 
     def upload(
         self,
@@ -430,7 +403,7 @@ class RemoteRepo:
         Args:
             src: `str`
                 The path to the local file to upload
-            message: `str`
+            commit_message: `str`
                 The message to commit with. Defaults to "Uploaded '{src}'"
             file_name: `str | None`
                 The name of the file to upload. If None, will use the name of the file in `src`

--- a/oxen-python/python/oxen/remote_repo.py
+++ b/oxen-python/python/oxen/remote_repo.py
@@ -363,28 +363,54 @@ class RemoteRepo:
             self._workspace = None
         return commit
 
-    def delete_file(
+    def delete_entry(
         self,
-        src: str,
-        commit_message: str,
+        file_path: str,
+        commit_message: Optional[str] = None,
         branch: Optional[str] = None,
     ):
         """
-        Delete a file from the remote repo.
-
+        Delete a file from the remote repo
         Args:
-            src: `str`
+            path: `str`
                 The path to the remote file to remove
             message: `str`
-                The message to commit with
+                The message to commit with. Defaults to "Removed '{file_path}'"
             branch: `str | None`
                 The branch to remove the file from. Defaults to `self.revision`
         """
         if branch is None:
             branch = self.revision
+        if commit_message is None:
+            message = f"Removed '{file_path}'"
         user = oxen_user.current_user()
 
-        self._repo.delete_file(branch, src, commit_message, user)
+        self._repo.delete_file(branch, file_path, message, user)
+
+    def delete_dir(
+        self,
+        dir_path: str,
+        commit_message: Optional[str] = None,
+        branch: Optional[str] = None,
+    ):
+        """
+        Delete an entry from the remote repo. This can be a file or a dir
+
+        Args:
+            path: `str`
+                The path to the remote entry to remove
+            message: `str`
+                The message to commit with. Defaults to 'Removed {dir_path}'
+            branch: `str | None`
+                The branch to remove the entry from. Defaults to `self.revision`
+        """
+        if branch is None:
+            branch = self.revision
+        if commit_message is None:
+            message = f"Removed {path}"
+        user = oxen_user.current_user()
+
+        self._repo.delete_dir(branch, dir_path, message, user)
 
     def upload(
         self,
@@ -413,6 +439,8 @@ class RemoteRepo:
             branch = self.revision
         if file_name is None:
             file_name = os.path.basename(src)
+        if commit_message is None:
+            commit_message = f"Removed {os.path(src)}"
         user = oxen_user.current_user()
 
         self._repo.put_file(branch, dst_dir, src, file_name, commit_message, user)

--- a/oxen-python/python/oxen/remote_repo.py
+++ b/oxen-python/python/oxen/remote_repo.py
@@ -363,7 +363,32 @@ class RemoteRepo:
             self._workspace = None
         return commit
 
-    def upload(
+    def delete_file(
+        self,
+        src: str,
+        commit_message: str,
+        file_name: Optional[str] = None,
+        dst_dir: Optional[str] = "",
+        branch: Optional[str] = None,
+    ):
+        """
+        Delete a file from the remote repo.
+
+        Args:
+            src: `str`
+                The path to the local file to remove
+            dst_dir: `str | None`
+                The directory to remove the file from. Defaults to the root dir
+            branch: `str | None`
+                The branch to remove the file from. Defaults to `self.revision`
+        """
+        if branch is None:
+            branch = self.revision
+        user = oxen_user.current_user()
+
+        self._repo.delete_file(branch, dst_dir, src, commit_message, user)
+
+        def upload(
         self,
         src: str,
         commit_message: str,

--- a/oxen-python/src/py_remote_repo.rs
+++ b/oxen-python/src/py_remote_repo.rs
@@ -240,6 +240,33 @@ impl PyRemoteRepo {
         Ok(())
     }
 
+    fn delete_file(
+        &self,
+        branch: &str,
+        directory: &str,
+        local_path: PathBuf,
+        commit_message: &str,
+        user: PyUser,
+    ) -> Result<(), PyOxenError> {
+        let commit_body = NewCommitBody {
+            message: commit_message.to_string(),
+            author: user.name().to_string(),
+            email: user.email().to_string(),
+        };
+        pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+            api::client::file::delete_file(
+                &self.repo,
+                &branch,
+                &directory,
+                &local_path,
+                Some(commit_body),
+            )
+            .await
+        })?;
+
+        Ok(())
+    }
+
     #[pyo3(signature = (revision="main", path=None, page_num=1, page_size=10))]
     fn log(
         &self,

--- a/oxen-python/src/py_remote_repo.rs
+++ b/oxen-python/src/py_remote_repo.rs
@@ -243,18 +243,38 @@ impl PyRemoteRepo {
     fn delete_file(
         &self,
         branch: &str,
-        local_path: PathBuf,
-        commit_message: &str,
+        file_path: PathBuf,
+        commit_message: Option<&str>,
         user: PyUser,
     ) -> Result<(), PyOxenError> {
-        let commit_body = NewCommitBody {
+        let commit_body = commit_message.map(|commit_message| NewCommitBody {
             message: commit_message.to_string(),
             author: user.name().to_string(),
             email: user.email().to_string(),
-        };
+        });
+
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::file::delete_file(&self.repo, &branch, &local_path, Some(commit_body))
-                .await
+            api::client::file::delete_file(&self.repo, &branch, &file_path, commit_body).await
+        })?;
+
+        Ok(())
+    }
+
+    fn delete_dir(
+        &self,
+        branch: &str,
+        dir_path: PathBuf,
+        commit_message: Option<&str>,
+        user: PyUser,
+    ) -> Result<(), PyOxenError> {
+        let commit_body = commit_message.map(|commit_message| NewCommitBody {
+            message: commit_message.to_string(),
+            author: user.name().to_string(),
+            email: user.email().to_string(),
+        });
+
+        pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+            api::client::dir::delete_dir(&self.repo, &branch, &dir_path, commit_body).await
         })?;
 
         Ok(())

--- a/oxen-python/src/py_remote_repo.rs
+++ b/oxen-python/src/py_remote_repo.rs
@@ -243,7 +243,6 @@ impl PyRemoteRepo {
     fn delete_file(
         &self,
         branch: &str,
-        dir: &str,
         local_path: PathBuf,
         commit_message: &str,
         user: PyUser,
@@ -254,14 +253,8 @@ impl PyRemoteRepo {
             email: user.email().to_string(),
         };
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::file::delete_file(
-                &self.repo,
-                &branch,
-                &dir,
-                &local_path,
-                Some(commit_body),
-            )
-            .await
+            api::client::file::delete_file(&self.repo, &branch, &local_path, Some(commit_body))
+                .await
         })?;
 
         Ok(())

--- a/oxen-python/src/py_remote_repo.rs
+++ b/oxen-python/src/py_remote_repo.rs
@@ -260,26 +260,6 @@ impl PyRemoteRepo {
         Ok(())
     }
 
-    fn delete_dir(
-        &self,
-        branch: &str,
-        dir_path: PathBuf,
-        commit_message: Option<&str>,
-        user: PyUser,
-    ) -> Result<(), PyOxenError> {
-        let commit_body = commit_message.map(|commit_message| NewCommitBody {
-            message: commit_message.to_string(),
-            author: user.name().to_string(),
-            email: user.email().to_string(),
-        });
-
-        pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::dir::delete_dir(&self.repo, &branch, &dir_path, commit_body).await
-        })?;
-
-        Ok(())
-    }
-
     #[pyo3(signature = (revision="main", path=None, page_num=1, page_size=10))]
     fn log(
         &self,

--- a/oxen-python/src/py_remote_repo.rs
+++ b/oxen-python/src/py_remote_repo.rs
@@ -243,7 +243,7 @@ impl PyRemoteRepo {
     fn delete_file(
         &self,
         branch: &str,
-        directory: &str,
+        dir: &str,
         local_path: PathBuf,
         commit_message: &str,
         user: PyUser,
@@ -257,7 +257,7 @@ impl PyRemoteRepo {
             api::client::file::delete_file(
                 &self.repo,
                 &branch,
-                &directory,
+                &dir,
                 &local_path,
                 Some(commit_body),
             )

--- a/oxen-rust/src/lib/src/api/client/dir.rs
+++ b/oxen-rust/src/lib/src/api/client/dir.rs
@@ -6,13 +6,9 @@ use crate::constants;
 use crate::error::OxenError;
 use crate::model::metadata::generic_metadata::GenericMetadata;
 use crate::model::metadata::MetadataDir;
-use crate::model::NewCommitBody;
 use crate::model::RemoteRepository;
 use crate::view::entries::EMetadataEntry;
-use crate::view::CommitResponse;
 use crate::view::{PaginatedDirEntries, PaginatedDirEntriesResponse};
-use reqwest::multipart::Form;
-use reqwest::multipart::Part;
 
 pub async fn list_root(remote_repo: &RemoteRepository) -> Result<PaginatedDirEntries, OxenError> {
     list(
@@ -95,47 +91,6 @@ pub async fn get_dir(
             "api::dir::get_dir error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
-}
-
-pub async fn delete_dir(
-    remote_repo: &RemoteRepository,
-    branch: impl AsRef<str>,
-    dir_path: impl AsRef<Path>,
-    commit_body: Option<NewCommitBody>,
-) -> Result<CommitResponse, OxenError> {
-    let branch = branch.as_ref();
-    let dir_path = dir_path.as_ref();
-    let Some(dir_name) = dir_path.file_name() else {
-        return Err(OxenError::basic_str("Cannot delete dir without dir name"));
-    };
-
-    let dir_name = dir_name.to_str().unwrap().to_string();
-    let parents = dir_path.parent().unwrap_or(Path::new(""));
-
-    let directory = parents.to_str().unwrap().to_string();
-
-    let uri = format!("/file/{branch}/{directory}");
-    log::debug!("delete_dir {uri:?}, dir_path {dir_path:?}");
-    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
-
-    let client = client::new_for_url(&url)?;
-    let dir_part = Part::text(dir_name.clone());
-    let dir_part = dir_part.file_name(dir_name.clone());
-
-    let mut form = Form::new().part("file_name", dir_part);
-
-    if let Some(body) = commit_body {
-        form = form.text("name", body.author);
-        form = form.text("email", body.email);
-        form = form.text("message", body.message);
-    }
-
-    let req = client.delete(&url).multipart(form);
-
-    let res = req.send().await?;
-    let body = client::parse_json_body(&url, res).await?;
-    let response: CommitResponse = serde_json::from_str(&body)?;
-    Ok(response)
 }
 
 #[cfg(test)]

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -137,29 +137,15 @@ pub async fn delete_file(
 ) -> Result<CommitResponse, OxenError> {
     let branch = branch.as_ref();
     let file_path = file_path.as_ref();
-    let Some(file_name) = file_path.file_name() else {
-        return Err(OxenError::basic_str("Cannot delete file without file name"));
-    };
 
-    let file_name = file_name
-        .to_str()
-        .ok_or_else(|| OxenError::basic_str("Invalid UTF-8 in filename"))?
-        .to_string();
-    let directory = file_path
-        .parent()
-        .ok_or_else(|| OxenError::basic_str("Invalid UTF-8 in filename"))?
-        .to_string_lossy()
-        .to_string();
+    let file_path = file_path.to_string_lossy().to_string();
 
-    let uri = format!("/file/{branch}/{directory}");
+    let uri = format!("/file/{branch}/{file_path}");
     log::debug!("delete_file {uri:?}, file_path {file_path:?}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
     let client = client::new_for_url(&url)?;
-    let file_part = Part::text(file_name.clone());
-    let file_part = file_part.file_name(file_name.clone());
-
-    let mut form = Form::new().part("file_name", file_part);
+    let mut form = Form::new();
 
     if let Some(body) = commit_body {
         form = form.text("name", body.author);

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -346,7 +346,7 @@ mod tests {
             repositories::pull(&local_repo).await?;
 
             // Assert the commit was made and the file is removed
-            assert!(!file_path.exists());
+            assert!(!local_repo.path.join(&file_path).exists());
             let commit = commit_response.commit;
 
             let deleted_file_node =

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -152,7 +152,7 @@ pub async fn delete_file(
         .to_string();
 
     let uri = format!("/file/{branch}/{directory}");
-    println!("delete_file {uri:?}, file_path {file_path:?}");
+    log::debug!("delete_file {uri:?}, file_path {file_path:?}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
     let client = client::new_for_url(&url)?;

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -139,12 +139,17 @@ pub async fn delete_file(
     let branch = branch.as_ref();
     let directory = directory.as_ref();
     let file_path = file_path.as_ref();
+    let Some(file_name) = file_path.file_name() else {
+        return Err(OxenError::basic_str("Cannot delete file without file name"));
+    };
+
     let uri = format!("/file/{branch}/{directory}");
     log::debug!("delete_file {uri:?}, file_path {file_path:?}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
     let client = client::new_for_url(&url)?;
     let file_part = Part::file(file_path).await?;
+    let file_part = file_part.file_name(file_name.to_str().unwrap().to_string());
 
     let mut form = Form::new().part("file", file_part);
 

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -147,7 +147,7 @@ pub async fn delete_file(
     let directory = parents.to_str().unwrap().to_string();
 
     let uri = format!("/file/{branch}/{directory}");
-    log::debug!("delete_file {uri:?}, file_path {file_path:?}");
+    println!("delete_file {uri:?}, file_path {file_path:?}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
     let client = client::new_for_url(&url)?;

--- a/oxen-rust/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -790,6 +790,10 @@ impl CommitMerkleTree {
 
         let vnodes = dir_merkle_node.children;
 
+        if vnodes.is_empty() {
+            log::debug!("dir_merkle_node for path {parent_path:?} has no children, returning None");
+            return Ok(None);
+        }
         // log::debug!("read_file vnodes: {}", vnodes.len());
 
         // Calculate the total number of children in the vnodes

--- a/oxen-rust/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -789,11 +789,6 @@ impl CommitMerkleTree {
         // log::debug!("read_file merkle_node: {:?}", dir_merkle_node);
 
         let vnodes = dir_merkle_node.children;
-
-        if vnodes.is_empty() {
-            log::debug!("dir_merkle_node for path {parent_path:?} has no children, returning None");
-            return Ok(None);
-        }
         // log::debug!("read_file vnodes: {}", vnodes.len());
 
         // Calculate the total number of children in the vnodes

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -398,7 +398,13 @@ pub async fn delete(
     // Get files to remove from payload
     let (name, email, message, file_names, _temp_files) =
         parse_multipart_fields_for_repo(payload).await?;
+
     let paths: Vec<PathBuf> = file_names.iter().map(|f| resource.path.join(f)).collect();
+    if paths.is_empty() {
+        return Err(OxenHttpError::BadRequest(
+            "No files specified for deletion".into(),
+        ));
+    }
 
     let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
 

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -412,7 +412,7 @@ pub async fn delete(
         author: name.clone().unwrap_or("".to_string()),
         email: email.clone().unwrap_or("".to_string()),
         message: message.clone().unwrap_or(format!(
-            "Auto-commit files to {}",
+            "Delete files from {}",
             &resource.path.to_string_lossy()
         )),
     };

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -433,7 +433,6 @@ pub async fn delete(
     }))
 }
 
-<<<<<<< HEAD
 /// Upload zip archive
 #[utoipa::path(
     post,
@@ -454,8 +453,6 @@ pub async fn delete(
         (status = 400, description = "Bad Request")
     )
 )]
-=======
->>>>>>> e9d2181bc (Update delete file endpoint for python method)
 pub async fn upload_zip(
     req: HttpRequest,
     payload: Multipart,

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -397,7 +397,7 @@ pub async fn delete(
     let (name, email, message, temp_files) = parse_multipart_fields_for_repo(payload).await?;
 
     let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
-    let paths: Vec<PathBuf> = temp_files.iter().map(|f| f.path.clone()).collect();
+    let paths: Vec<PathBuf> = temp_files.iter().map(|f| resource.path.join(f.path.clone())).collect();
 
     // Stage the files as removed
     for path in paths {

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -376,7 +376,7 @@ pub async fn delete(
     req: HttpRequest,
     payload: Multipart,
 ) -> actix_web::Result<HttpResponse, OxenHttpError> {
-    log::debug!("file::put path {:?}", req.path());
+    log::debug!("file::delete path {:?}", req.path());
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
@@ -397,7 +397,7 @@ pub async fn delete(
     let (name, email, message, temp_files) = parse_multipart_fields_for_repo(payload).await?;
 
     let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
-    let paths: Vec<PathBuf> = temp_files.iter().map(|f| resource.path.join(f.path.clone())).collect();
+    let paths: Vec<PathBuf> = temp_files.iter().map(|f| f.path.clone()).collect();
 
     // Stage the files as removed
     for path in paths {
@@ -424,6 +424,7 @@ pub async fn delete(
     }))
 }
 
+<<<<<<< HEAD
 /// Upload zip archive
 #[utoipa::path(
     post,
@@ -444,6 +445,8 @@ pub async fn delete(
         (status = 400, description = "Bad Request")
     )
 )]
+=======
+>>>>>>> e9d2181bc (Update delete file endpoint for python method)
 pub async fn upload_zip(
     req: HttpRequest,
     payload: Multipart,

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -352,6 +352,78 @@ pub async fn put(
     }))
 }
 
+/// Delete file
+#[utoipa::path(
+    delete,
+    path = "/api/repos/{namespace}/{repo_name}/file/{resource}",
+    tag = "Files",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("resource" = String, Path, description = "Path to the file to be deleted (including branch)", example = "main/train/images/n01440764_10026.JPEG"),
+    ),
+    request_body(
+        content_type = "multipart/form-data",
+        content = FileUploadBody,
+    ),
+    responses(
+        (status = 200, description = "File removed successfully", body = CommitResponse),
+        (status = 404, description = "Branch or path not found")
+    )
+)]
+pub async fn delete(
+    req: HttpRequest,
+    payload: Multipart,
+) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    log::debug!("file::put path {:?}", req.path());
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let repo_name = path_param(&req, "repo_name")?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+
+    // Parse the resource (branch/commit/path)
+    let resource = parse_resource(&req, &repo)?;
+
+    // Resource must specify branch because we need to commit the workspace back to a branch
+    let branch = resource
+        .branch
+        .clone()
+        .ok_or(OxenError::local_branch_not_found(
+            resource.version.to_string_lossy(),
+        ))?;
+    let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
+
+    let (name, email, message, temp_files) = parse_multipart_fields_for_repo(payload).await?;
+
+    let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
+    let paths: Vec<PathBuf> = temp_files.iter().map(|f| f.path.clone()).collect();
+
+    // Stage the files as removed
+    for path in paths {
+        repositories::workspaces::files::rm(&workspace, &path).await?;
+    }
+
+    // Commit workspace
+    let commit_body = NewCommitBody {
+        author: name.clone().unwrap_or("".to_string()),
+        email: email.clone().unwrap_or("".to_string()),
+        message: message.clone().unwrap_or(format!(
+            "Auto-commit files to {}",
+            &resource.path.to_string_lossy()
+        )),
+    };
+
+    let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
+
+    log::debug!("file::delete workspace commit ✅ success! commit {commit:?}");
+
+    Ok(HttpResponse::Ok().json(CommitResponse {
+        status: StatusMessage::resource_deleted(),
+        commit,
+    }))
+}
+
 /// Upload zip archive
 #[utoipa::path(
     post,

--- a/oxen-rust/src/server/src/services/file.rs
+++ b/oxen-rust/src/server/src/services/file.rs
@@ -9,6 +9,10 @@ pub fn file() -> Scope {
         .route("/{resource:.*}", web::head().to(controllers::file::get))
         .route("/{resource:.*}", web::put().to(controllers::file::put))
         .route(
+            "/{resource:.*}",
+            web::delete().to(controllers::file::delete),
+        )
+        .route(
             "/upload_zip/{resource:.*}",
             web::post().to(controllers::file::upload_zip),
         )


### PR DESCRIPTION
Adds delete file endpoint analogous to put_file in the controller module. It stages a file for removal and commits it in one step. 

To test this, I recommend setting up a remote repo with files in it, pointing a python remote repo to it, and then using the new delete_file() method with that repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote file deletion with optional commit messages and branch selection
  * Uploads accept explicit commit messages with sensible defaults

* **API**
  * File service now exposes DELETE for resources

* **Tests**
  * Added tests covering remote file deletion workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->