### PR TITLE
Implement manager for dir hashes db

### DIFF
--- a/oxen-rust/src/lib/src/core/db.rs
+++ b/oxen-rust/src/lib/src/core/db.rs
@@ -2,5 +2,6 @@
 //!
 
 pub mod data_frames;
+pub mod dir_hashes;
 pub mod key_val;
 pub mod merkle_node;

--- a/oxen-rust/src/lib/src/core/db/dir_hashes.rs
+++ b/oxen-rust/src/lib/src/core/db/dir_hashes.rs
@@ -1,0 +1,1 @@
+pub mod dir_hashes_db;

--- a/oxen-rust/src/lib/src/core/db/dir_hashes/dir_hashes_db.rs
+++ b/oxen-rust/src/lib/src/core/db/dir_hashes/dir_hashes_db.rs
@@ -1,0 +1,100 @@
+use crate::constants::{DIR_HASHES_DIR, HISTORY_DIR};
+use crate::core::db;
+use crate::error::OxenError;
+use crate::model::{Commit, LocalRepository};
+use crate::util;
+
+use lru::LruCache;
+use rocksdb::{DBWithThreadMode, MultiThreaded};
+use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, RwLock};
+
+const DB_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
+
+// Static cache of DB instances with LRU eviction
+static DB_INSTANCES: LazyLock<RwLock<LruCache<PathBuf, Arc<DBWithThreadMode<MultiThreaded>>>>> =
+    LazyLock::new(|| RwLock::new(LruCache::new(DB_CACHE_SIZE)));
+
+// Commit db is the directories per commit
+// This helps us skip to a directory in the tree
+// .oxen/history/{COMMIT_ID}/dir_hashes
+pub fn dir_hash_db_path(repo: &LocalRepository, commit: &Commit) -> PathBuf {
+    let commit_id = &commit.id;
+    dir_hash_db_path_from_commit_id(repo, commit_id)
+}
+
+pub fn dir_hash_db_path_from_commit_id(
+    repo: &LocalRepository,
+    commit_id: impl AsRef<str>,
+) -> PathBuf {
+    let commit_id = commit_id.as_ref();
+    util::fs::oxen_hidden_dir(&repo.path)
+        .join(Path::new(HISTORY_DIR))
+        .join(commit_id)
+        .join(DIR_HASHES_DIR)
+}
+
+pub fn with_dir_hash_db_manager<F, T>(
+    repository: &LocalRepository,
+    commit_id: &String,
+    operation: F,
+) -> Result<T, OxenError>
+where
+    F: FnOnce(&DBWithThreadMode<MultiThreaded>) -> Result<T, OxenError>,
+{
+    let dir_hashes_db = {
+        let dir_hashes_db_dir = dir_hash_db_path_from_commit_id(repository, commit_id);
+
+        // 1. If this dir_hashes db exists in cache, return the existing connection
+        {
+            let cache_r = match DB_INSTANCES.read() {
+                Ok(cache_r) => cache_r,
+                Err(e) => {
+                    return Err(OxenError::basic_str(format!(
+                        "Could not open LRU for dir hash db cache: {e:?}"
+                    )));
+                }
+            };
+            if let Some(db) = cache_r.peek(&dir_hashes_db_dir) {
+                // Cache hit: return the existing connection
+                let dir_hashes_db = Arc::clone(db);
+                return operation(&dir_hashes_db);
+            }
+        }
+
+        // 2. If not exists, create the directory and open the db
+        let mut cache_w = match DB_INSTANCES.write() {
+            Ok(cache_w) => cache_w,
+            Err(e) => {
+                return Err(OxenError::basic_str(format!(
+                    "Could not open LRU for dir hash db cache: {e:?}"
+                )));
+            }
+        };
+
+        if let Some(db) = cache_w.get(&dir_hashes_db_dir) {
+            Arc::clone(db)
+        } else {
+            // Cache miss: open a new connection to the db
+
+            if !dir_hashes_db_dir.exists() {
+                return Err(OxenError::basic_str(format!(
+                    "Could not find dir_hashes db for commit {commit_id}"
+                )));
+            }
+
+            let opts = db::key_val::opts::default();
+            let dir_hashes_db: DBWithThreadMode<MultiThreaded> =
+                DBWithThreadMode::open_for_read_only(&opts, &dir_hashes_db_dir, false)?;
+
+            // Wrap the DB in an Arc and store it in the cache
+            let db = Arc::new(dir_hashes_db);
+            cache_w.put(dir_hashes_db_dir, db.clone());
+
+            db
+        }
+    };
+
+    operation(&dir_hashes_db)
+}

--- a/oxen-rust/src/lib/src/repositories/commits/commit_writer.rs
+++ b/oxen-rust/src/lib/src/repositories/commits/commit_writer.rs
@@ -267,7 +267,9 @@ pub fn commit_dir_entries_with_parents(
     )?;
 
     let opts = db::key_val::opts::default();
-    let dir_hash_db_path = repositories::tree::dir_hash_db_path_from_commit_id(repo, &commit_id);
+    let commit_id_string = format!("{commit_id}").to_string();
+    let dir_hash_db_path =
+        CommitMerkleTree::dir_hash_db_path_from_commit_id(repo, &commit_id_string);
     let dir_hash_db: DBWithThreadMode<SingleThreaded> =
         DBWithThreadMode::open(&opts, dunce::simplified(&dir_hash_db_path))?;
 
@@ -368,7 +370,9 @@ pub fn commit_dir_entries_new(
     )?;
 
     let opts = db::key_val::opts::default();
-    let dir_hash_db_path = repositories::tree::dir_hash_db_path_from_commit_id(repo, &commit_id);
+    let commit_id_string = format!("{commit_id}").to_string();
+    let dir_hash_db_path =
+        CommitMerkleTree::dir_hash_db_path_from_commit_id(repo, &commit_id_string);
     let dir_hash_db: DBWithThreadMode<SingleThreaded> =
         DBWithThreadMode::open(&opts, dunce::simplified(&dir_hash_db_path))?;
 
@@ -490,7 +494,9 @@ pub fn commit_dir_entries(
     )?;
 
     let opts = db::key_val::opts::default();
-    let dir_hash_db_path = repositories::tree::dir_hash_db_path_from_commit_id(repo, &commit_id);
+    let commit_id_string = format!("{commit_id}").to_string();
+    let dir_hash_db_path =
+        CommitMerkleTree::dir_hash_db_path_from_commit_id(repo, &commit_id_string);
     let dir_hash_db: DBWithThreadMode<SingleThreaded> =
         DBWithThreadMode::open(&opts, dunce::simplified(&dir_hash_db_path))?;
 

--- a/oxen-rust/src/lib/src/repositories/tree.rs
+++ b/oxen-rust/src/lib/src/repositories/tree.rs
@@ -2,19 +2,18 @@ use bytesize::ByteSize;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use rocksdb::{DBWithThreadMode, IteratorMode, MultiThreaded};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::str;
 use tar::Archive;
 
-use crate::constants::{DIR_HASHES_DIR, HISTORY_DIR, NODES_DIR, OXEN_HIDDEN_DIR, TREE_DIR};
+use crate::constants::{NODES_DIR, OXEN_HIDDEN_DIR, TREE_DIR};
 use crate::core::commit_sync_status;
-use crate::core::db;
 use crate::core::db::merkle_node::merkle_node_db::{node_db_path, node_db_prefix};
 use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::core::node_sync_status;
 use crate::core::v_latest::index::CommitMerkleTree as CommitMerkleTreeLatest;
+use crate::core::v_latest::index::CommitMerkleTree;
 use crate::core::v_old::v0_19_0::index::CommitMerkleTree as CommitMerkleTreeV0_19_0;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
@@ -174,7 +173,7 @@ pub fn has_dir(
     commit: &Commit,
     path: impl AsRef<Path>,
 ) -> Result<bool, OxenError> {
-    let dir_hashes = repositories::tree::dir_hashes(repo, commit)?;
+    let dir_hashes = CommitMerkleTreeLatest::dir_hashes(repo, commit)?;
     Ok(dir_hashes.contains_key(path.as_ref()))
 }
 
@@ -184,7 +183,7 @@ pub fn has_path(
     path: impl AsRef<Path>,
 ) -> Result<bool, OxenError> {
     let path = path.as_ref();
-    let dir_hashes = repositories::tree::dir_hashes(repo, commit)?;
+    let dir_hashes = CommitMerkleTreeLatest::dir_hashes(repo, commit)?;
     match dir_hashes.get(path) {
         Some(dir_hash) => {
             let node = get_node_by_id_with_children(repo, dir_hash)?.unwrap();
@@ -882,9 +881,12 @@ pub fn cp_dir_hashes_to(
     original_commit_id: &MerkleHash,
     new_commit_id: &MerkleHash,
 ) -> Result<(), OxenError> {
-    let original_dir_hashes_path = dir_hash_db_path_from_commit_id(repo, original_commit_id);
-    let new_dir_hashes_path = dir_hash_db_path_from_commit_id(repo, new_commit_id);
+    let original_dir_hashes_path =
+        CommitMerkleTree::dir_hash_db_path_from_commit_id(repo, &original_commit_id.to_string());
+    let new_dir_hashes_path =
+        CommitMerkleTree::dir_hash_db_path_from_commit_id(repo, &new_commit_id.to_string());
     util::fs::copy_dir_all(original_dir_hashes_path, new_dir_hashes_path)?;
+
     Ok(())
 }
 
@@ -1103,38 +1105,6 @@ fn p_write_tree(
     }
     db.close()?;
     Ok(())
-}
-
-// TODO: Deprecate. This should go directly to CommitMerkleTree
-/// The dir hashes allow you to skip to a directory in the tree
-pub fn dir_hashes(
-    repo: &LocalRepository,
-    commit: &Commit,
-) -> Result<HashMap<PathBuf, MerkleHash>, OxenError> {
-    let node_db_dir = repositories::tree::dir_hash_db_path(repo, commit);
-    log::debug!("loading dir_hashes from: {node_db_dir:?}");
-    let opts = db::key_val::opts::default();
-    let node_db: DBWithThreadMode<MultiThreaded> =
-        DBWithThreadMode::open_for_read_only(&opts, node_db_dir, false)?;
-    let mut dir_hashes = HashMap::new();
-    let iterator = node_db.iterator(IteratorMode::Start);
-    for item in iterator {
-        match item {
-            Ok((key, value)) => {
-                let key = str::from_utf8(&key)?;
-                let value = str::from_utf8(&value)?;
-                let hash = value.parse()?;
-                dir_hashes.insert(PathBuf::from(key), hash);
-            }
-            _ => {
-                return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
-                ));
-            }
-        }
-    }
-    // log::debug!("read dir_hashes: {:?}", dir_hashes);
-    Ok(dir_hashes)
 }
 
 // TODO: Refactor to remove 'is_download' var here
@@ -1395,23 +1365,6 @@ pub fn get_ancestor_nodes(
     }
 
     Ok(())
-}
-
-// Commit db is the directories per commit
-// This helps us skip to a directory in the tree
-// .oxen/history/{COMMIT_ID}/dir_hashes
-pub fn dir_hash_db_path(repo: &LocalRepository, commit: &Commit) -> PathBuf {
-    util::fs::oxen_hidden_dir(&repo.path)
-        .join(Path::new(HISTORY_DIR))
-        .join(&commit.id)
-        .join(DIR_HASHES_DIR)
-}
-
-pub fn dir_hash_db_path_from_commit_id(repo: &LocalRepository, commit_id: &MerkleHash) -> PathBuf {
-    util::fs::oxen_hidden_dir(&repo.path)
-        .join(Path::new(HISTORY_DIR))
-        .join(commit_id.to_string())
-        .join(DIR_HASHES_DIR)
 }
 
 // TODO: Deduplicate these


### PR DESCRIPTION
Implements a db manager function with an associated cache for the dir_hashes db in a parallel manner to the staged_db_manager. Replaces direct access of the dir_hashes db with this manager where it's used for read only. Also deprecates repositories::tree::dir_hashes, routing all logic that interacts with the dir_hash db through core::v_latest::index::CommitMerkleTree and the new dir_hashes_db module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized directory hash database management with centralized caching and thread-safe operations for improved performance and reliability during repository operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->