### PR TITLE
Fix panic in oxen diff outside repo

### DIFF
--- a/oxen-rust/src/lib/src/repositories/diffs.rs
+++ b/oxen-rust/src/lib/src/repositories/diffs.rs
@@ -83,10 +83,18 @@ pub async fn diff(opts: DiffOpts) -> Result<Vec<DiffResult>, OxenError> {
 
     let repo = match repo {
         Err(e) => {
-            log::error!("Failed to get repo: {e}");
+            log::error!("Failed to get repo: {e}. Comparing files...");
+
+            let path_1 = opts.path_1;
+            let Some(path_2) = opts.path_2 else {
+                return Err(OxenError::basic_str(
+                    "Error: `oxen diff` requires a repo or file paths",
+                ));
+            };
+
             let result = diff_files(
-                opts.path_1,
-                opts.path_2.unwrap(),
+                path_1,
+                path_2,
                 opts.keys.clone(),
                 opts.targets.clone(),
                 vec![],


### PR DESCRIPTION
Changes a panic to an error.

No important or functional difference in the code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling with enhanced messages when repository initialization fails
  * Added validation to ensure both file paths are provided for file comparison mode

* **New Features**
  * Diff command now supports direct file-to-file comparison as a fallback when repository context is unavailable

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->