### PR TITLE
fix delete file via api 

### DIFF
--- a/oxen-rust/src/lib/src/model/merkle_tree/node/merkle_tree_node.rs
+++ b/oxen-rust/src/lib/src/model/merkle_tree/node/merkle_tree_node.rs
@@ -565,7 +565,7 @@ impl MerkleTreeNode {
             // log::debug!(
             //     "get_by_path_helper {} is file! [{:?}] {:?} {:?}",
             //     self,
-            //     self.node.dtype(),
+            //     self.node.node_type(),
             //     file_path,
             //     path
             // );

--- a/oxen-rust/src/lib/src/repositories/commits/commit_writer.rs
+++ b/oxen-rust/src/lib/src/repositories/commits/commit_writer.rs
@@ -1061,37 +1061,37 @@ fn compute_dir_node(
             let err_msg = format!("compute_dir_node No entries found for directory {path:?}");
             return Err(OxenError::basic_str(err_msg));
         };
-        log::debug!(
-            "Aggregating dir {:?} child {:?} with {} vnodes",
-            path,
-            child,
-            vnodes.len()
-        );
+        // log::debug!(
+        //     "Aggregating dir {:?} child {:?} with {} vnodes",
+        //     path,
+        //     child,
+        //     vnodes.len()
+        // );
         for vnode in vnodes.iter() {
-            log::debug!("Aggregating vnode entries {:?}", vnode.entries.len());
+            // log::debug!("Aggregating vnode entries {:?}", vnode.entries.len());
             for entry in vnode.entries.iter() {
-                log::debug!("Aggregating entry {}", entry.node);
+                // log::debug!("Aggregating entry {}", entry.node);
                 match &entry.node.node {
                     EMerkleTreeNode::Directory(dir_node) => {
                         if path == *child {
                             num_entries += 1;
                         }
-                        log::debug!(
-                            "Updating hash for dir {} -> hash {} status {:?}",
-                            dir_node.name(),
-                            dir_node.hash(),
-                            entry.status
-                        );
+                        // log::debug!(
+                        //     "Updating hash for dir {} -> hash {} status {:?}",
+                        //     dir_node.name(),
+                        //     dir_node.hash(),
+                        //     entry.status
+                        // );
                         hasher.update(dir_node.name().as_bytes());
                         hasher.update(&dir_node.hash().to_le_bytes());
                     }
                     EMerkleTreeNode::File(file_node) => {
-                        log::debug!(
-                            "Updating hash for file {} -> hash {} status {:?}",
-                            file_node.name(),
-                            file_node.hash(),
-                            entry.status
-                        );
+                        // log::debug!(
+                        //     "Updating hash for file {} -> hash {} status {:?}",
+                        //     file_node.name(),
+                        //     file_node.hash(),
+                        //     entry.status
+                        // );
                         hasher.update(file_node.name().as_bytes());
                         hasher.update(&file_node.combined_hash().to_le_bytes());
 
@@ -1128,13 +1128,13 @@ fn compute_dir_node(
                 EMerkleTreeNode::Directory(_) => {
                     // Do nothing
                 }
-                EMerkleTreeNode::File(file_node) => {
-                    log::debug!(
-                        "Updating hash for file {} -> hash {} status {:?}",
-                        file_node.name(),
-                        file_node.hash(),
-                        entry.status
-                    );
+                EMerkleTreeNode::File(_) => {
+                    // log::debug!(
+                    //     "Updating hash for file {} -> hash {} status {:?}",
+                    //     file_node.name(),
+                    //     file_node.hash(),
+                    //     entry.status
+                    // );
 
                     match entry.status {
                         StagedEntryStatus::Removed => {

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -400,8 +400,7 @@ pub async fn delete(
 
     // Stage the path as removed
     log::debug!("file::delete staging path {path:?}");
-    let err_files = repositories::workspaces::files::rm(&workspace, &path).await?;
-    log::debug!("file::delete err_files: {err_files:?}");
+    repositories::workspaces::files::rm(&workspace, &path).await?;
 
     // Commit workspace
     let commit_body = NewCommitBody {

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -395,10 +395,13 @@ pub async fn delete(
     // Get the commit info from the payload
     let (name, email, message, _temp_files) = parse_multipart_fields_for_repo(payload).await?;
 
+    log::debug!("file::delete creating workspace for commit: {commit}");
     let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
 
     // Stage the path as removed
-    repositories::workspaces::files::rm(&workspace, &path).await?;
+    log::debug!("file::delete staging path {path:?}");
+    let err_files = repositories::workspaces::files::rm(&workspace, &path).await?;
+    log::debug!("file::delete err_files: {err_files:?}");
 
     // Commit workspace
     let commit_body = NewCommitBody {


### PR DESCRIPTION
by passing in the workspace commit instead of the head commit. HEAD does not work on the server side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an asynchronous end-to-end test verifying file deletion after upload and remote sync.

* **Bug Fixes**
  * File removal now uses an explicit commit reference to ensure correct detection and deletion of files, improving consistency of remove operations.

* **Chores**
  * Reduced and consolidated diagnostic logging; added targeted debug logs around deletion flow for clearer observability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->