### PR TITLE
Update environment variable names

### DIFF
--- a/oxen-rust/src/cli/src/cmd/clone.rs
+++ b/oxen-rust/src/cli/src/cmd/clone.rs
@@ -37,7 +37,7 @@ impl RunCmd for CloneCmd {
             .arg(
                 Arg::new("depth")
                     .long("depth")
-                    .help("Used in combination with --subtree. The depth at which to clone the subtree. If not provided, the entire subtree will be cloned.")
+                    .help("Used in combination with --filter. The depth at which to clone a subtree. If not provided, the entire subtree will be cloned.")
                     .action(clap::ArgAction::Set),
             )
             .arg(

--- a/oxen-rust/src/lib/src/api/client/versions.rs
+++ b/oxen-rust/src/lib/src/api/client/versions.rs
@@ -1,6 +1,6 @@
 use crate::api;
 use crate::api::client;
-use crate::constants::{max_retries, AVG_CHUNK_SIZE, MAX_RETRIES};
+use crate::constants::{max_retries, AVG_CHUNK_SIZE};
 use crate::error::OxenError;
 use crate::model::entry::commit_entry::Entry;
 use crate::model::{LocalRepository, MerkleHash, RemoteRepository};
@@ -198,7 +198,7 @@ pub async fn download_data_from_version_paths(
     hashes: &[String],
     local_repo: &LocalRepository,
 ) -> Result<u64, OxenError> {
-    let total_retries = max_retries().try_into().unwrap_or(MAX_RETRIES as u64);
+    let total_retries = max_retries().try_into().unwrap_or(max_retries() as u64);
     let mut num_retries = 0;
 
     while num_retries < total_retries {

--- a/oxen-rust/src/lib/src/constants.rs
+++ b/oxen-rust/src/lib/src/constants.rs
@@ -226,11 +226,11 @@ pub fn max_retries() -> usize {
             max_retries
         } else {
             // If parsing failed, fall back to default
-            NUM_HTTP_RETRIES
+            NUM_HTTP_RETRIES.try_into().unwrap()
         }
     } else {
         // Environment variable not set, use default
-        NUM_HTTP_RETRIES
+        NUM_HTTP_RETRIES.try_into().unwrap()
     }
 }
 

--- a/oxen-rust/src/lib/src/constants.rs
+++ b/oxen-rust/src/lib/src/constants.rs
@@ -178,9 +178,6 @@ pub const EVAL_DURATION_COL: &str = "_oxen_eval_duration";
 pub const AVG_CHUNK_SIZE: u64 = 1024 * 1024 * 10;
 // Retry and back off of upload tasks N times
 /// Retry and back off of upload tasks N times
-pub const MAX_RETRIES: usize = 5;
-// Allow up to N concurrent upload tasks
-/// Allow up to N concurrent upload tasks
 pub const MAX_CONCURRENT_UPLOADS: usize = 30;
 // Retry and back off of requests N times
 /// Retry and back off of requests N times
@@ -223,17 +220,17 @@ pub const OXEN_STACK_SIZE: usize = 16_777_216;
 
 // Parse the maximum number of retries allowed on upload from environment variable
 pub fn max_retries() -> usize {
-    if let Ok(max_retries) = std::env::var("OXEN_MAX_RETRIES") {
+    if let Ok(max_retries) = std::env::var("OXEN_NUM_RETRIES") {
         // If the environment variable is set, use that
         if let Ok(max_retries) = max_retries.parse::<usize>() {
             max_retries
         } else {
             // If parsing failed, fall back to default
-            MAX_RETRIES
+            NUM_HTTP_RETRIES
         }
     } else {
         // Environment variable not set, use default
-        MAX_RETRIES
+        NUM_HTTP_RETRIES
     }
 }
 

--- a/oxen-rust/src/lib/src/constants.rs
+++ b/oxen-rust/src/lib/src/constants.rs
@@ -176,15 +176,15 @@ pub const EVAL_DURATION_COL: &str = "_oxen_eval_duration";
 // Average chunk size of ~10mb
 /// Average chunk size of ~10mb when chunking and sending data
 pub const AVG_CHUNK_SIZE: u64 = 1024 * 1024 * 10;
-// Retry and back off of upload tasks N times
-/// Retry and back off of upload tasks N times
+// Allow up to N concurrent upload tasks
+/// Allow up to N concurrent upload tasks
 pub const MAX_CONCURRENT_UPLOADS: usize = 30;
 // Retry and back off of requests N times
 /// Retry and back off of requests N times
 #[cfg(test)]
 pub const NUM_HTTP_RETRIES: u64 = 1;
 #[cfg(not(test))]
-pub const NUM_HTTP_RETRIES: u64 = 10;
+pub const NUM_HTTP_RETRIES: u64 = 5;
 /// Number of workers
 pub const DEFAULT_NUM_WORKERS: usize = 8;
 /// Default timeout for HTTP requests


### PR DESCRIPTION
Deprecates the 'MAX_RETRIES' environment variable. We had 2 different variables  to configure the number of HTTP Request retries, so this deprecates one of them. Also fixed the help message for the clone depth option (--subtree isn't a path anymore, it's called --filter now)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the clone command help to better describe the --depth option for subtree cloning.

* **Chores / Configuration**
  * Renamed the environment variable that controls retry behavior and removed the old fixed retry constant; default retry count for non-test builds changed from 10 to 5, and client retry fallbacks now use the updated lookup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->