### PR TITLE
Allow list_branches without HEAD

### DIFF
--- a/oxen-rust/src/lib/src/core/refs/ref_manager.rs
+++ b/oxen-rust/src/lib/src/core/refs/ref_manager.rs
@@ -160,20 +160,17 @@ impl RefManager {
 
     pub fn list_branches(&self) -> Result<Vec<Branch>, OxenError> {
         let mut branch_names: Vec<Branch> = vec![];
-        let maybe_head_ref = self.read_head_ref()?;
         let iter = self.refs_db.iterator(IteratorMode::Start);
         for item in iter {
             match item {
                 Ok((key, value)) => match (str::from_utf8(&key), str::from_utf8(&value)) {
                     (Ok(key_str), Ok(value)) => {
-                        if maybe_head_ref.is_some() {
-                            let ref_name = String::from(key_str);
-                            let id = String::from(value);
-                            branch_names.push(Branch {
-                                name: ref_name,
-                                commit_id: id,
-                            });
-                        }
+                        let ref_name = String::from(key_str);
+                        let id = String::from(value);
+                        branch_names.push(Branch {
+                            name: ref_name,
+                            commit_id: id,
+                        });
                     }
                     _ => {
                         return Err(OxenError::basic_str("Could not read utf8 val..."));


### PR DESCRIPTION
Allows `oxen branch` to display branches in a repo without a HEAD commit. This is useful if you run `oxen fetch` after pointing a new repo to a remote with `oxen config --set-remote`. Although this does download a branches local, `oxen branch` won't show you it until a head commit has been set, which is confusing.

To test:
1. `oxen init` a new repo
2. `oxen config --set-remote` to point it to a non-empty repo
3. `oxen fetch` to fetch the tree
4. `oxen branch` will show the available branches, whereas it previously wouldn't

I'm not sure why we were previously guarding the `list branches` function behind there being a head commit 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed branch listing functionality to consistently display all available branches, eliminating cases where branches were previously omitted based on reference states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->