### PR TITLE
Qol/print statements

### DIFF
--- a/oxen-rust/src/lib/src/constants.rs
+++ b/oxen-rust/src/lib/src/constants.rs
@@ -223,3 +223,6 @@ pub const DEFAULT_NOTEBOOK_BASE_IMAGE: &str = "debian:bookworm-slim";
 
 // Oxen stack size
 pub const OXEN_STACK_SIZE: usize = 16_777_216;
+
+// Prefix for error messages
+pub const OXEN_ERROR: &str = "Error: ";

--- a/oxen-rust/src/lib/src/core/v_latest/add.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/add.rs
@@ -226,10 +226,10 @@ pub async fn add_files(
     // TODO: Make rm_with_staged_db return the stats of the files it removes
     if !paths_to_remove.is_empty() {
         match core::v_latest::rm::rm_with_staged_db(&paths_to_remove, repo, &rm_opts, &staged_db) {
-            Ok(_) => {},
+            Ok(_) => {}
             Err(e) => {
                 return Err(OxenError::basic_str(format!(
-                    "`oxen add` could not remove files: \n{}", e
+                    "`oxen add` could not remove files: \n{e}"
                 )));
             }
         }

--- a/oxen-rust/src/lib/src/core/v_latest/add.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/add.rs
@@ -225,19 +225,28 @@ pub async fn add_files(
     // Stage the non-existant paths as removed
     // TODO: Make rm_with_staged_db return the stats of the files it removes
     if !paths_to_remove.is_empty() {
-        core::v_latest::rm::rm_with_staged_db(&paths_to_remove, repo, &rm_opts, &staged_db)?;
+        match core::v_latest::rm::rm_with_staged_db(&paths_to_remove, repo, &rm_opts, &staged_db) {
+            Ok(_) => {},
+            Err(e) => {
+                return Err(OxenError::basic_str(format!(
+                    "`oxen add` could not remove files: \n{}", e
+                )));
+            }
+        }
     }
 
     // Stop the timer, and round the duration to the nearest second
     let duration = Duration::from_millis(start.elapsed().as_millis() as u64);
     log::debug!("---END--- oxen add: {paths:?} duration: {duration:?}");
 
-    println!(
-        "🐂 oxen added {} files ({}) in {}",
-        total.total_files,
-        bytesize::ByteSize::b(total.total_bytes),
-        humantime::format_duration(duration)
-    );
+    if total.total_files > 0 {
+        println!(
+            "🐂 oxen added {} files ({}) in {}",
+            total.total_files,
+            bytesize::ByteSize::b(total.total_bytes),
+            humantime::format_duration(duration)
+        );
+    }
 
     Ok(total)
 }

--- a/oxen-rust/src/lib/src/core/v_latest/rm.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/rm.rs
@@ -466,7 +466,7 @@ fn remove_inner(
 
     // Head commit should always exist here, because we're removing committed files
     let Some(head_commit) = repositories::commits::head_commit_maybe(repo)? else {
-        let error = "Error: head commit not found".to_string();
+        let error = "head commit not found".to_string();
         return Err(OxenError::basic_str(error));
     };
 
@@ -486,7 +486,7 @@ fn remove_inner(
         {
             dir_node
         } else {
-            let error = format!("Error: parent dir not found in tree for {path:?}");
+            let error = format!("parent dir not found in tree for {path:?}");
             return Err(OxenError::basic_str(error));
         };
 
@@ -523,11 +523,11 @@ fn remove_inner(
                     util::fs::remove_file(&full_path)?;
                 }
             } else {
-                let error = "Error: Unexpected file type".to_string();
+                let error = "Unexpected file type".to_string();
                 return Err(OxenError::basic_str(error));
             }
         } else {
-            let error = format!("Error: {path:?} must be committed in order to use `oxen rm`");
+            let error = format!("{path:?} must be committed in order to use `oxen rm`");
             return Err(OxenError::basic_str(error));
         }
     }
@@ -584,7 +584,7 @@ fn remove_dir_inner(
     let dir_node = match CommitMerkleTree::dir_with_children_recursive(repo, commit, path, None)? {
         Some(node) => node,
         None => {
-            let error = format!("Error: {path:?} must be committed in order to use `oxen rm`");
+            let error = format!("{path:?} must be committed in order to use `oxen rm`");
             return Err(OxenError::basic_str(error));
         }
     };
@@ -635,7 +635,7 @@ fn process_remove_dir(
         parent_path = parent.to_path_buf();
 
         let Some(relative_path_str) = relative_path.to_str() else {
-            let error = format!("Error: {relative_path:?} is not a valid string");
+            let error = format!("{relative_path:?} is not a valid string");
             return Err(OxenError::basic_str(error));
         };
 
@@ -722,7 +722,7 @@ fn r_process_remove_dir(
                 }
             }
             _ => {
-                let error = "Error: Unexpected node type".to_string();
+                let error = "Unexpected node type".to_string();
                 return Err(OxenError::basic_str(error));
             }
         }

--- a/oxen-rust/src/lib/src/error.rs
+++ b/oxen-rust/src/lib/src/error.rs
@@ -13,11 +13,11 @@ use std::path::PathBuf;
 use std::path::StripPrefixError;
 use tokio::task::JoinError;
 
+use crate::constants::OXEN_ERROR;
 use crate::model::Schema;
 use crate::model::Workspace;
 use crate::model::{Commit, ParsedResource};
 use crate::model::{Remote, RepoNew};
-use crate::constants::OXEN_ERROR;
 
 pub mod path_buf_error;
 pub mod string_error;

--- a/oxen-rust/src/lib/src/error.rs
+++ b/oxen-rust/src/lib/src/error.rs
@@ -17,6 +17,7 @@ use crate::model::Schema;
 use crate::model::Workspace;
 use crate::model::{Commit, ParsedResource};
 use crate::model::{Remote, RepoNew};
+use crate::constants::OXEN_ERROR;
 
 pub mod path_buf_error;
 pub mod string_error;
@@ -159,7 +160,8 @@ impl fmt::Display for OxenError {
 
 impl OxenError {
     pub fn basic_str(s: impl AsRef<str>) -> Self {
-        OxenError::Basic(StringError::from(s.as_ref()))
+        let s = format!("{}{}", OXEN_ERROR, s.as_ref());
+        OxenError::Basic(StringError::from(s))
     }
 
     pub fn thumbnailing_not_enabled(s: impl AsRef<str>) -> Self {


### PR DESCRIPTION
Just an idea for updating our error messages for clarity 

We should probably also start getting away from always using 'OxenError::basic_str' everywhere, but this is a start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling during file addition to properly report failures when removing non-existent paths.
  * Suppressed unnecessary success messages when no files are added.

* **Chores**
  * Standardized error message formatting across the application for improved consistency and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->