### PR TITLE
Update dir node metadata for removed files

### DIFF
--- a/oxen-rust/src/lib/src/core/v_latest/rm.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/rm.rs
@@ -248,7 +248,6 @@ fn remove_file_inner(
         data_type_counts: HashMap::new(),
     };
 
-    // TODO: This is ugly, but the only current solution to get the stats from the removed file
     match process_remove_file_and_parents(repo, &path, staged_db, file_node) {
         Ok(Some(node)) => {
             if let EMerkleTreeNode::File(file_node) = &node.node.node {
@@ -665,7 +664,6 @@ fn process_remove_dir(
 }
 
 // Recursively remove all files and directories starting from a particular directory
-// WARNING: This function relies on the initial dir having the correct relative path to the repo
 
 // TODO: Refactor to singular match statement/loop
 // TODO: Currently, this function is only called sequentially. Consider using Arc/AtomicU64 to parallelize


### PR DESCRIPTION
Solves a bug where removing all the files in a dir and then attempting to re-add them would cause a panic in CommitMerkleTree. This panic happened because there would be a mis-match between 'dir_merkle_node.children.len()', the children loaded in from the node db for a dir (which would be 0, as all the dir's files were removed), and 'dir_node.num_entries()', the metadata for the node (which, despite the dir now having 0 entries, wouldn't get updated and would be non-zero), resulting in the file lookup logic attempting to lookup a non-existant bucket in dir_merkle_node.children. It was ultimately caused by a flaw in the commit logic, whereby we wouldn't actually decrement the number of children in a dir node's metadata when files were removed from it. This PR corrects that bug and adds a unit test that triggers the previous panic.

To repro on main:

1. `oxen add` a file in a dir in an empty repo (dir/file) and commit
2. `oxen rm` the file (dir/file) and commit
3.  `oxen add` with the file will now cause a panic. There may also be other ways to get this panic.

To verify that we get the correct behavior now, you can use `oxen node` with the hash of the dir node before and after doing `oxen rm` on its subfiles. You should see `num_entries` on the dir node's metadata get decremented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced commit tracking to properly record and maintain file removal history, improving repository state accuracy.

* **Tests**
  * Added comprehensive tests for file removal and re-addition workflows to ensure operations complete without issues.

* **Chore**
  * Internal code cleanup and documentation adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->