### PR TITLE
Correct list_files_and_dirs

### DIFF
--- a/oxen-rust/src/lib/src/model/merkle_tree/node/merkle_tree_node.rs
+++ b/oxen-rust/src/lib/src/model/merkle_tree/node/merkle_tree_node.rs
@@ -385,7 +385,7 @@ impl MerkleTreeNode {
         for child in &self.children {
             if let EMerkleTreeNode::Directory(dir) = &child.node {
                 let new_path = current_path.join(dir.name());
-                nodes.insert(new_path.clone(), self.clone());
+                nodes.insert(new_path.clone(), child.clone());
 
                 child.list_files_and_dirs_helper(&new_path, nodes)?;
             } else {


### PR DESCRIPTION
Fixes a logic error in a helper function in MerkleTreeNode which was causing a problem with using the delete file API to remove  a dir. This function is supposed to collect nodes with their paths to stage them for removal, but was actually associating each dir path with the dir's parent node (i.e., the VNode), resulting in an unexpected Node type error in the rm logic