### PR TITLE
Implement retry logic for version file upload

### DIFF
--- a/oxen-rust/src/lib/src/api/client.rs
+++ b/oxen-rust/src/lib/src/api/client.rs
@@ -60,7 +60,7 @@ pub fn new_for_url_no_user_agent<U: IntoUrl>(url: U) -> Result<Client, OxenError
 
 fn new_for_host<S: AsRef<str>>(host: S, should_add_user_agent: bool) -> Result<Client, OxenError> {
     match builder_for_host(host.as_ref(), should_add_user_agent)?
-        .timeout(time::Duration::from_secs(constants::DEFAULT_TIMEOUT_SECS))
+        .timeout(time::Duration::from_secs(constants::timeout()))
         .build()
     {
         Ok(client) => Ok(client),

--- a/oxen-rust/src/lib/src/api/client/versions.rs
+++ b/oxen-rust/src/lib/src/api/client/versions.rs
@@ -763,12 +763,13 @@ pub async fn workspace_multipart_batch_upload_parts_with_retry(
     while (!files_to_retry.is_empty()) && retry_count < max_retries {
         retry_count += 1;
 
-        let _paths = vec![];
+        let paths = files_to_retry.iter().map(|f| f.path.clone()).collect();
+
         upload_result = match workspace_multipart_batch_upload_versions(
             remote_repo,
             local_repo,
             client.clone(),
-            _paths,
+            paths,
             upload_result,
         )
         .await
@@ -786,8 +787,12 @@ pub async fn workspace_multipart_batch_upload_parts_with_retry(
             Err(e) => {
                 // TODO: Consider converting this to a debug log
                 log::error!("failed to upload version files after {retry_count} retries: {e:?}");
+
+                // Note: `files_to_add` and `err_files` aren't actually used by
+                // workspace_multipart_batch_upload to process retry files differently
+                // Hence, these fields can be empty
                 UploadResult {
-                    files_to_add: files_to_retry.clone(),
+                    files_to_add: vec![],
                     err_files: vec![],
                 }
             }

--- a/oxen-rust/src/lib/src/api/client/versions.rs
+++ b/oxen-rust/src/lib/src/api/client/versions.rs
@@ -1,6 +1,6 @@
 use crate::api;
 use crate::api::client;
-use crate::constants::{AVG_CHUNK_SIZE, MAX_RETRIES as DEFAULT_MAX_RETRIES, NUM_HTTP_RETRIES};
+use crate::constants::{max_retries, AVG_CHUNK_SIZE, MAX_RETRIES};
 use crate::error::OxenError;
 use crate::model::entry::commit_entry::Entry;
 use crate::model::{LocalRepository, MerkleHash, RemoteRepository};
@@ -177,7 +177,7 @@ pub async fn download_data_from_version_paths(
     hashes: &[String],
     local_repo: &LocalRepository,
 ) -> Result<u64, OxenError> {
-    let total_retries = NUM_HTTP_RETRIES;
+    let total_retries = max_retries().try_into().unwrap_or(MAX_RETRIES as u64);
     let mut num_retries = 0;
 
     while num_retries < total_retries {
@@ -721,77 +721,71 @@ pub async fn workspace_multipart_batch_upload_versions(
     Ok(result)
 }
 
-// /// Multipart batch upload pre-computed multiparts with retry
-// /// Posts a multipart to the server in parallel and retries on failure
-// /// Returns a list of files that failed to upload
-/* pub async fn workspace_multipart_batch_upload_parts_with_retry(
+pub async fn workspace_multipart_batch_upload_parts_with_retry(
     remote_repo: &RemoteRepository,
     client: Arc<reqwest::Client>,
     form: reqwest::multipart::Form,
-) -> Result<Vec<ErrorFileInfo>, OxenError> {
-
-    let mut retry_count: usize = 0;
-    let mut err_files: Vec<ErrorFileInfo> = vec![];
-    let max_retries = max_retries();
-
-    while retry_count < max_retries {
-        retry_count += 1;
-
-        // Upload multiparts, returning any that failed for retry
-        match workspace_multipart_batch_upload_parts(
-            remote_repo,
-            client.clone(),
-            form,
-        ).await {
-            Ok(err_files) => {
-                return Ok(err_files);
-            }
-            Err(e) => {
-                log::error!("Error uploading version files: {:?}", e);
-                if retry_count == max_retries {
-                    return Err(OxenError::basic_str(format!("failed to upload version files to workspace after retries: {:?}", e)));
-                }
-            }
-        }
-
-        let wait_time = exponential_backoff(BASE_WAIT_TIME, retry_count, MAX_WAIT_TIME);
-        sleep(Duration::from_millis(wait_time as u64)).await;
-    }
-
-    Err(OxenError::basic_str("failed to upload version files to workspace after retries"))
-} */
-
-pub async fn workspace_multipart_batch_upload_parts(
-    remote_repo: &RemoteRepository,
-    client: Arc<reqwest::Client>,
-    form: reqwest::multipart::Form,
+    files_to_retry: Vec<FileWithHash>,
+    local_repo: &Option<LocalRepository>,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     log::debug!("Beginning workspace multipart batch upload");
     let uri = ("/versions").to_string();
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
+    let mut retry_count: usize = 1;
+    let max_retries = max_retries();
+
+    // Upload the processed version files
     let response = client.post(&url).multipart(form).send().await?;
-    let body = client::parse_json_body(&url, response).await?;
-    let result: ErrorFilesResponse = serde_json::from_str(&body)?;
-
-    Ok(result.err_files)
-}
-
-// Parse the maximum number of retries allowed on upload from environment variable
-// TODO: Should we enforce a limit on this?
-fn max_retries() -> usize {
-    if let Ok(max_retries) = std::env::var("OXEN_MAX_RETRIES") {
-        // If the environment variable is set, use that
-        if let Ok(max_retries) = max_retries.parse::<usize>() {
-            max_retries
-        } else {
-            // If parsing failed, fall back to default
-            DEFAULT_MAX_RETRIES
+    let mut upload_result: UploadResult = match client::parse_json_body(&url, response).await {
+        Ok(body) => {
+            let result: ErrorFilesResponse = serde_json::from_str(&body)?;
+            UploadResult {
+                files_to_add: vec![],
+                err_files: result.err_files,
+            }
         }
-    } else {
-        // Environment variable not set, use default
-        DEFAULT_MAX_RETRIES
+        Err(e) => {
+            log::error!("failed to upload version files: {e:?}");
+            UploadResult {
+                files_to_add: files_to_retry.clone(),
+                err_files: vec![],
+            }
+        }
+    };
+
+    // If files fail, rebuild parts for the err_files and retry
+    while (!files_to_retry.is_empty()) && retry_count < max_retries {
+        retry_count += 1;
+
+        let _paths = vec![];
+        upload_result = match workspace_multipart_batch_upload_versions(
+            remote_repo,
+            local_repo,
+            client.clone(),
+            _paths,
+            upload_result,
+        )
+        .await
+        {
+            Ok(upload_result) => upload_result,
+            Err(e) => {
+                // TODO: Consider converting this to a debug log
+                log::error!("failed to upload version files after {retry_count} retries: {e:?}");
+                UploadResult {
+                    files_to_add: files_to_retry.clone(),
+                    err_files: vec![],
+                }
+            }
+        };
+
+        if !upload_result.err_files.is_empty() {
+            let wait_time = exponential_backoff(BASE_WAIT_TIME, retry_count, MAX_WAIT_TIME);
+            sleep(Duration::from_millis(wait_time as u64)).await;
+        }
     }
+
+    Ok(upload_result.err_files)
 }
 
 pub fn exponential_backoff(base_wait_time: usize, n: usize, max: usize) -> usize {

--- a/oxen-rust/src/lib/src/api/client/versions.rs
+++ b/oxen-rust/src/lib/src/api/client/versions.rs
@@ -798,10 +798,16 @@ pub async fn workspace_multipart_batch_upload_parts_with_retry(
             }
         };
 
-        if !upload_result.err_files.is_empty() {
+        if !files_to_retry.is_empty() {
             let wait_time = exponential_backoff(BASE_WAIT_TIME, retry_count, MAX_WAIT_TIME);
             sleep(Duration::from_millis(wait_time as u64)).await;
         }
+    }
+
+    if !files_to_retry.is_empty() {
+        return Err(OxenError::basic_str(format!(
+            "Failed to upload version files after {max_retries} retries"
+        )));
     }
 
     Ok(upload_result.err_files)

--- a/oxen-rust/src/lib/src/api/client/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/api/client/workspaces/files.rs
@@ -497,11 +497,12 @@ async fn parallel_batched_small_file_upload(
                                 form = form.part("file[]", part);
                             }
 
+                            let mut files_to_retry = files_to_stage.clone();
                             match api::client::versions::workspace_multipart_batch_upload_parts_with_retry(
                                 &remote_repo_clone,
                                 Arc::clone(&client_clone),
                                 form,
-                                files_to_stage.clone(),
+                                &mut files_to_retry,
                                 &local_repo_clone.clone(),
                             )
                             .await

--- a/oxen-rust/src/lib/src/api/client/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/api/client/workspaces/files.rs
@@ -1,5 +1,5 @@
 use crate::api::client;
-use crate::constants::{max_retries, chunk_size};
+use crate::constants::{chunk_size, max_retries};
 use crate::core::progress::push_progress::PushProgress;
 use crate::error::OxenError;
 use crate::model::{LocalRepository, RemoteRepository};
@@ -602,7 +602,10 @@ async fn parallel_batched_small_file_upload(
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     if !err_files.is_empty() {
-        return Err(OxenError::basic_str(format!("Failed to upload {} files after retry", err_files.len())));
+        return Err(OxenError::basic_str(format!(
+            "Failed to upload {} files after retry",
+            err_files.len()
+        )));
     }
 
     Ok(())

--- a/oxen-rust/src/lib/src/constants.rs
+++ b/oxen-rust/src/lib/src/constants.rs
@@ -223,3 +223,35 @@ pub const DEFAULT_NOTEBOOK_BASE_IMAGE: &str = "debian:bookworm-slim";
 
 // Oxen stack size
 pub const OXEN_STACK_SIZE: usize = 16_777_216;
+
+// Parse the maximum number of retries allowed on upload from environment variable
+pub fn max_retries() -> usize {
+    if let Ok(max_retries) = std::env::var("OXEN_MAX_RETRIES") {
+        // If the environment variable is set, use that
+        if let Ok(max_retries) = max_retries.parse::<usize>() {
+            max_retries
+        } else {
+            // If parsing failed, fall back to default
+            MAX_RETRIES
+        }
+    } else {
+        // Environment variable not set, use default
+        MAX_RETRIES
+    }
+}
+
+// Parse the timeout for http requests from environment variable
+pub fn timeout() -> u64 {
+    if let Ok(timeout) = std::env::var("OXEN_TIMEOUT_SECS") {
+        // If the environment variable is set, use that
+        if let Ok(timeout) = timeout.parse::<u64>() {
+            timeout
+        } else {
+            // If parsing failed, fall back to default
+            DEFAULT_TIMEOUT_SECS
+        }
+    } else {
+        // Environment variable not set, use default
+        DEFAULT_TIMEOUT_SECS
+    }
+}

--- a/oxen-rust/src/lib/src/constants.rs
+++ b/oxen-rust/src/lib/src/constants.rs
@@ -255,3 +255,19 @@ pub fn timeout() -> u64 {
         DEFAULT_TIMEOUT_SECS
     }
 }
+
+// Parse the timeout for http requests from environment variable
+pub fn chunk_size() -> u64 {
+    if let Ok(chunk_size) = std::env::var("OXEN_AVG_CHUNK_SIZE") {
+        // If the environment variable is set, use that
+        if let Ok(chunk_size) = chunk_size.parse::<u64>() {
+            chunk_size
+        } else {
+            // If parsing failed, fall back to default
+            AVG_CHUNK_SIZE
+        }
+    } else {
+        // Environment variable not set, use default
+        AVG_CHUNK_SIZE
+    }
+}

--- a/oxen-rust/src/lib/src/repositories.rs
+++ b/oxen-rust/src/lib/src/repositories.rs
@@ -221,7 +221,7 @@ pub async fn create(
     // Create oxen hidden dir
     let hidden_dir = util::fs::oxen_hidden_dir(&repo_dir);
     log::debug!("repositories::create hidden dir: {hidden_dir:?}");
-    util::fs::create_dir_all(&hidden_dir)?;
+    util::fs::create_dir_all(&hidden)?;
 
     // Create config file
     let local_repo = LocalRepository::new(&repo_dir, new_repo.storage_opts)?;
@@ -233,7 +233,7 @@ pub async fn create(
 
     // Create history dir
     let history_dir = util::fs::oxen_hidden_dir(&repo_dir).join(constants::HISTORY_DIR);
-    util::fs::create_dir_all(history_dir)?;
+    util::fs::create_dir_all(history)?;
 
     // Create HEAD file and point it to DEFAULT_BRANCH_NAME
     with_ref_manager(&local_repo, |manager| {

--- a/oxen-rust/src/lib/src/repositories.rs
+++ b/oxen-rust/src/lib/src/repositories.rs
@@ -221,7 +221,7 @@ pub async fn create(
     // Create oxen hidden dir
     let hidden_dir = util::fs::oxen_hidden_dir(&repo_dir);
     log::debug!("repositories::create hidden dir: {hidden_dir:?}");
-    util::fs::create_dir_all(&hidden)?;
+    util::fs::create_dir_all(&hidden_dir)?;
 
     // Create config file
     let local_repo = LocalRepository::new(&repo_dir, new_repo.storage_opts)?;
@@ -233,7 +233,7 @@ pub async fn create(
 
     // Create history dir
     let history_dir = util::fs::oxen_hidden_dir(&repo_dir).join(constants::HISTORY_DIR);
-    util::fs::create_dir_all(history)?;
+    util::fs::create_dir_all(history_dir)?;
 
     // Create HEAD file and point it to DEFAULT_BRANCH_NAME
     with_ref_manager(&local_repo, |manager| {

--- a/oxen-rust/src/lib/src/util/fs.rs
+++ b/oxen-rust/src/lib/src/util/fs.rs
@@ -758,6 +758,23 @@ pub fn create_dir_all(src: impl AsRef<Path>) -> Result<(), OxenError> {
     }
 }
 
+/// Wrapper around the util::fs::create_dir command to tell us which file it failed on
+/// creates a directory if they don't exist
+pub fn create_dir(src: impl AsRef<Path>) -> Result<(), OxenError> {
+    if src.as_ref().exists() {
+        return Ok(());
+    }
+
+    let src = src.as_ref();
+    match std::fs::create_dir(src) {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            log::error!("create_dir {src:?} {err}");
+            Err(OxenError::file_error(src, err))
+        }
+    }
+}
+
 /// Wrapper around the util::fs::remove_dir_all command to tell us which file it failed on
 pub fn remove_dir_all(src: impl AsRef<Path>) -> Result<(), OxenError> {
     let src = src.as_ref();


### PR DESCRIPTION
This PR updates the workspace add logic for small files in the following ways:
1. HTTP request timeout times are now configurable via the env variable DEFAULT_TIMEOUT_SECS
2. Retry logic is implemented for the version file upload. It's done by sending files that fail to upload to the old workspace_multipart_batch_upload logic. Retry is done here both in the case that individual files fail, or the request as a whole fails (I was thinking we'd want that in case the failure was caused by a timeout), although we could definitely change that.

To test this, I would do workspace add with various workloads. I imagine we'll discuss this in more depth in planning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timeout, retry limit, and chunk-size now configurable via OXEN_TIMEOUT_SECS, OXEN_MAX_RETRIES, and OXEN_AVG_CHUNK_SIZE.
  * Added a utility to create a single directory with robust error reporting.

* **Bug Fixes**
  * Multipart upload retry flow overhauled: accumulated error reporting, jittered exponential backoff, environment-driven retry limits, improved logging, and stronger retry orchestration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->