### PR TITLE
ENG-540 // Add oxen push --fix command to fix repo with corrupted version files

### DIFF
--- a/oxen-python/src/py_repo.rs
+++ b/oxen-python/src/py_repo.rs
@@ -207,6 +207,7 @@ impl PyRepo {
                         delete,
                         missing_files_commit_id: None,
                         missing_files: false,
+                        fix: false,
                     };
                     // Push to the remote branch
                     repositories::push::push_remote_branch(&repo, &opts).await

--- a/oxen-python/src/py_repo.rs
+++ b/oxen-python/src/py_repo.rs
@@ -205,9 +205,7 @@ impl PyRepo {
                         remote: remote.to_string(),
                         branch: branch.to_string(),
                         delete,
-                        missing_files_commit_id: None,
-                        missing_files: false,
-                        fix: false,
+                        ..Default::default()
                     };
                     // Push to the remote branch
                     repositories::push::push_remote_branch(&repo, &opts).await

--- a/oxen-rust/src/cli/src/cmd/push.rs
+++ b/oxen-rust/src/cli/src/cmd/push.rs
@@ -48,6 +48,12 @@ impl RunCmd for PushCmd {
                     .value_name("COMMIT_ID")
                     .default_missing_value("true")
             )
+            .arg(
+                Arg::new("fix")
+                    .long("fix")
+                    .help("Fix corrupted files on the remote.")
+                    .action(clap::ArgAction::SetTrue)
+            )
     }
 
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
@@ -66,6 +72,7 @@ impl RunCmd for PushCmd {
             } else {
                 (false, None)
             };
+        let fix = args.get_flag("fix");
 
         let repo = LocalRepository::from_current_dir()?;
         let current_branch = repositories::branches::current_branch(&repo)?;
@@ -85,6 +92,7 @@ impl RunCmd for PushCmd {
             delete,
             missing_files,
             missing_files_commit_id,
+            fix,
         };
 
         // Call into liboxen to push or delete

--- a/oxen-rust/src/cli/src/cmd/push.rs
+++ b/oxen-rust/src/cli/src/cmd/push.rs
@@ -49,9 +49,9 @@ impl RunCmd for PushCmd {
                     .default_missing_value("true")
             )
             .arg(
-                Arg::new("fix")
-                    .long("fix")
-                    .help("Fix corrupted files on the remote.")
+                Arg::new("revalidate")
+                    .long("revalidate")
+                    .help("Revalidate file hashes on remote and push any missing files.")
                     .action(clap::ArgAction::SetTrue)
             )
     }
@@ -72,7 +72,7 @@ impl RunCmd for PushCmd {
             } else {
                 (false, None)
             };
-        let fix = args.get_flag("fix");
+        let revalidate = args.get_flag("revalidate");
 
         let repo = LocalRepository::from_current_dir()?;
         let current_branch = repositories::branches::current_branch(&repo)?;
@@ -92,7 +92,7 @@ impl RunCmd for PushCmd {
             delete,
             missing_files,
             missing_files_commit_id,
-            fix,
+            revalidate,
         };
 
         // Call into liboxen to push or delete

--- a/oxen-rust/src/lib/src/api/client/versions.rs
+++ b/oxen-rust/src/lib/src/api/client/versions.rs
@@ -90,7 +90,7 @@ pub async fn clean(
     log::debug!("api::client::versions::clean {url}");
 
     let client = client::new_for_url(&url)?;
-    let res = client.put(&url).send().await?;
+    let res = client.delete(&url).send().await?;
     let body = client::parse_json_body(&url, res).await?;
     let response: Result<CleanCorruptedVersionsResponse, serde_json::Error> =
         serde_json::from_str(&body);

--- a/oxen-rust/src/lib/src/api/client/versions.rs
+++ b/oxen-rust/src/lib/src/api/client/versions.rs
@@ -6,8 +6,9 @@ use crate::model::entry::commit_entry::Entry;
 use crate::model::{LocalRepository, MerkleHash, RemoteRepository};
 use crate::util::{self, concurrency, hasher};
 use crate::view::versions::{
-    CompleteVersionUploadRequest, CompletedFileUpload, CreateVersionUploadRequest,
-    MultipartLargeFileUpload, MultipartLargeFileUploadStatus, VersionFile, VersionFileResponse,
+    CleanCorruptedVersionsResponse, CompleteVersionUploadRequest, CompletedFileUpload,
+    CreateVersionUploadRequest, MultipartLargeFileUpload, MultipartLargeFileUploadStatus,
+    VersionFile, VersionFileResponse,
 };
 use crate::view::{ErrorFileInfo, ErrorFilesResponse, FileWithHash};
 
@@ -77,6 +78,26 @@ pub async fn get(
         Ok(version_file) => Ok(Some(version_file.version)),
         Err(err) => Err(OxenError::basic_str(format!(
             "api::client::versions::get() Could not deserialize response [{err}]\n{body}"
+        ))),
+    }
+}
+
+pub async fn clean(
+    remote_repo: &RemoteRepository,
+) -> Result<CleanCorruptedVersionsResponse, OxenError> {
+    let uri = "/versions";
+    let url = api::endpoint::url_from_repo(remote_repo, uri)?;
+    log::debug!("api::client::versions::clean {url}");
+
+    let client = client::new_for_url(&url)?;
+    let res = client.put(&url).send().await?;
+    let body = client::parse_json_body(&url, res).await?;
+    let response: Result<CleanCorruptedVersionsResponse, serde_json::Error> =
+        serde_json::from_str(&body);
+    match response {
+        Ok(response) => Ok(response),
+        Err(err) => Err(OxenError::basic_str(format!(
+            "api::client::versions::clean() Could not deserialize response [{err}]\n{body}"
         ))),
     }
 }

--- a/oxen-rust/src/lib/src/opts/push_opts.rs
+++ b/oxen-rust/src/lib/src/opts/push_opts.rs
@@ -5,5 +5,5 @@ pub struct PushOpts {
     pub delete: bool,
     pub missing_files: bool,
     pub missing_files_commit_id: Option<String>,
-    pub fix: bool,
+    pub revalidate: bool,
 }

--- a/oxen-rust/src/lib/src/opts/push_opts.rs
+++ b/oxen-rust/src/lib/src/opts/push_opts.rs
@@ -5,4 +5,5 @@ pub struct PushOpts {
     pub delete: bool,
     pub missing_files: bool,
     pub missing_files_commit_id: Option<String>,
+    pub fix: bool,
 }

--- a/oxen-rust/src/lib/src/storage/local.rs
+++ b/oxen-rust/src/lib/src/storage/local.rs
@@ -7,12 +7,18 @@ use std::path::{Path, PathBuf};
 use crate::constants::{VERSION_CHUNKS_DIR, VERSION_CHUNK_FILE_NAME, VERSION_FILE_NAME};
 use crate::error::OxenError;
 use crate::storage::version_store::{ReadSeek, VersionStore};
+use crate::util::{concurrency, hasher};
+use crate::view::versions::CleanCorruptedVersionsResult;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use tokio::fs::{self, File};
 use tokio::io::AsyncReadExt;
 use tokio::io::{BufReader, BufWriter};
+use tokio::sync::Semaphore;
 use tokio_stream::Stream;
 use tokio_util::io::ReaderStream;
 
@@ -364,6 +370,199 @@ impl VersionStore for LocalVersionStore {
         }
 
         Ok(version_path)
+    }
+
+    // It's left here for a quick fix. TODO: Move the business logic to versions controller.
+    async fn clean_corrupted_versions(&self) -> Result<CleanCorruptedVersionsResult, OxenError> {
+        // Keep record of the stats
+        #[derive(Default)]
+        struct Stats {
+            scanned_objects: AtomicUsize,
+            corrupted_objects: AtomicUsize,
+            io_errors: AtomicUsize,
+            deleted_objects: AtomicUsize,
+        }
+
+        impl Stats {
+            fn incr_scanned(&self) {
+                self.scanned_objects.fetch_add(1, Ordering::Relaxed);
+            }
+            fn incr_corrupted(&self) {
+                self.corrupted_objects.fetch_add(1, Ordering::Relaxed);
+            }
+            fn incr_io_error(&self) {
+                self.io_errors.fetch_add(1, Ordering::Relaxed);
+            }
+            fn incr_deleted(&self) {
+                self.deleted_objects.fetch_add(1, Ordering::Relaxed);
+            }
+
+            fn snapshot(&self) -> (usize, usize, usize, usize) {
+                (
+                    self.scanned_objects.load(Ordering::Relaxed),
+                    self.corrupted_objects.load(Ordering::Relaxed),
+                    self.io_errors.load(Ordering::Relaxed),
+                    self.deleted_objects.load(Ordering::Relaxed),
+                )
+            }
+        }
+
+        let start = std::time::Instant::now();
+        let stats = Arc::new(Stats::default());
+
+        // Limit concurrency
+        let concurrency = concurrency::default_num_threads();
+        let semaphore = Arc::new(Semaphore::new(concurrency));
+
+        // Read prefix dirs
+        let mut prefix_rd = fs::read_dir(&self.root_path).await?;
+        let mut prefix_paths: Vec<PathBuf> = Vec::new();
+        while let Some(entry) = prefix_rd.next_entry().await? {
+            match entry.file_type().await {
+                Ok(ft) if ft.is_dir() => {
+                    prefix_paths.push(entry.path());
+                }
+                _ => {
+                    stats.incr_io_error();
+                }
+            }
+        }
+
+        // Spawn one task per prefix (concurrent)
+        let mut handles = Vec::with_capacity(prefix_paths.len());
+
+        for prefix_path in prefix_paths {
+            let semaphore_cl = semaphore.clone();
+            let stats_cl = stats.clone();
+            let handle = tokio::spawn(async move {
+                let mut suffix_rd = match fs::read_dir(&prefix_path).await {
+                    Ok(rd) => rd,
+                    Err(_) => {
+                        stats_cl.incr_io_error();
+                        return;
+                    }
+                };
+
+                // Process suffix directories sequentially
+                while let Ok(Some(entry)) = suffix_rd.next_entry().await {
+                    // Only process directories
+                    let file_type = match entry.file_type().await {
+                        Ok(ft) => ft,
+                        Err(_) => {
+                            stats_cl.incr_io_error();
+                            continue;
+                        }
+                    };
+                    if !file_type.is_dir() {
+                        continue;
+                    }
+
+                    let suffix_path = entry.path();
+
+                    // hash = prefix+suffix
+                    let prefix_name = match prefix_path.file_name().and_then(|s| s.to_str()) {
+                        Some(p) => p.to_string(),
+                        None => {
+                            stats_cl.incr_io_error();
+                            continue;
+                        }
+                    };
+                    let suffix_name = match suffix_path.file_name().and_then(|s| s.to_str()) {
+                        Some(s) => s.to_string(),
+                        None => {
+                            stats_cl.incr_io_error();
+                            continue;
+                        }
+                    };
+                    let expected_hash = format!("{prefix_name}{suffix_name}");
+
+                    // Acquire concurrency permit for heavy operations (I/O, hashing)
+                    let permit = semaphore_cl.clone().acquire_owned().await.unwrap();
+
+                    {
+                        // First read the data async
+                        let data_path = suffix_path.join("data");
+                        let data = match fs::read(&data_path).await {
+                            Ok(b) => b,
+                            Err(_) => {
+                                // cannot read data - treat as corrupted: delete dir
+                                stats_cl.incr_io_error();
+
+                                if fs::remove_dir_all(&suffix_path).await.is_ok() {
+                                    stats_cl.incr_deleted();
+                                }
+                                drop(permit);
+                                continue;
+                            }
+                        };
+
+                        // increment scanned count
+                        stats_cl.incr_scanned();
+
+                        // Compute hash in blocking thread
+                        let actual_hash =
+                            match tokio::task::spawn_blocking(move || hasher::hash_buffer(&data))
+                                .await
+                            {
+                                Ok(h) => h,
+                                Err(_) => {
+                                    log::debug!(
+                                        "Failed to compute hash for version file {expected_hash}"
+                                    );
+                                    stats_cl.incr_io_error();
+
+                                    if fs::remove_dir_all(&suffix_path).await.is_ok() {
+                                        stats_cl.incr_deleted();
+                                    }
+                                    drop(permit);
+                                    continue;
+                                }
+                            };
+
+                        if actual_hash != expected_hash {
+                            log::debug!("version file {actual_hash} is corrupted!");
+                            // mismatch - delete the corrupted version dir
+                            stats_cl.incr_corrupted();
+                            match fs::remove_dir_all(&suffix_path).await {
+                                Ok(_) => {
+                                    stats_cl.incr_deleted();
+                                    log::debug!("Corrupted version file {actual_hash} deleted");
+                                }
+                                Err(_) => {
+                                    stats_cl.incr_io_error();
+                                    log::debug!(
+                                        "Failed to delete corrupted version file {actual_hash}"
+                                    );
+                                }
+                            }
+                        }
+
+                        // release permit
+                        drop(permit);
+                    }
+                }
+            });
+
+            handles.push(handle);
+        }
+
+        // Await all prefix tasks
+        for h in handles {
+            let _ = h.await;
+        }
+
+        // Gather stats and return result
+        let (scanned, corrupted, io_errors, deleted) = stats.snapshot();
+        let elapsed = std::time::Duration::from_millis(start.elapsed().as_millis() as u64);
+        let result = CleanCorruptedVersionsResult {
+            scanned: scanned as u64,
+            corrupted: corrupted as u64,
+            cleaned: deleted as u64,
+            errors: io_errors as u64,
+            elapsed,
+        };
+
+        Ok(result)
     }
 
     fn storage_type(&self) -> &str {

--- a/oxen-rust/src/lib/src/storage/s3.rs
+++ b/oxen-rust/src/lib/src/storage/s3.rs
@@ -8,6 +8,7 @@ use tokio_stream::Stream;
 
 use super::version_store::VersionStore;
 use crate::storage::version_store::ReadSeek;
+use crate::view::versions::CleanCorruptedVersionsResult;
 
 /// S3 implementation of version storage
 #[derive(Debug)]
@@ -169,6 +170,11 @@ impl VersionStore for S3VersionStore {
         _hash: &str,
         _cleanup: bool,
     ) -> Result<PathBuf, OxenError> {
+        // TODO: Implement S3 version chunk combination
+        Err(OxenError::basic_str("S3VersionStore not yet implemented"))
+    }
+
+    async fn clean_corrupted_versions(&self) -> Result<CleanCorruptedVersionsResult, OxenError> {
         // TODO: Implement S3 version chunk combination
         Err(OxenError::basic_str("S3VersionStore not yet implemented"))
     }

--- a/oxen-rust/src/lib/src/storage/version_store.rs
+++ b/oxen-rust/src/lib/src/storage/version_store.rs
@@ -16,6 +16,7 @@ use crate::error::OxenError;
 use crate::opts::StorageOpts;
 use crate::storage::{LocalVersionStore, S3VersionStore};
 use crate::util;
+use crate::view::versions::CleanCorruptedVersionsResult;
 
 /// Configuration for version storage backend
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -203,6 +204,9 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
 
     /// List all versions
     async fn list_versions(&self) -> Result<Vec<String>, OxenError>;
+
+    /// Clean corrupted version files
+    async fn clean_corrupted_versions(&self) -> Result<CleanCorruptedVersionsResult, OxenError>;
 
     /// Get the storage type identifier (e.g., "local", "s3")
     fn storage_type(&self) -> &str;

--- a/oxen-rust/src/lib/src/view/versions.rs
+++ b/oxen-rust/src/lib/src/view/versions.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use crate::model::MerkleHash;
 
@@ -60,4 +60,25 @@ pub struct CreateVersionUploadRequest {
     pub file_name: String,
     pub size: u64,
     pub dst_dir: Option<PathBuf>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct CleanCorruptedVersionsResponse {
+    #[serde(flatten)]
+    pub status: StatusMessage,
+    pub result: CleanCorruptedVersionsResult,
+}
+
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
+pub struct CleanCorruptedVersionsResult {
+    // Number of version files scanned
+    pub scanned: u64,
+    // Number of version files that were corrupted(hash mismatch)
+    pub corrupted: u64,
+    // Number of version files that were successfully deleted
+    pub cleaned: u64,
+    // Errors that occurred during the cleanup process
+    pub errors: u64,
+    // Elapsed time in seconds
+    pub elapsed: Duration,
 }

--- a/oxen-rust/src/server/src/controllers/versions.rs
+++ b/oxen-rust/src/server/src/controllers/versions.rs
@@ -14,7 +14,7 @@ use liboxen::model::metadata::metadata_image::ImgResize;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
 use liboxen::util;
-use liboxen::view::versions::{VersionFile, VersionFileResponse};
+use liboxen::view::versions::{CleanCorruptedVersionsResponse, VersionFile, VersionFileResponse};
 use liboxen::view::{ErrorFileInfo, ErrorFilesResponse, StatusMessage};
 use mime;
 use parking_lot::Mutex;
@@ -53,6 +53,21 @@ pub async fn metadata(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
             hash: version_id,
             size: metadata.len() as u64,
         },
+    }))
+}
+
+// Clean corrupted version files for the remote repo
+pub async fn clean(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let repo_name = path_param(&req, "repo_name")?;
+    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let version_store = repo.version_store()?;
+    let result = version_store.clean_corrupted_versions().await?;
+
+    Ok(HttpResponse::Ok().json(CleanCorruptedVersionsResponse {
+        status: StatusMessage::resource_found(),
+        result,
     }))
 }
 

--- a/oxen-rust/src/server/src/services/versions.rs
+++ b/oxen-rust/src/server/src/services/versions.rs
@@ -18,7 +18,7 @@ pub fn versions() -> Scope {
             web::method(Method::from_bytes(b"QUERY").unwrap())
                 .to(controllers::versions::batch_download),
         )
-        .route("", web::put().to(controllers::versions::clean))
+        .route("", web::delete().to(controllers::versions::clean))
         .route(
             "/{version_id}/metadata",
             web::get().to(controllers::versions::metadata),

--- a/oxen-rust/src/server/src/services/versions.rs
+++ b/oxen-rust/src/server/src/services/versions.rs
@@ -18,6 +18,7 @@ pub fn versions() -> Scope {
             web::method(Method::from_bytes(b"QUERY").unwrap())
                 .to(controllers::versions::batch_download),
         )
+        .route("", web::put().to(controllers::versions::clean))
         .route(
             "/{version_id}/metadata",
             web::get().to(controllers::versions::metadata),


### PR DESCRIPTION
Added a --fix param in `oxen push` that cleans corrupted version files and push the missing files.
New endpoint `PUT /versions`:
It scans the repo versions dir and checks if the actual hash matches the expected hash. If not, delete its version file directory. Per prefix directory parallelism is implemented, the subfix within is processed in sequence. Concurrency is set to the number of CPU. 

To test:
1. push some files to the remote like normal. 
2. Access the versions directory in `/Oxen_code/Oxen/oxen-rust/data/{user_id}/{repo_id}/.oxen/versions/files` and edit some of the version files to "corrupt" them. 
3. Run `oxen push --fix` in cli to fix the repo.

I did some testing on a similar sized repo as Nex (16GB w/ ~90k small files), scanning took 15-25s.
CLI message looks like ↓
<img width="646" height="90" alt="image" src="https://github.com/user-attachments/assets/ca4df27f-c5a0-4734-a34e-c26ba74f9292" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --revalidate flag to push: revalidates remote file hashes, removes corrupted version data, and retries pushing missing files.
  * New server DELETE /versions endpoint to trigger remote cleaning of corrupted version data.
  * Storage backends expose a cleaning operation that returns stats (scanned, corrupted, cleaned, errors, elapsed).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->