### PR TITLE
Add mv file support

### DIFF
--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -421,7 +421,10 @@ mod tests {
             .await?;
 
             assert_eq!(mv_response.status.status_message, "resource_updated");
-            assert!(mv_response.commit.message.contains("Move file to new location"));
+            assert!(mv_response
+                .commit
+                .message
+                .contains("Move file to new location"));
 
             // Pull the changes
             repositories::pull(&local_repo).await?;

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -128,6 +128,49 @@ pub async fn get_file_thumbnail(
     .await
 }
 
+/// Move/rename a file in place (mv in a temp workspace and commit)
+pub async fn mv_file(
+    remote_repo: &RemoteRepository,
+    branch: impl AsRef<str>,
+    source_path: impl AsRef<Path>,
+    new_path: impl AsRef<Path>,
+    commit_body: Option<NewCommitBody>,
+) -> Result<CommitResponse, OxenError> {
+    let branch = branch.as_ref();
+    let source_path = source_path.as_ref();
+    let new_path = new_path.as_ref();
+
+    let source_path_str = source_path.to_string_lossy().to_string();
+    let new_path_str = new_path.to_string_lossy().to_string();
+
+    let uri = format!("/file/{branch}/{source_path_str}");
+    log::debug!("mv_file {uri:?}, new_path {new_path_str:?}");
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+
+    let client = client::new_for_url(&url)?;
+
+    // Build JSON body
+    let mut body = serde_json::json!({
+        "new_path": new_path_str
+    });
+
+    if let Some(commit) = commit_body {
+        body["name"] = serde_json::Value::String(commit.author);
+        body["email"] = serde_json::Value::String(commit.email);
+        body["message"] = serde_json::Value::String(commit.message);
+    }
+
+    let req = client
+        .patch(&url)
+        .header("Content-Type", "application/json")
+        .body(body.to_string());
+
+    let res = req.send().await?;
+    let body = client::parse_json_body(&url, res).await?;
+    let response: CommitResponse = serde_json::from_str(&body)?;
+    Ok(response)
+}
+
 /// Delete a file in place (rm from a temp workspace and commit)
 pub async fn delete_file(
     remote_repo: &RemoteRepository,
@@ -342,6 +385,59 @@ mod tests {
 
             // Verify the file is deleted
             assert!(!file_path.exists(), "File should be deleted after deletion");
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_mv_file() -> Result<(), OxenError> {
+        test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
+            let branch_name = "main";
+
+            // File to move
+            let source_path = "train/dog_1.jpg";
+            let new_path = "renamed/images/dog_moved.jpg";
+
+            // Verify the file exists before moving
+            let file_path = local_repo.path.join(source_path);
+            assert!(file_path.exists(), "Source file should exist before move");
+
+            // Move the file
+            let mv_commit_body = NewCommitBody {
+                author: "Test Author".to_string(),
+                email: "test@example.com".to_string(),
+                message: "Move file to new location".to_string(),
+            };
+
+            let mv_response = api::client::file::mv_file(
+                &remote_repo,
+                branch_name,
+                source_path,
+                new_path,
+                Some(mv_commit_body),
+            )
+            .await?;
+
+            assert_eq!(mv_response.status.status_message, "resource_updated");
+            assert!(mv_response.commit.message.contains("Move file to new location"));
+
+            // Pull the changes
+            repositories::pull(&local_repo).await?;
+
+            // Verify the file is at the new location
+            let new_file_path = local_repo.path.join(new_path);
+            assert!(
+                new_file_path.exists(),
+                "File should exist at new location after move"
+            );
+
+            // Verify the file is no longer at the original location
+            assert!(
+                !file_path.exists(),
+                "File should not exist at original location after move"
+            );
 
             Ok(remote_repo)
         })

--- a/oxen-rust/src/lib/src/core/v_latest/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/workspaces/files.rs
@@ -764,7 +764,7 @@ fn has_dir_node(
 
 /// Move or rename a file within a workspace.
 /// This stages the old path as "Removed" and the new path as "Added".
-pub async fn mv(
+pub fn mv(
     workspace: &Workspace,
     path: impl AsRef<Path>,
     new_path: impl AsRef<Path>,

--- a/oxen-rust/src/lib/src/core/v_latest/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/workspaces/files.rs
@@ -816,6 +816,11 @@ pub async fn mv(
     let seen_dirs = Arc::new(Mutex::new(HashSet::new()));
 
     with_staged_db_manager(workspace_repo, |staged_db_manager| {
+        if staged_db_manager.read_from_staged_db(new_path)?.is_some() {
+            return Err(OxenError::basic_str(format!(
+                "Destination already staged: {new_path:?}"
+            )));
+        }
         // Add the file node at the new path
         staged_db_manager.upsert_file_node(new_path, new_status, &new_file_node)?;
 
@@ -828,7 +833,6 @@ pub async fn mv(
                 StagedEntryStatus::Removed,
                 &removed_file_node,
             )?;
-
             // Add parent directories for the removed path
             if let Some(parents) = path.parent() {
                 for dir in parents.ancestors() {

--- a/oxen-rust/src/lib/src/repositories/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/repositories/workspaces/files.rs
@@ -118,9 +118,7 @@ mod tests {
             let original_path = Path::new("annotations")
                 .join("train")
                 .join("bounding_box.csv");
-            let new_path = Path::new("renamed")
-                .join("data")
-                .join("bbox_renamed.csv");
+            let new_path = Path::new("renamed").join("data").join("bbox_renamed.csv");
 
             // Move the file
             let result = workspaces::files::mv(&workspace, &original_path, &new_path).await?;

--- a/oxen-rust/src/lib/src/repositories/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/repositories/workspaces/files.rs
@@ -79,14 +79,14 @@ pub async fn upload_zip(
     }
 }
 
-pub async fn mv(
+pub fn mv(
     workspace: &Workspace,
     path: impl AsRef<Path>,
     new_path: impl AsRef<Path>,
 ) -> Result<PathBuf, OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::workspaces::files::mv(workspace, path, new_path).await,
+        _ => core::v_latest::workspaces::files::mv(workspace, path, new_path),
     }
 }
 
@@ -121,7 +121,7 @@ mod tests {
             let new_path = Path::new("renamed").join("data").join("bbox_renamed.csv");
 
             // Move the file
-            let result = workspaces::files::mv(&workspace, &original_path, &new_path).await?;
+            let result = workspaces::files::mv(&workspace, &original_path, &new_path)?;
             assert_eq!(result, new_path);
 
             // Check status - should show the original as removed and new as added

--- a/oxen-rust/src/lib/src/repositories/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/repositories/workspaces/files.rs
@@ -78,3 +78,111 @@ pub async fn upload_zip(
         }
     }
 }
+
+pub async fn mv(
+    workspace: &Workspace,
+    path: impl AsRef<Path>,
+    new_path: impl AsRef<Path>,
+) -> Result<PathBuf, OxenError> {
+    match workspace.base_repo.min_version() {
+        MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
+        _ => core::v_latest::workspaces::files::mv(workspace, path, new_path).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::config::UserConfig;
+    use crate::error::OxenError;
+    use crate::model::NewCommitBody;
+    use crate::repositories::{self, workspaces};
+    use crate::test;
+
+    #[tokio::test]
+    async fn test_mv_file_in_workspace() -> Result<(), OxenError> {
+        // Skip workspace ops on windows
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let branch_name = "test-mv";
+            let branch = repositories::branches::create_checkout(&repo, branch_name)?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
+            let workspace_id = UserConfig::identifier()?;
+            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+
+            // Original file path that exists in the repo
+            let original_path = Path::new("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+            let new_path = Path::new("renamed")
+                .join("data")
+                .join("bbox_renamed.csv");
+
+            // Move the file
+            let result = workspaces::files::mv(&workspace, &original_path, &new_path).await?;
+            assert_eq!(result, new_path);
+
+            // Check status - should show the original as removed and new as added
+            let status = workspaces::status::status(&workspace)?;
+            println!("Status after mv: {:?}", status);
+
+            // The original path should be staged as removed in staged_files
+            let removed_entry = status.staged_files.get(&original_path);
+            assert!(
+                removed_entry.is_some(),
+                "Original path should be in staged_files"
+            );
+            assert_eq!(
+                removed_entry.unwrap().status,
+                crate::model::StagedEntryStatus::Removed,
+                "Original path should have Removed status"
+            );
+
+            // The new path should be in staged_files with Added status
+            let added_entry = status.staged_files.get(&new_path);
+            assert!(added_entry.is_some(), "New path should be staged");
+            assert_eq!(
+                added_entry.unwrap().status,
+                crate::model::StagedEntryStatus::Added,
+                "New path should have Added status"
+            );
+
+            // The move should be detected
+            assert!(
+                !status.moved_files.is_empty(),
+                "Move should be detected in moved_files"
+            );
+
+            // Commit the workspace and verify the file is at the new location
+            let user = UserConfig::get()?.to_user();
+            let new_commit = NewCommitBody {
+                author: user.name.clone(),
+                email: user.email.clone(),
+                message: "Moved file to new location".to_string(),
+            };
+            let commit =
+                workspaces::commit(&workspace, &new_commit, branch_name.to_string()).await?;
+
+            // Verify the file exists at the new path in the commit
+            let new_file = repositories::tree::get_file_by_path(&repo, &commit, &new_path)?;
+            assert!(
+                new_file.is_some(),
+                "File should exist at new path after commit"
+            );
+
+            // Verify the file no longer exists at the original path
+            let old_file = repositories::tree::get_file_by_path(&repo, &commit, &original_path)?;
+            assert!(
+                old_file.is_none(),
+                "File should not exist at original path after commit"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+}

--- a/oxen-rust/src/lib/src/view/workspaces.rs
+++ b/oxen-rust/src/lib/src/view/workspaces.rs
@@ -73,7 +73,8 @@ pub struct ValidateUploadFeasibilityRequest {
     pub size: u64,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct RenameRequest {
+    #[schema(example = "path/to/new_file.txt")]
     pub new_path: String,
 }

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -468,7 +468,7 @@ pub async fn mv(req: HttpRequest, body: String) -> actix_web::Result<HttpRespons
 
     // Stage the move
     log::debug!("file::mv moving {source_path:?} to {new_path:?}");
-    repositories::workspaces::files::mv(&workspace, &source_path, &new_path).await?;
+    repositories::workspaces::files::mv(&workspace, &source_path, &new_path)?;
 
     // Commit workspace
     let commit_body = NewCommitBody {

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -31,7 +31,7 @@ use utoipa::ToSchema;
     title = "FileUploadBody",
     description = "Body for uploading a file via multipart/form-data",
     example = json!({
-        "file": "<binary data>", 
+        "file": "<binary data>",
         "message": "Adding a picture of a cow",
         "name": "bessie",
         "email": "bessie@oxen.ai"
@@ -373,6 +373,121 @@ pub async fn delete(
 
     Ok(HttpResponse::Ok().json(CommitResponse {
         status: StatusMessage::resource_deleted(),
+        commit,
+    }))
+}
+
+#[derive(ToSchema, Deserialize)]
+#[schema(
+    title = "FileMoveBody",
+    description = "Body for moving/renaming a file",
+    example = json!({
+        "new_path": "new/path/to/file.txt",
+        "message": "Renamed file to new location",
+        "name": "bessie",
+        "email": "bessie@oxen.ai"
+    })
+)]
+pub struct FileMoveBody {
+    #[schema(example = "new/path/to/file.txt")]
+    pub new_path: String,
+    #[schema(example = "Moved file to new location")]
+    pub message: Option<String>,
+    #[schema(example = "bessie")]
+    pub name: Option<String>,
+    #[schema(example = "bessie@oxen.ai")]
+    pub email: Option<String>,
+}
+
+/// Move/Rename file
+#[utoipa::path(
+    patch,
+    path = "/api/repos/{namespace}/{repo_name}/file/{resource}",
+    tag = "Files",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("resource" = String, Path, description = "Path to the source file (including branch)", example = "main/train/images/old_name.jpg"),
+    ),
+    request_body(
+        content_type = "application/json",
+        content = FileMoveBody
+    ),
+    responses(
+        (status = 200, description = "File moved/renamed successfully", body = CommitResponse),
+        (status = 400, description = "Bad Request"),
+        (status = 404, description = "Branch or file not found")
+    )
+)]
+pub async fn mv(req: HttpRequest, body: String) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    log::debug!("file::mv path {:?}", req.path());
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let repo_name = path_param(&req, "repo_name")?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+
+    // Parse the resource (branch/commit/path)
+    let resource = parse_resource(&req, &repo)?;
+
+    // Resource must specify branch because we need to commit the workspace back to a branch
+    let branch = resource
+        .branch
+        .clone()
+        .ok_or(OxenError::local_branch_not_found(
+            resource.version.to_string_lossy(),
+        ))?;
+    let commit = resource.commit.clone().ok_or(OxenHttpError::NotFound)?;
+    let source_path = resource.path;
+
+    // Parse the request body
+    let body: FileMoveBody = serde_json::from_str(&body)?;
+
+    // Validate new_path
+    if body.new_path.is_empty() {
+        return Err(OxenHttpError::BadRequest("new_path cannot be empty".into()));
+    }
+
+    let new_path = PathBuf::from(&body.new_path);
+
+    // Verify source file exists
+    if repositories::entries::get_file(&repo, &commit, &source_path)?.is_none() {
+        return Err(OxenHttpError::NotFound);
+    }
+
+    // Check if new_path already exists
+    if repositories::entries::get_file(&repo, &commit, &new_path)?.is_some() {
+        return Err(OxenHttpError::BadRequest(
+            "new_path already exists in the repository".into(),
+        ));
+    }
+
+    log::debug!("file::mv creating workspace for commit: {commit}");
+    let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
+
+    // Stage the move
+    log::debug!("file::mv moving {source_path:?} to {new_path:?}");
+    repositories::workspaces::files::mv(&workspace, &source_path, &new_path).await?;
+
+    // Commit workspace
+    let commit_body = NewCommitBody {
+        author: body.name.clone().unwrap_or_default(),
+        email: body.email.clone().unwrap_or_default(),
+        message: body.message.clone().unwrap_or_else(|| {
+            format!(
+                "Move {} to {}",
+                source_path.to_string_lossy(),
+                new_path.to_string_lossy()
+            )
+        }),
+    };
+
+    let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
+
+    log::debug!("file::mv workspace commit ✅ success! commit {commit:?}");
+
+    Ok(HttpResponse::Ok().json(CommitResponse {
+        status: StatusMessage::resource_updated(),
         commit,
     }))
 }

--- a/oxen-rust/src/server/src/controllers/versions/chunks.rs
+++ b/oxen-rust/src/server/src/controllers/versions/chunks.rs
@@ -61,7 +61,7 @@ pub async fn upload(
         .await
         .map_err(|e| OxenHttpError::BasicError(e.to_string().into()))?;
 
-    Ok(HttpResponse::Ok().json(StatusMessage::resource_found()))
+    Ok(HttpResponse::Ok().json(StatusMessage::resource_created()))
 }
 
 pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttpError> {

--- a/oxen-rust/src/server/src/controllers/workspaces/files.rs
+++ b/oxen-rust/src/server/src/controllers/workspaces/files.rs
@@ -562,12 +562,13 @@ pub async fn mv(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttp
     // Parse request body
     let body: RenameRequest = serde_json::from_str(&body)?;
 
-    // Validate new_path
+    // Validate new_path is not empty
     if body.new_path.is_empty() {
         return Err(OxenHttpError::BadRequest("new_path cannot be empty".into()));
     }
 
-    let new_path = PathBuf::from(&body.new_path);
+    // Validate and normalize new_path
+    let new_path = util::fs::validate_and_normalize_path(&body.new_path)?;
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()

--- a/oxen-rust/src/server/src/controllers/workspaces/files.rs
+++ b/oxen-rust/src/server/src/controllers/workspaces/files.rs
@@ -212,7 +212,7 @@ pub async fn get(
         ("path" = String, Path, description = "The directory to upload the file to", example = "data/train")
     ),
     request_body(
-        content_type = "multipart/form-data", 
+        content_type = "multipart/form-data",
         description = "Multipart upload of file. Form field 'file' should be the file content.",
         content = FileUpload,
     ),
@@ -576,7 +576,7 @@ pub async fn mv(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttp
     };
 
     // Check if new_path already exists in the workspace or base repo
-    if repositories::entries::get_file(&repo, &workspace.commit, &new_path)?.is_some() {
+    if repositories::tree::get_node_by_path(&repo, &workspace.commit, &new_path)?.is_some() {
         return Err(OxenHttpError::BadRequest(
             "new_path already exists in the repository".into(),
         ));
@@ -586,7 +586,7 @@ pub async fn mv(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttp
     if util::fs::is_tabular(&path) {
         repositories::workspaces::data_frames::rename(&workspace, &path, &new_path).await?;
     } else {
-        repositories::workspaces::files::mv(&workspace, &path, &new_path).await?;
+        repositories::workspaces::files::mv(&workspace, &path, &new_path)?;
     }
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_updated()))

--- a/oxen-rust/src/server/src/controllers/workspaces/files.rs
+++ b/oxen-rust/src/server/src/controllers/workspaces/files.rs
@@ -13,6 +13,7 @@ use liboxen::model::Workspace;
 use liboxen::repositories;
 use liboxen::util;
 use liboxen::util::hasher;
+use liboxen::view::workspaces::RenameRequest;
 use liboxen::view::{
     ErrorFileInfo, ErrorFilesResponse, FilePathsResponse, FileWithHash, StatusMessage,
     StatusMessageDescription,
@@ -526,6 +527,68 @@ pub async fn validate(req: HttpRequest, _body: String) -> Result<HttpResponse, O
     };
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_found()))
+}
+
+/// Move or rename a file within the workspace
+#[utoipa::path(
+    patch,
+    path = "/{namespace}/{repo_name}/workspaces/{workspace_id}/files/{path}",
+    tag = "Workspace Files",
+    params(
+        ("namespace" = String, Path, description = "The namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "The name of the repository", example = "ImageNet-1k"),
+        ("workspace_id" = String, Path, description = "The UUID of the workspace", example = "580c0587-c157-417b-9118-8686d63d2745"),
+        ("path" = String, Path, description = "The current path to the file to move/rename", example = "images/train/dog_1.jpg")
+    ),
+    request_body(
+        content = RenameRequest,
+        description = "The new path for the file",
+        example = json!({"new_path": "images/train/renamed_dog_1.jpg"})
+    ),
+    responses(
+        (status = 200, description = "File successfully moved/renamed", body = StatusMessage),
+        (status = 400, description = "Invalid request (empty new_path or new_path already exists)"),
+        (status = 404, description = "Workspace or file not found")
+    )
+)]
+pub async fn mv(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let repo_name = path_param(&req, "repo_name")?;
+    let workspace_id = path_param(&req, "workspace_id")?;
+    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let path = PathBuf::from(path_param(&req, "path")?);
+
+    // Parse request body
+    let body: RenameRequest = serde_json::from_str(&body)?;
+
+    // Validate new_path
+    if body.new_path.is_empty() {
+        return Err(OxenHttpError::BadRequest("new_path cannot be empty".into()));
+    }
+
+    let new_path = PathBuf::from(&body.new_path);
+
+    let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
+        return Ok(HttpResponse::NotFound()
+            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+    };
+
+    // Check if new_path already exists in the workspace or base repo
+    if repositories::entries::get_file(&repo, &workspace.commit, &new_path)?.is_some() {
+        return Err(OxenHttpError::BadRequest(
+            "new_path already exists in the repository".into(),
+        ));
+    }
+
+    // For tabular files, use the data_frames rename instead
+    if util::fs::is_tabular(&path) {
+        repositories::workspaces::data_frames::rename(&workspace, &path, &new_path).await?;
+    } else {
+        repositories::workspaces::files::mv(&workspace, &path, &new_path).await?;
+    }
+
+    Ok(HttpResponse::Ok().json(StatusMessage::resource_updated()))
 }
 
 // Read the payload files into memory, compute the hash, and save to version store

--- a/oxen-rust/src/server/src/services/file.rs
+++ b/oxen-rust/src/server/src/services/file.rs
@@ -8,6 +8,7 @@ pub fn file() -> Scope {
         .route("/{resource:.*}", web::get().to(controllers::file::get))
         .route("/{resource:.*}", web::head().to(controllers::file::get))
         .route("/{resource:.*}", web::put().to(controllers::file::put))
+        .route("/{resource:.*}", web::patch().to(controllers::file::mv))
         .route(
             "/{resource:.*}",
             web::delete().to(controllers::file::delete),

--- a/oxen-rust/src/server/src/services/workspaces.rs
+++ b/oxen-rust/src/server/src/services/workspaces.rs
@@ -45,6 +45,10 @@ pub fn workspace() -> Scope {
                 )
                 .route(
                     "/files/{path:.*}",
+                    web::patch().to(controllers::workspaces::files::mv),
+                )
+                .route(
+                    "/files/{path:.*}",
                     web::get().to(controllers::workspaces::files::get),
                 )
                 .route(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Move/rename files within repositories and workspaces via PATCH endpoints (server + client support).
  * File move operations accept optional commit metadata (author name, email, message).
  * Added workspace-level move API and workspace move within repo workflows.
  * Path validation/normalization utility to enforce safe target paths.

* **Improvements**
  * Workspace rename request now serializable with an example in the API schema.

* **Bug Fixes**
  * Chunk upload completion now returns resource-created.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->