### PR TITLE
Allow creating workspace on an empty repo, Workspace create endpoint refactor

### DIFF
--- a/oxen-rust/src/lib/src/api/client/workspaces.rs
+++ b/oxen-rust/src/lib/src/api/client/workspaces.rs
@@ -145,50 +145,6 @@ pub async fn create_with_path(
     }
 }
 
-// Creates a new branch on the remote and instantiates a workspace
-pub async fn create_with_new_branch(
-    remote_repo: &RemoteRepository,
-    branch_name: impl AsRef<str>,
-    workspace_id: impl AsRef<str>,
-    path: impl AsRef<Path>,
-    workspace_name: Option<String>,
-) -> Result<WorkspaceResponseWithStatus, OxenError> {
-    let branch_name = branch_name.as_ref();
-    let workspace_id = workspace_id.as_ref();
-    let path = path.as_ref();
-    let url =
-        api::endpoint::url_from_repo(remote_repo, &format!("/workspaces/{workspace_id}/new"))?;
-    log::debug!("create workspace {url} with new branch {branch_name}\n");
-
-    let body = NewWorkspace {
-        branch_name: branch_name.to_string(),
-        workspace_id: workspace_id.to_string(),
-        // These two are needed for the oxen hub right now, ignored by the server
-        resource_path: Some(path.to_str().unwrap().to_string()),
-        entity_type: Some("user".to_string()),
-        name: workspace_name,
-        force: Some(true),
-    };
-
-    let client = client::new_for_url(&url)?;
-    let res = client.put(&url).json(&body).send().await?;
-
-    let body = client::parse_json_body(&url, res).await?;
-    log::debug!("create_workspace_with_new_branch got body: {body}");
-    let response: Result<WorkspaceResponseView, serde_json::Error> = serde_json::from_str(&body);
-    match response {
-        Ok(val) => Ok(WorkspaceResponseWithStatus {
-            id: val.workspace.id,
-            name: val.workspace.name,
-            commit: val.workspace.commit,
-            status: val.status.status_message,
-        }),
-        Err(err) => Err(OxenError::basic_str(format!(
-            "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
-        ))),
-    }
-}
-
 pub async fn delete(
     remote_repo: &RemoteRepository,
     workspace_id: impl AsRef<str>,

--- a/oxen-rust/src/lib/src/core/v_latest/clone.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/clone.rs
@@ -103,7 +103,7 @@ pub async fn clone_repo_remote_mode(
         local_repo.set_vfs(None);
     }
 
-    let workspace = api::client::workspaces::create_with_new_branch(
+    let workspace = api::client::workspaces::create_with_path(
         &remote_repo,
         &branch_name,
         &workspace_id,

--- a/oxen-rust/src/lib/src/core/v_latest/commits.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/commits.rs
@@ -327,8 +327,7 @@ pub fn create_initial_commit(
     };
 
     // Compute the commit hash
-    let commit_id =
-        repositories::commits::commit_writer::compute_commit_id(&new_commit)?;
+    let commit_id = repositories::commits::commit_writer::compute_commit_id(&new_commit)?;
 
     // Create the commit node
     let commit_node = CommitNode::new(
@@ -366,7 +365,7 @@ pub fn create_initial_commit(
 
     // Create the branch pointing to this commit
     with_ref_manager(repo, |manager| {
-        manager.create_branch(branch_name, &commit_id.to_string())
+        manager.create_branch(branch_name, commit_id.to_string())
     })?;
 
     // Set HEAD to the new branch

--- a/oxen-rust/src/lib/src/core/v_latest/commits.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/commits.rs
@@ -87,14 +87,8 @@ pub fn commit_allow_empty(
         };
 
         // Compute the commit hash
-        let mut hasher = xxhash_rust::xxh3::Xxh3::new();
-        hasher.update(b"commit");
-        hasher.update(format!("{:?}", new_commit_data.parent_ids).as_bytes());
-        hasher.update(new_commit_data.message.as_bytes());
-        hasher.update(new_commit_data.author.as_bytes());
-        hasher.update(new_commit_data.email.as_bytes());
-        hasher.update(&new_commit_data.timestamp.unix_timestamp().to_le_bytes());
-        let commit_hash = MerkleHash::new(hasher.digest128());
+        let commit_hash =
+            repositories::commits::commit_writer::compute_commit_id(&new_commit_data)?;
 
         let new_commit = Commit::from_new_and_id(&new_commit_data, commit_hash.to_string());
 

--- a/oxen-rust/src/lib/src/core/v_latest/commits.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/commits.rs
@@ -366,7 +366,8 @@ pub fn create_initial_commit(
 
     // Initialize the dir_hash_db with the root directory hash
     let commit_id_string = commit_id.to_string();
-    let dir_hash_db_path = CommitMerkleTree::dir_hash_db_path_from_commit_id(repo, &commit_id_string);
+    let dir_hash_db_path =
+        CommitMerkleTree::dir_hash_db_path_from_commit_id(repo, &commit_id_string);
     let dir_hash_db: DBWithThreadMode<SingleThreaded> =
         DBWithThreadMode::open(&opts::default(), dunce::simplified(&dir_hash_db_path))?;
     str_val_db::put(&dir_hash_db, "", &dir_node.hash().to_string())?;

--- a/oxen-rust/src/lib/src/repositories/commits.rs
+++ b/oxen-rust/src/lib/src/repositories/commits.rs
@@ -149,6 +149,23 @@ pub fn create_empty_commit(
     }
 }
 
+/// Create an initial empty commit for an empty repository.
+/// This creates the first commit with an empty tree and sets up the branch.
+/// Returns an error if the repository already has commits.
+pub fn create_initial_commit(
+    repo: &LocalRepository,
+    branch_name: impl AsRef<str>,
+    user: &User,
+    message: impl AsRef<str>,
+) -> Result<Commit, OxenError> {
+    let branch_name = branch_name.as_ref();
+    let message = message.as_ref();
+    match repo.min_version() {
+        MinOxenVersion::V0_10_0 => panic!("create_initial_commit not supported in v0.10.0"),
+        _ => core::v_latest::commits::create_initial_commit(repo, branch_name, user, message),
+    }
+}
+
 /// List commits on the current branch from HEAD
 pub fn list(repo: &LocalRepository) -> Result<Vec<Commit>, OxenError> {
     match repo.min_version() {

--- a/oxen-rust/src/lib/src/repositories/commits/commit_writer.rs
+++ b/oxen-rust/src/lib/src/repositories/commits/commit_writer.rs
@@ -783,7 +783,7 @@ fn split_into_vnodes(
     Ok(results)
 }
 
-fn compute_commit_id(new_commit: &NewCommit) -> Result<MerkleHash, OxenError> {
+pub fn compute_commit_id(new_commit: &NewCommit) -> Result<MerkleHash, OxenError> {
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();
     hasher.update(b"commit");
     hasher.update(format!("{:?}", new_commit.parent_ids).as_bytes());

--- a/oxen-rust/src/server/src/controllers/workspaces.rs
+++ b/oxen-rust/src/server/src/controllers/workspaces.rs
@@ -2,8 +2,9 @@ use crate::errors::{OxenHttpError, WorkspaceBranch};
 use crate::helpers::get_repo;
 use crate::params::{app_data, path_param, NameParam};
 
+use liboxen::constants::INITIAL_COMMIT_MSG;
 use liboxen::error::OxenError;
-use liboxen::model::NewCommitBody;
+use liboxen::model::{NewCommitBody, User};
 use liboxen::repositories;
 use liboxen::view::merge::MergeableResponse;
 use liboxen::view::workspaces::{ListWorkspaceResponseView, NewWorkspace, WorkspaceResponse};
@@ -62,13 +63,43 @@ pub async fn get_or_create(
         }
     };
 
-    let Some(branch) = repositories::branches::get_by_name(&repo, &data.branch_name)? else {
-        return Ok(
-            HttpResponse::BadRequest().json(StatusMessage::error(format!(
-                "Branch not found: {}",
+    // Try to get the branch, or create it if the repo is empty
+    let branch = match repositories::branches::get_by_name(&repo, &data.branch_name)? {
+        Some(branch) => branch,
+        None => {
+            // Branch doesn't exist - check if repo is empty
+            if repositories::commits::head_commit_maybe(&repo)?.is_some() {
+                // Repo has commits but branch doesn't exist - this is an error
+                return Ok(
+                    HttpResponse::BadRequest().json(StatusMessage::error(format!(
+                        "Branch not found: {}. For non-empty repositories, create the branch first.",
+                        data.branch_name
+                    ))),
+                );
+            }
+
+            // Repo is empty - create initial commit with the requested branch
+            log::debug!(
+                "get_or_create: empty repo, creating initial commit on branch {}",
                 data.branch_name
-            ))),
-        );
+            );
+            let user = User {
+                name: "Oxen".to_string(),
+                email: "oxen@oxen.ai".to_string(),
+            };
+            repositories::commits::create_initial_commit(
+                &repo,
+                &data.branch_name,
+                &user,
+                INITIAL_COMMIT_MSG,
+            )?;
+
+            // Now get the newly created branch
+            repositories::branches::get_by_name(&repo, &data.branch_name)?
+                .ok_or_else(|| {
+                    OxenError::basic_str("Failed to create initial branch")
+                })?
+        }
     };
 
     // Return workspace if it already exists
@@ -153,6 +184,10 @@ pub async fn get(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpEr
 }
 
 /// Create a new workspace
+///
+/// **DEPRECATED**: Use PUT (get_or_create) instead. This endpoint now delegates to get_or_create
+/// for consistent idempotent behavior. The POST method is retained for backward compatibility.
+#[deprecated(note = "Use PUT /workspaces (get_or_create) instead")]
 #[utoipa::path(
     post,
     path = "/api/repos/{namespace}/{repo_name}/workspaces",
@@ -165,7 +200,7 @@ pub async fn get(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpEr
     ),
     request_body(
         content = NewWorkspace,
-        description = "Workspace creation details.",
+        description = "Workspace creation details. DEPRECATED: Use PUT method instead for idempotent get-or-create behavior.",
         example = json!({
             "branch_name": "main",
             "name": "bessie_workspace",
@@ -173,58 +208,18 @@ pub async fn get(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpEr
         })
     ),
     responses(
-        (status = 200, description = "Workspace created", body = WorkspaceResponseView),
+        (status = 200, description = "Workspace created or found", body = WorkspaceResponseView),
         (status = 400, description = "Invalid payload or branch not found"),
         (status = 404, description = "Repository not found")
     )
 )]
+#[allow(deprecated)]
 pub async fn create(
     req: HttpRequest,
     body: String,
 ) -> actix_web::Result<HttpResponse, OxenHttpError> {
-    let app_data = app_data(&req)?;
-    let namespace = path_param(&req, "namespace")?;
-    let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
-
-    let data: Result<NewWorkspace, serde_json::Error> = serde_json::from_str(&body);
-    let data = match data {
-        Ok(data) => data,
-        Err(err) => {
-            log::error!("Unable to parse body. Err: {err}\n{body}");
-            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
-        }
-    };
-
-    let Some(branch) = repositories::branches::get_by_name(&repo, &data.branch_name)? else {
-        return Ok(
-            HttpResponse::BadRequest().json(StatusMessage::error(format!(
-                "Branch not found: {}",
-                data.branch_name
-            ))),
-        );
-    };
-
-    let workspace_id = &data.workspace_id;
-    let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
-
-    // Create the workspace
-    repositories::workspaces::create_with_name(
-        &repo,
-        &commit,
-        workspace_id,
-        data.name.clone(),
-        true,
-    )?;
-
-    Ok(HttpResponse::Ok().json(WorkspaceResponseView {
-        status: StatusMessage::resource_created(),
-        workspace: WorkspaceResponse {
-            id: workspace_id.clone(),
-            name: data.name.clone(),
-            commit: commit.into(),
-        },
-    }))
+    // Delegate to get_or_create for consistent behavior
+    get_or_create(req, body).await
 }
 
 /// Create workspace from new branch

--- a/oxen-rust/src/server/src/main.rs
+++ b/oxen-rust/src/server/src/main.rs
@@ -111,7 +111,6 @@ const SUPPORT: &str = "
         crate::controllers::workspaces::get_or_create,
         crate::controllers::workspaces::get,
         crate::controllers::workspaces::create,
-        crate::controllers::workspaces::create_with_new_branch,
         crate::controllers::workspaces::list,
         crate::controllers::workspaces::clear,
         crate::controllers::workspaces::delete,

--- a/oxen-rust/src/server/src/services/workspaces.rs
+++ b/oxen-rust/src/server/src/services/workspaces.rs
@@ -8,7 +8,8 @@ pub mod data_frames;
 pub fn workspace() -> Scope {
     web::scope("/workspaces")
         .route("", web::put().to(controllers::workspaces::get_or_create))
-        .route("", web::post().to(controllers::workspaces::create))
+        // POST is deprecated - use PUT for idempotent get-or-create behavior
+        .route("", web::post().to(controllers::workspaces::get_or_create))
         .route("", web::get().to(controllers::workspaces::list))
         .route("", web::delete().to(controllers::workspaces::clear))
         .service(

--- a/oxen-rust/src/server/src/services/workspaces.rs
+++ b/oxen-rust/src/server/src/services/workspaces.rs
@@ -17,10 +17,6 @@ pub fn workspace() -> Scope {
                 .route("", web::get().to(controllers::workspaces::get))
                 .route("", web::delete().to(controllers::workspaces::delete))
                 .route(
-                    "/new",
-                    web::put().to(controllers::workspaces::create_with_new_branch),
-                )
-                .route(
                     "/changes",
                     web::get().to(controllers::workspaces::changes::list_root),
                 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create an initial commit automatically for empty repositories.

* **Improvements**
  * Workspace creation during clone supports explicit workspace names and better status reporting.
  * CLI: commit and workspace commands accept an optional --branch flag and show clearer errors when no branch is specified.
  * Workspace creation endpoints are now idempotent (safe to retry).

* **Deprecations**
  * POST /workspaces deprecated; prefer PUT /workspaces (get-or-create).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->