### PR TITLE
Allow workspace create endpoint on empty repo

### DIFF
--- a/oxen-rust/src/cli/src/cmd/commit.rs
+++ b/oxen-rust/src/cli/src/cmd/commit.rs
@@ -53,7 +53,8 @@ impl RunCmd for CommitCmd {
         println!("Committing with message: {message}");
 
         if allow_empty {
-            repositories::commits::commit_allow_empty(&repo, message)?;
+            let branch_name = repositories::branches::current_branch(&repo)?.map(|b| b.name);
+            repositories::commits::commit_allow_empty(&repo, message, branch_name.as_deref())?;
         } else {
             repositories::commit(&repo, message)?;
         }

--- a/oxen-rust/src/lib/src/api/client/workspaces.rs
+++ b/oxen-rust/src/lib/src/api/client/workspaces.rs
@@ -266,10 +266,14 @@ mod tests {
         test::run_empty_remote_repo_test(|_local_repo, remote_repo| async move {
             let branch_name = "custom";
             let workspace_id = "test_workspace_id";
-            let _path = "path"; // 'resource path' param isn't used by the server, only the hub
-            let workspace =
-                create_with_new_branch(&remote_repo, branch_name, workspace_id, _path, None)
-                    .await?;
+            let workspace = create_with_new_branch(
+                &remote_repo,
+                branch_name,
+                workspace_id,
+                Path::new("/"),
+                None,
+            )
+            .await?;
 
             assert_eq!(workspace.id, workspace_id);
 

--- a/oxen-rust/src/lib/src/api/client/workspaces.rs
+++ b/oxen-rust/src/lib/src/api/client/workspaces.rs
@@ -258,6 +258,24 @@ mod tests {
         .await
     }
 
+    // Creates an empty commit to base the workspace off of
+    #[tokio::test]
+    async fn test_create_workspace_on_empty_repo() -> Result<(), OxenError> {
+        test::run_empty_remote_repo_test(|_local_repo, remote_repo| async move {
+            let branch_name = "main";
+            let workspace_id = "test_workspace_id";
+            let _path = "path"; // 'resource path' param isn't used by the server, only the hub
+            let workspace =
+                create_with_new_branch(&remote_repo, branch_name, workspace_id, _path, None)
+                    .await?;
+
+            assert_eq!(workspace.id, workspace_id);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
     #[tokio::test]
     async fn test_create_workspace_with_name() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {

--- a/oxen-rust/src/lib/src/api/client/workspaces.rs
+++ b/oxen-rust/src/lib/src/api/client/workspaces.rs
@@ -266,6 +266,8 @@ mod tests {
         test::run_empty_remote_repo_test(|_local_repo, remote_repo| async move {
             let branch_name = "custom";
             let workspace_id = "test_workspace_id";
+
+            println!("Creating workspace");
             let workspace = create_with_new_branch(
                 &remote_repo,
                 branch_name,
@@ -279,6 +281,8 @@ mod tests {
 
             let directory_name = "images";
             let path = test::test_img_file();
+            
+            println!("Adding file");
             let result = api::client::workspaces::files::add(
                 &remote_repo,
                 &workspace_id,
@@ -292,6 +296,8 @@ mod tests {
             let page_num = constants::DEFAULT_PAGE_NUM;
             let page_size = constants::DEFAULT_PAGE_SIZE;
             let path = Path::new(directory_name);
+
+            println!("Listing changes");
             let entries = api::client::workspaces::changes::list(
                 &remote_repo,
                 &workspace_id,
@@ -314,6 +320,8 @@ mod tests {
                 author: "Test User".to_string(),
                 email: "test@oxen.ai".to_string(),
             };
+
+            println!("Commit");
             let commit =
                 api::client::workspaces::commit(&remote_repo, branch_name, workspace_id, &body)
                     .await?;
@@ -322,6 +330,7 @@ mod tests {
             assert!(remote_commit.is_some());
             assert_eq!(commit.id, remote_commit.unwrap().id);
 
+            println!("Get branch");
             let branch = api::client::branches::get_by_name(&remote_repo, &branch_name).await?;
             assert!(branch.is_some());
 

--- a/oxen-rust/src/server/src/controllers/commits.rs
+++ b/oxen-rust/src/server/src/controllers/commits.rs
@@ -717,7 +717,11 @@ pub async fn create(
         };
 
     // Create Commit from uri params
-    match repositories::commits::create_empty_commit(&repository, bn.branch_name, &new_commit) {
+    match repositories::commits::create_empty_commit(
+        &repository,
+        &new_commit,
+        Some(bn.branch_name.as_str()),
+    ) {
         Ok(commit) => Ok(HttpResponse::Ok().json(CommitResponse {
             status: StatusMessage::resource_created(),
             commit: commit.to_owned(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Returns "Branch not found" (404) when a requested branch is missing.
  * Workspace creation now creates or uses a head (including creating an empty commit if needed) so branches can be created on empty repositories.

* **New Features**
  * Empty-commit operations accept an optional branch context to target specific branches.
  * Commit CLI supports creating an empty commit with an optional branch context.

* **Tests**
  * Added a test verifying workspace and branch creation on an empty repository.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->