### PR TITLE
API-98 // Change the versions dir location in config.toml to relative path

### DIFF
--- a/oxen-rust/src/lib/src/core/v_latest/prune.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/prune.rs
@@ -281,7 +281,7 @@ async fn prune_versions(
     dry_run: bool,
 ) -> Result<(), OxenError> {
     let storage_opts = StorageOpts::from_path(&repo.path, true);
-    let version_store = create_version_store(&storage_opts)?;
+    let version_store = create_version_store(&repo.path, &storage_opts)?;
 
     let all_versions = version_store.list_versions().await?;
     stats.versions_scanned = all_versions.len();

--- a/oxen-rust/src/lib/src/model/repository/local_repository.rs
+++ b/oxen-rust/src/lib/src/model/repository/local_repository.rs
@@ -74,7 +74,7 @@ impl LocalRepository {
         } else {
             StorageOpts::from_path(&repo.path, true)
         };
-        let store = create_version_store(&storage_opts)?;
+        let store = create_version_store(&repo.path, &storage_opts)?;
         repo.version_store = Some(store);
         Ok(repo)
     }
@@ -88,7 +88,7 @@ impl LocalRepository {
     }
 
     pub fn init_version_store(&mut self, storage_opts: &StorageOpts) -> Result<(), OxenError> {
-        let store = create_version_store(storage_opts)?;
+        let store = create_version_store(&self.path, storage_opts)?;
         self.version_store = Some(store);
         Ok(())
     }
@@ -99,14 +99,14 @@ impl LocalRepository {
         let storage_opts = StorageOpts::from_path(&self.path, true);
 
         // Create and initialize the store
-        let store = create_version_store(&storage_opts)?;
+        let store = create_version_store(&self.path, &storage_opts)?;
         self.version_store = Some(store);
         Ok(())
     }
 
     /// Initialize local version store at a new location
     pub async fn set_version_store(&mut self, storage_opts: &StorageOpts) -> Result<(), OxenError> {
-        let version_store = create_version_store(storage_opts)?;
+        let version_store = create_version_store(&self.path, storage_opts)?;
         version_store.init().await?;
         self.version_store = Some(version_store);
 
@@ -307,16 +307,17 @@ impl LocalRepository {
         let storage = self.version_store.as_ref().map(|store| {
             let settings = store.storage_settings();
             let path = settings.get("path").unwrap();
-            let storage_path = if util::fs::is_relative_to_dir(path, &self.path) {
-                // If location is within the repo dir, use the relative path in case the repo was moved
-                util::fs::path_relative_to_dir(path, &self.path)
-                    .unwrap()
-                    .to_string_lossy()
-                    .into_owned()
-            } else {
-                // Otherwise, use the absolute path
-                path.clone()
-            };
+            let storage_path =
+                if util::fs::is_relative_to_dir(path, util::fs::oxen_hidden_dir(&self.path)) {
+                    // If path is within .oxen (default location), use the relative path in case the repo was moved
+                    util::fs::path_relative_to_dir(path, &self.path)
+                        .unwrap()
+                        .to_string_lossy()
+                        .into_owned()
+                } else {
+                    // Otherwise, use the absolute path
+                    path.clone()
+                };
 
             StorageConfig {
                 type_: store.storage_type().to_string(),

--- a/oxen-rust/src/lib/src/model/repository/local_repository.rs
+++ b/oxen-rust/src/lib/src/model/repository/local_repository.rs
@@ -304,26 +304,32 @@ impl LocalRepository {
         let config_path = util::fs::config_filepath(&self.path);
 
         // Determine the current storage type and settings using the trait methods
-        let storage = self.version_store.as_ref().map(|store| {
-            let settings = store.storage_settings();
-            let path = settings.get("path").unwrap();
-            let storage_path =
-                if util::fs::is_relative_to_dir(path, util::fs::oxen_hidden_dir(&self.path)) {
-                    // If path is within .oxen (default location), use the relative path in case the repo was moved
-                    util::fs::path_relative_to_dir(path, &self.path)
-                        .unwrap()
-                        .to_string_lossy()
-                        .into_owned()
-                } else {
-                    // Otherwise, use the absolute path
-                    path.clone()
-                };
+        let storage = self
+            .version_store
+            .as_ref()
+            .map(|store| -> Result<StorageConfig, OxenError> {
+                let settings = store.storage_settings();
+                let path = settings
+                    .get("path")
+                    .ok_or_else(|| OxenError::basic_str("Storage settings missing 'path' key"))?;
+                let storage_path =
+                    if util::fs::is_relative_to_dir(path, util::fs::oxen_hidden_dir(&self.path)) {
+                        // If path is within .oxen (default location), use the relative path in case the repo was moved
+                        util::fs::path_relative_to_dir(path, &self.path)
+                            .unwrap()
+                            .to_string_lossy()
+                            .into_owned()
+                    } else {
+                        // Otherwise, use the absolute path
+                        path.clone()
+                    };
 
-            StorageConfig {
-                type_: store.storage_type().to_string(),
-                settings: HashMap::from([("path".to_string(), storage_path)]),
-            }
-        });
+                Ok(StorageConfig {
+                    type_: store.storage_type().to_string(),
+                    settings: HashMap::from([("path".to_string(), storage_path)]),
+                })
+            })
+            .transpose()?;
 
         let config = RepositoryConfig {
             remote_name: self.remote_name.clone(),


### PR DESCRIPTION
To test:
Run `oxen init` and check the .oxen/config.toml to find the path in storage.settings is ".oxen/versions/files"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved storage path handling so repository-relative paths are resolved consistently against the repo location.
  * Version storage initialization made more explicit and consistent across workflows, with clearer handling of local vs remote storage paths.
  * Storage configuration now validates and preserves computed paths when saving repository settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->