### PR TITLE
Enable array of struct arrow parsing for chat history

### DIFF
--- a/oxen-rust/src/lib/src/core/df/tabular.rs
+++ b/oxen-rust/src/lib/src/core/df/tabular.rs
@@ -840,13 +840,13 @@ fn struct_array_to_json(
             Value::Array(rows)
         }
         Err(e) => {
-            log::warn!("Failed to convert StructArray to DataFrame: {:?}", e);
+            log::warn!("Failed to convert StructArray to DataFrame: {e:?}");
             let mut map = serde_json::Map::new();
             for (i, field) in fields.iter().enumerate() {
                 if let Some(values) = struct_array.values().get(i) {
                     let len = values.len();
                     if len > 0 {
-                        let val_str = format!("{:?}", values);
+                        let val_str = format!("{values:?}");
                         // Look for actual URL or string content
                         if let Some(start) = val_str.find("https://") {
                             // Extract URL starting from https://

--- a/oxen-rust/src/lib/src/core/df/tabular.rs
+++ b/oxen-rust/src/lib/src/core/df/tabular.rs
@@ -813,8 +813,7 @@ fn any_val_to_json(value: AnyValue) -> Value {
             Value::Object(map)
         }
         AnyValue::Struct(_len, struct_array, fields) => {
-            let json_value = struct_array_to_json(struct_array, fields);
-            json_value
+            struct_array_to_json(struct_array, fields);
         }
 
         other => panic!("Unsupported dtype in JSON conversion: {other:?}"),

--- a/oxen-rust/src/lib/src/core/df/tabular.rs
+++ b/oxen-rust/src/lib/src/core/df/tabular.rs
@@ -813,7 +813,7 @@ fn any_val_to_json(value: AnyValue) -> Value {
             Value::Object(map)
         }
         AnyValue::Struct(_len, struct_array, fields) => {
-            struct_array_to_json(struct_array, fields);
+            struct_array_to_json(struct_array, fields)
         }
 
         other => panic!("Unsupported dtype in JSON conversion: {other:?}"),

--- a/oxen-rust/src/lib/src/core/df/tabular.rs
+++ b/oxen-rust/src/lib/src/core/df/tabular.rs
@@ -812,9 +812,7 @@ fn any_val_to_json(value: AnyValue) -> Value {
 
             Value::Object(map)
         }
-        AnyValue::Struct(_len, struct_array, fields) => {
-            struct_array_to_json(struct_array, fields)
-        }
+        AnyValue::Struct(_len, struct_array, fields) => struct_array_to_json(struct_array, fields),
 
         other => panic!("Unsupported dtype in JSON conversion: {other:?}"),
     }

--- a/oxen-rust/src/lib/src/core/v_latest/data_frames.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/data_frames.rs
@@ -61,7 +61,7 @@ pub async fn get_slice(
                 .commit
                 .as_ref()
                 .ok_or(OxenError::basic_str("Commit not found"))?;
-            let file_node = repositories::tree::get_file_by_path(base_repo, &commit, &path)?
+            let file_node = repositories::tree::get_file_by_path(base_repo, commit, &path)?
                 .ok_or(OxenError::path_does_not_exist(path.as_ref()))?;
             Ok(file_node)
         }

--- a/oxen-rust/src/lib/src/core/v_latest/data_frames.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/data_frames.rs
@@ -1,10 +1,13 @@
 use crate::core::db::data_frames::df_db::with_df_db_manager;
 use crate::core::df::tabular::transform_new;
 use crate::core::df::{sql, tabular};
+use crate::core::staged::with_staged_db_manager;
 use crate::error::OxenError;
 use crate::model::data_frame::{DataFrameSchemaSize, DataFrameSlice, DataFrameSliceSchemas};
+use crate::model::merkle_tree::node::EMerkleTreeNode;
 use crate::model::metadata::generic_metadata::GenericMetadata;
 use crate::model::metadata::metadata_tabular::MetadataTabularImpl;
+use crate::model::ParsedResource;
 use crate::model::{Commit, DataFrameSize, LocalRepository, Schema, Workspace};
 use crate::opts::DFOpts;
 use crate::{repositories, util};
@@ -16,13 +19,53 @@ pub mod schemas;
 
 pub async fn get_slice(
     repo: &LocalRepository,
-    commit: &Commit,
+    resource: &ParsedResource,
     path: impl AsRef<Path>,
     opts: &DFOpts,
 ) -> Result<DataFrameSlice, OxenError> {
-    // Get the file node
-    let file_node = repositories::tree::get_file_by_path(repo, commit, &path)?
-        .ok_or(OxenError::path_does_not_exist(path.as_ref()))?;
+    let workspace = resource.workspace.as_ref();
+    let commit = match workspace {
+        Some(ws) => ws.commit.clone(),
+        None => resource
+            .commit
+            .clone()
+            .ok_or(OxenError::basic_str("Commit not found"))?,
+    };
+
+    let (staged_repo, base_repo) = match workspace {
+        Some(ws) => (&ws.workspace_repo, repo),
+        None => (repo, repo),
+    };
+
+    let file_node = match workspace {
+        Some(ws) => with_staged_db_manager(staged_repo, |staged_db_manager| {
+            // Try staged DB first
+            if let Some(staged_node) = staged_db_manager.read_from_staged_db(&path)? {
+                let file_node = match staged_node.node.node {
+                    EMerkleTreeNode::File(f) => Ok(f),
+                    _ => Err(OxenError::basic_str(
+                        "Only single file download is supported",
+                    )),
+                }?;
+                return Ok(file_node);
+            }
+
+            // Fall back to commit tree using workspace's commit
+            let commit = &ws.commit;
+            let file_node = repositories::tree::get_file_by_path(base_repo, commit, &path)?
+                .ok_or(OxenError::path_does_not_exist(path.as_ref()))?;
+            Ok(file_node)
+        }),
+        None => {
+            let commit = resource
+                .commit
+                .as_ref()
+                .ok_or(OxenError::basic_str("Commit not found"))?;
+            let file_node = repositories::tree::get_file_by_path(base_repo, &commit, &path)?
+                .ok_or(OxenError::path_does_not_exist(path.as_ref()))?;
+            Ok(file_node)
+        }
+    }?;
 
     log::debug!("get_slice file_node {file_node:?}");
 
@@ -46,7 +89,7 @@ pub async fn get_slice(
         height: metadata.height,
     };
 
-    let handle_sql_result = handle_sql_querying(repo, commit, path, opts, &data_frame_size).await;
+    let handle_sql_result = handle_sql_querying(repo, &commit, path, opts, &data_frame_size).await;
     if let Ok(response) = handle_sql_result {
         return Ok(response);
     }

--- a/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -38,7 +38,7 @@ pub fn add(
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     let row_changes_path = repositories::workspaces::data_frames::row_changes_path(workspace, path);
 
-    let df = tabular::parse_json_to_df(&data)?;
+    let df = tabular::parse_json_to_df(data)?;
     log::debug!("add() df: {df:?}");
 
     let mut result = with_df_db_manager(db_path, |manager| {
@@ -160,7 +160,7 @@ pub fn update(
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     let row_changes_path = repositories::workspaces::data_frames::row_changes_path(workspace, path);
 
-    let mut df = tabular::parse_json_to_df(&data)?;
+    let mut df = tabular::parse_json_to_df(data)?;
     log::debug!("update() df: {df:?}");
     let mut row = repositories::workspaces::data_frames::rows::get_by_id(workspace, path, row_id)?;
     if row.height() == 0 {

--- a/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -4,7 +4,6 @@ use polars::prelude::NamedFrom;
 use polars::prelude::PlSmallStr;
 use polars::series::Series;
 use rocksdb::DB;
-use serde_json::json;
 use serde_json::Value;
 
 use crate::constants::DIFF_STATUS_COL;

--- a/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -39,10 +39,9 @@ pub fn add(
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     let row_changes_path = repositories::workspaces::data_frames::row_changes_path(workspace, path);
 
-    log::debug!("add_row() path: {row_changes_path:?} got db_path: {db_path:?}");
-
     let mut normalized_data = data.clone();
     maybe_normalize_message_content(&mut normalized_data);
+    log::debug!("add() normalized_data: {normalized_data:?}");
     let df = tabular::parse_json_to_df(&normalized_data)?;
     log::debug!("add() df: {df:?}");
 
@@ -165,8 +164,11 @@ pub fn update(
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     let row_changes_path = repositories::workspaces::data_frames::row_changes_path(workspace, path);
 
-    let mut df = tabular::parse_json_to_df(data)?;
-
+    let mut normalized_data = data.clone();
+    maybe_normalize_message_content(&mut normalized_data);
+    log::debug!("update() normalized_data: {normalized_data:?}");
+    let mut df = tabular::parse_json_to_df(&normalized_data)?;
+    log::debug!("update() df: {df:?}");
     let mut row = repositories::workspaces::data_frames::rows::get_by_id(workspace, path, row_id)?;
     if row.height() == 0 {
         return Err(OxenError::resource_not_found("row not found"));

--- a/oxen-rust/src/lib/src/repositories/data_frames.rs
+++ b/oxen-rust/src/lib/src/repositories/data_frames.rs
@@ -2,7 +2,7 @@ use crate::core;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::data_frame::DataFrameSlice;
-use crate::model::{Commit, LocalRepository};
+use crate::model::{LocalRepository, ParsedResource};
 use crate::opts::DFOpts;
 
 use std::path::Path;
@@ -11,12 +11,12 @@ pub mod schemas;
 
 pub async fn get_slice(
     repo: &LocalRepository,
-    commit: &Commit,
+    resource: &ParsedResource,
     path: impl AsRef<Path>,
     opts: &DFOpts,
 ) -> Result<DataFrameSlice, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::data_frames::get_slice(repo, commit, path, opts).await,
+        _ => core::v_latest::data_frames::get_slice(repo, resource, path, opts).await,
     }
 }

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -117,35 +117,37 @@ pub async fn get(
     let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let version_store = repo.version_store()?;
     let resource = parse_resource(&req, &repo)?;
-    let workspace_ref = resource.workspace.as_ref();
-
-    let repo = if let Some(workspace) = workspace_ref {
-        &workspace.workspace_repo
-    } else {
-        &repo
-    };
-
+    let workspace = resource.workspace.as_ref();
     let path = resource.path.clone();
 
-    // if resource is workspace, get file node from the staged db
-    let entry = match workspace_ref {
-        Some(_workspace_ref) => with_staged_db_manager(repo, |staged_db_manager| {
-            let staged_node = staged_db_manager
-                .read_from_staged_db(&path)?
-                .ok_or_else(|| OxenError::basic_str("File not found in staged DB"))?;
+    // Use workspace_repo for staged DB operations, base_repo for commit tree lookups
+    let (staged_repo, base_repo) = match workspace {
+        Some(ws) => (&ws.workspace_repo, &repo),
+        None => (&repo, &repo),
+    };
 
-            let file_node = match staged_node.node.node {
-                EMerkleTreeNode::File(f) => Ok(f),
-                _ => Err(OxenError::basic_str(
-                    "Only single file download is supported",
-                )),
-            }?;
+    let entry = match workspace {
+        Some(ws) => with_staged_db_manager(staged_repo, |staged_db_manager| {
+            // Try staged DB first
+            if let Some(staged_node) = staged_db_manager.read_from_staged_db(&path)? {
+                let file_node = match staged_node.node.node {
+                    EMerkleTreeNode::File(f) => Ok(f),
+                    _ => Err(OxenError::basic_str(
+                        "Only single file download is supported",
+                    )),
+                }?;
+                return Ok(file_node);
+            }
+
+            // Fall back to commit tree using workspace's commit
+            let commit = &ws.commit;
+            let file_node = repositories::tree::get_file_by_path(base_repo, commit, &path)?
+                .ok_or(OxenError::path_does_not_exist(path.clone()))?;
             Ok(file_node)
         }),
         None => {
-            // Otherwise get file node from commit tree
             let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
-            let file_node = repositories::tree::get_file_by_path(repo, &commit, &path)?
+            let file_node = repositories::tree::get_file_by_path(base_repo, &commit, &path)?
                 .ok_or(OxenError::path_does_not_exist(path.clone()))?;
             Ok(file_node)
         }

--- a/oxen-rust/src/server/src/controllers/workspaces/data_frames/rows.rs
+++ b/oxen-rust/src/server/src/controllers/workspaces/data_frames/rows.rs
@@ -159,7 +159,7 @@ pub async fn update(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, Oxen
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
     };
-    log::debug!("update row repo {namespace}/{repo_name} -> {workspace_id}/{file_path:?}");
+    log::debug!("update row repo {namespace}/{repo_name} -> {workspace_id}/{file_path:?} with json data {data:?}");
 
     let modified_row = repositories::workspaces::data_frames::rows::update(
         &repo, &workspace, &file_path, &row_id, data,


### PR DESCRIPTION
In order to modify a row that contains an array of structs, we need to manually handle the polars -> duckdb case.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * STRUCT/list fields from JSON-like uploads are now stored as JSON to avoid binding issues.
  * Preserve complex nested types during row updates so lists/structs remain intact.
  * Improved JSON serialization for struct/list values to ensure nested records convert correctly.

* **Refactor**
  * Prefer staged data when resolving workspace files, with commit-tree fallback.

* **New Features**
  * Non-indexed dataframe requests now return dataframe views and include an is_indexed flag.

* **Chores**
  * Added minor runtime diagnostics and extra update logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->