### PR TITLE
Add AWS credentials to ci_test workflow for S3 version store

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -23,6 +23,10 @@ jobs:
       AWS_REGION: us-west-1
       AWS_ROLE: arn:aws:iam::213020545630:role/ci-test-integration-role
 
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - name: Free up disk space
         if: matrix.platform == 'linux'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -47,6 +47,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          role-duration-seconds: 900
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Copy rust-toolchain.toml to root
         if: matrix.platform != 'windows'
         run: |
@@ -226,11 +233,3 @@ jobs:
           .venv\Scripts\Activate.ps1
           maturin develop
           pytest -s tests --ignore=tests/test_data_frame.py --ignore=tests/test_embeddings.py --ignore=tests/test_fsspec_backend.py
-
-      # S3 version store tests
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ env.AWS_ROLE }}
-          role-duration-seconds: 900
-          aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -19,6 +19,10 @@ jobs:
             platform: windows
       fail-fast: false
 
+    env:
+      AWS_REGION: us-west-1
+      AWS_ROLE: arn:aws:iam::213020545630:role/ci-test-integration-role
+
     steps:
       - name: Free up disk space
         if: matrix.platform == 'linux'
@@ -222,3 +226,11 @@ jobs:
           .venv\Scripts\Activate.ps1
           maturin develop
           pytest -s tests --ignore=tests/test_data_frame.py --ignore=tests/test_embeddings.py --ignore=tests/test_fsspec_backend.py
+
+      # S3 version store tests
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          role-duration-seconds: 900
+          aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
This configures the AWS CLI to use the new ci_test_integration IAM role for accessing the test bucket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline updated to configure AWS credentials (using role and region from environment variables) during automated runs — credentials are now set up earlier in the workflow, improving reliability for tests and builds that require AWS access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->