### PR TITLE
Update branch id in after remote merge

### DIFF
--- a/oxen-rust/src/lib/src/api/client/merger.rs
+++ b/oxen-rust/src/lib/src/api/client/merger.rs
@@ -260,8 +260,9 @@ mod tests {
                 ..Default::default()
             };
             repositories::push::push_remote_branch(&local_repo, &opts).await?;
+
             // Merge the head branch into base
-            api::client::merger::merge(&remote_repo, base, head).await?;
+            let merge_result = api::client::merger::merge(&remote_repo, base, head).await?;
 
             repositories::checkout::checkout(&local_repo, base).await?;
             let commits_before = repositories::commits::list(&local_repo)?;
@@ -273,6 +274,10 @@ mod tests {
 
             let path = local_repo.path.join(new_file_name);
             assert!(path.exists());
+
+            // Check that the branch was updated
+            let new_head = repositories::branches::current_branch(&local_repo)?.unwrap();
+            assert_eq!(new_head.commit_id, merge_result.merge.id);
 
             Ok(remote_repo)
         })

--- a/oxen-rust/src/server/src/controllers/merger.rs
+++ b/oxen-rust/src/server/src/controllers/merger.rs
@@ -110,6 +110,9 @@ pub async fn merge(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     // Check if mergeable
     match repositories::merge::merge_into_base(&repo, &head_branch, &base_branch).await {
         Ok(Some(merge_commit)) => {
+            // If the merge was successful, update the branch
+            repositories::branches::update(&repo, &base_branch.name, &merge_commit.id)?;
+
             let response = MergeSuccessResponse {
                 status: StatusMessage::resource_found(),
                 commits: MergeResult {


### PR DESCRIPTION
This fixes merge requests on the hub. Right now, when you merge a merge request, it goes through successfully, but the base branch isn't actually updated. 

To test:
1. Setup the server, hub, and frontend locally. Create a repo on the hub with 2 branches that don't conflict
2.  In the UI, create a merge request and hit merge
3.  Clone the repo locally. On main, main won't have the merge commit. On this branch, it will

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Merge operations now correctly update the target branch to point to the newly merged commit
* Enhanced validation to confirm branch HEAD is properly updated following merge completion

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->