### PR TITLE
API-50 // refactor blocking store version method to be async

### DIFF
--- a/oxen-rust/src/lib/src/storage/local.rs
+++ b/oxen-rust/src/lib/src/storage/local.rs
@@ -115,20 +115,6 @@ impl VersionStore for LocalVersionStore {
         Ok(())
     }
 
-    // Synchronous method to write to version store, for use in tokio::spawn_blocking threads
-    fn store_version_blocking(&self, hash: &str, data: &[u8]) -> Result<(), OxenError> {
-        let version_dir = self.version_dir(hash);
-        std::fs::create_dir_all(&version_dir)?;
-
-        let version_path = self.version_path(hash);
-
-        if !version_path.exists() {
-            std::fs::write(&version_path, data)?;
-        }
-
-        Ok(())
-    }
-
     fn open_version(
         &self,
         hash: &str,

--- a/oxen-rust/src/lib/src/storage/s3.rs
+++ b/oxen-rust/src/lib/src/storage/s3.rs
@@ -61,12 +61,6 @@ impl VersionStore for S3VersionStore {
         Err(OxenError::basic_str("S3VersionStore not yet implemented"))
     }
 
-    fn store_version_blocking(&self, _hash: &str, _data: &[u8]) -> Result<(), OxenError> {
-        // TODO: Implement S3 version storage
-        // This method may not be necessary for S3
-        Err(OxenError::basic_str("S3VersionStore not yet implemented"))
-    }
-
     fn open_version(
         &self,
         _hash: &str,

--- a/oxen-rust/src/lib/src/storage/version_store.rs
+++ b/oxen-rust/src/lib/src/storage/version_store.rs
@@ -77,13 +77,6 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// * `data` - The raw bytes to store
     async fn store_version(&self, hash: &str, data: &[u8]) -> Result<(), OxenError>;
 
-    /// Synchronous method to store a version file from bytes
-    ///
-    /// # Arguments
-    /// * `hash` - The content hash that identifies this version
-    /// * `data` - The raw bytes to store
-    fn store_version_blocking(&self, hash: &str, data: &[u8]) -> Result<(), OxenError>;
-
     /// Store a chunk of a version file
     ///
     /// # Arguments

--- a/oxen-rust/src/server/src/controllers/versions.rs
+++ b/oxen-rust/src/server/src/controllers/versions.rs
@@ -6,6 +6,7 @@ use crate::params::{app_data, parse_resource, path_param};
 
 use actix_multipart::Multipart;
 use actix_web::{web, Error, HttpRequest, HttpResponse};
+use async_compression::tokio::bufread::GzipDecoder;
 use async_compression::tokio::write::GzipEncoder;
 use flate2::read::GzDecoder;
 use futures_util::{StreamExt, TryStreamExt as _};
@@ -17,14 +18,12 @@ use liboxen::util;
 use liboxen::view::versions::{VersionFile, VersionFileResponse};
 use liboxen::view::{ErrorFileInfo, ErrorFilesResponse, StatusMessage};
 use mime;
-use parking_lot::Mutex;
 use std::io::Read as StdRead;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs::File;
-use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
-use tokio::task::JoinSet;
+use tokio::io::{AsyncRead, AsyncWriteExt};
 use tokio_tar::Builder;
 use tokio_util::io::{ReaderStream, StreamReader};
 
@@ -299,8 +298,7 @@ pub async fn save_multiparts(
     })?;
     let gzip_mime: mime::Mime = "application/gzip".parse().unwrap();
 
-    let mut save_tasks = JoinSet::new();
-    let err_files: Arc<Mutex<Vec<ErrorFileInfo>>> = Arc::new(Mutex::new(vec![]));
+    let mut err_files: Vec<ErrorFileInfo> = vec![];
 
     while let Some(mut field) = payload.try_next().await? {
         let Some(content_disposition) = field.content_disposition().cloned() else {
@@ -318,12 +316,7 @@ pub async fn save_multiparts(
                     },
                     |fhash_os_str| Ok(fhash_os_str.to_string()),
                 )?;
-                // log::debug!("upload file_hash: {upload_filehash:?}");
-                // Read the bytes from the stream
-                let mut field_bytes = Vec::new();
-                while let Some(chunk) = field.try_next().await? {
-                    field_bytes.extend_from_slice(&chunk);
-                }
+                log::debug!("upload file_hash: {upload_filehash:?}");
 
                 let is_gzipped = field
                     .content_type()
@@ -332,106 +325,44 @@ pub async fn save_multiparts(
                     })
                     .unwrap_or(false);
 
-                let upload_filehash_copy = upload_filehash.clone();
-                let version_store_copy = version_store.clone();
-                let err_files_clone = Arc::clone(&err_files);
-                let write_task = tokio::task::spawn_blocking(move || {
-                    // Decompress the data if it's gzipped
-                    let data_to_store = match if is_gzipped {
-                        // log::debug!(
-                        //     "Decompressing gzipped data for hash: {}",
-                        //     &upload_filehash_copy
-                        // );
+                // Read the bytes from the stream
+                let mut field_bytes = Vec::new();
+                while let Some(chunk) = field.try_next().await? {
+                    field_bytes.extend_from_slice(&chunk);
+                }
 
-                        let mut decoder = GzDecoder::new(&field_bytes[..]);
-                        let mut decompressed_bytes = Vec::new();
+                let mut reader: Box<dyn AsyncRead + Send + Unpin> = if is_gzipped {
+                    // async decompression
+                    let cursor = std::io::Cursor::new(field_bytes);
+                    let buf_reader = BufReader::new(cursor);
+                    Box::new(GzipDecoder::new(buf_reader))
+                } else {
+                    let cursor = std::io::Cursor::new(field_bytes);
+                    Box::new(cursor)
+                };
 
-                        match decoder.read_to_end(&mut decompressed_bytes) {
-                            Ok(_) => Ok(decompressed_bytes),
-                            Err(e) => Err(OxenError::basic_str(format!(
-                                "Failed to decompress gzipped data: {e}"
-                            ))),
-                        }
-                    } else {
-                        log::debug!("Data for hash {} is not gzipped.", &upload_filehash_copy);
-
-                        Ok(field_bytes)
-                    } {
-                        Ok(data) => data,
-                        Err(e) => {
-                            log::error!(
-                                "Failed to execute blocking decompression task for hash {}: {}",
-                                &upload_filehash,
-                                e
-                            );
-                            {
-                                let mut err_files_clone = err_files_clone.lock();
-                                record_error_file(
-                                    &mut err_files_clone,
-                                    upload_filehash.clone(),
-                                    None,
-                                    format!("Failed to store version: {e}"),
-                                );
-                            }
-                            return;
-                        }
-                    };
-
-                    // Write data to version store
-                    match version_store_copy
-                        .store_version_blocking(&upload_filehash, &data_to_store)
-                    {
-                        Ok(_) => {
-                            // log::info!(
-                            //     "Successfully stored version for hash: {}",
-                            //     &upload_filehash
-                            // );
-                        }
-                        Err(e) => {
-                            log::error!(
-                                "Failed to store version for hash {}: {}",
-                                &upload_filehash,
-                                e
-                            );
-                            {
-                                let mut err_files_clone = err_files_clone.lock();
-                                record_error_file(
-                                    &mut err_files_clone,
-                                    upload_filehash.clone(),
-                                    None,
-                                    format!("Failed to store version: {e}"),
-                                );
-                            }
-                        }
+                match version_store
+                    .store_version_from_reader(&upload_filehash, &mut reader)
+                    .await
+                {
+                    Ok(_) => {
+                        log::info!("Successfully stored version for hash: {upload_filehash}");
                     }
-                });
-
-                save_tasks.spawn(write_task);
+                    Err(e) => {
+                        log::error!("Failed to store version for hash {upload_filehash}: {e}");
+                        record_error_file(
+                            &mut err_files,
+                            upload_filehash.clone(),
+                            None,
+                            format!("Failed to store version: {e}"),
+                        );
+                        continue;
+                    }
+                }
             }
         }
     }
 
-    while let Some(res) = save_tasks.join_next().await {
-        match res {
-            Ok(_) => {}
-            Err(e) => {
-                // Only log the error here, as err_files are recorded immediately when the error occurs
-                log::error!("A task panicked or was cancelled: {e:?}");
-            }
-        }
-    }
-
-    // Get the err_files from the mutex
-    let mutex = match Arc::try_unwrap(err_files) {
-        Ok(mutex) => mutex,
-        Err(e) => {
-            let err = format!("Couldn't acquire mutex guard for err_files: {e:?}");
-            log::error!("{err}");
-            return Err(actix_web::error::ErrorInternalServerError(err));
-        }
-    };
-
-    let err_files = mutex.into_inner();
     Ok(err_files)
 }
 


### PR DESCRIPTION
Revert it to before blocking method was introduced. Additionally, use async decompression to avoid spawning blocking thread. 
Tested with workspace add batch of small files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed synchronous blocking methods from version storage, consolidating to asynchronous operations only.
  * Simplified version storage workflow to use async-only file reading and decompression, improving consistency.
  * Streamlined error handling in version storage operations for better reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->