### PR TITLE
oxen workspace download falls-back to commit

### DIFF
--- a/oxen-rust/src/cli/src/cmd/workspace/download.rs
+++ b/oxen-rust/src/cli/src/cmd/workspace/download.rs
@@ -1,8 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 
+use liboxen::model::RemoteRepository;
+use liboxen::view::workspaces::WorkspaceResponse;
 use liboxen::{api, error::OxenError, model::LocalRepository};
 
 use crate::cmd::RunCmd;
@@ -23,16 +25,16 @@ impl RunCmd for WorkspaceDownloadCmd {
                     .long("workspace-id")
                     .short('w')
                     .required_unless_present("workspace-name")
-                    .help("The workspace ID of the workspace")
-                    .conflicts_with("workspace-name"),
+                    .conflicts_with("workspace-name")
+                    .help("The workspace ID of the workspace"),
             )
             .arg(
                 Arg::new("workspace-name")
                     .long("workspace-name")
                     .short('n')
                     .required_unless_present("workspace-id")
-                    .help("The name of the workspace")
-                    .conflicts_with("workspace-id"),
+                    .conflicts_with("workspace-id")
+                    .help("The name of the workspace"),
             )
             .arg(
                 Arg::new("file")
@@ -52,7 +54,9 @@ impl RunCmd for WorkspaceDownloadCmd {
 
     async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
         // Parse Args
-        let file_path = args.get_one::<String>("file").expect("Must supply file");
+        let file_path = args
+            .get_one::<String>("file")
+            .map_or_else(|| Err(OxenError::basic_str("Must supply --file (-f)")), Ok)?;
 
         let workspace_name = args.get_one::<String>("workspace-name");
         let workspace_id = args.get_one::<String>("workspace-id");
@@ -61,31 +65,83 @@ impl RunCmd for WorkspaceDownloadCmd {
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(file_path));
 
-        let workspace_identifier = match workspace_id {
-            Some(id) => id,
-            None => {
-                // If no ID is provided, try to get the workspace by name
-                if let Some(name) = workspace_name {
-                    name
-                } else {
-                    return Err(OxenError::basic_str(
-                        "Either workspace-id or workspace-name must be provided.",
-                    ));
-                }
-            }
-        };
-
         let repository = LocalRepository::from_current_dir()?;
         let remote_repo = api::client::repositories::get_default_remote(&repository).await?;
 
-        api::client::workspaces::files::download(
-            &remote_repo,
-            workspace_identifier,
-            file_path,
-            Some(&output_path),
-        )
-        .await?;
+        let workspace: WorkspaceResponse = match (workspace_id, workspace_name) {
+            (Some(workspace_id), None) => api::client::workspaces::get(&remote_repo, workspace_id)
+                .await
+                .and_then(|w| match w {
+                    Some(workspace) => Ok(workspace),
+                    None => Err(workspace_not_found(&format!("ID={workspace_id}"))),
+                })?,
+            (None, Some(workspace_name)) => {
+                api::client::workspaces::get_by_name(&remote_repo, workspace_name)
+                    .await
+                    .and_then(|w| match w {
+                        Some(workspace) => Ok(workspace),
+                        None => Err(workspace_not_found(&format!("name={workspace_name}"))),
+                    })?
+            }
+            // This should never be reached due to clap's required_unless_present
+            _ => Err(OxenError::basic_str(
+                "Either --workspace-id or --workspace-name must be provided.",
+            ))?,
+        };
 
-        Ok(())
+        download(&remote_repo, &workspace, file_path, output_path.as_path()).await
+    }
+}
+
+/// CLI-facing error message for when a workspace is not found.
+fn workspace_not_found(message: &str) -> OxenError {
+    // TODO: should be a `OxenError::WorkspaceNotFound` but this is debug-rendered in the CLI at the moment.
+    //       To control formatting exactly, it's an `OxenError::Basic`.
+    //
+    //       CLI error rendering needs to be updated so we can use error variants properly & have precise
+    //       error message formatting control.
+    // OxenError::WorkspaceNotFound(Box::new(StringError::new(format!("Workspace {message} does not exist"))))
+    OxenError::basic_str(format!("Workspace {message} does not exist"))
+}
+
+/// Downloads a file from a remote workspace, or from the workspace's base commit, to a local filepath.
+async fn download(
+    remote_repo: &RemoteRepository,
+    workspace: &WorkspaceResponse,
+    file_path: &str,
+    output_path: &Path,
+) -> Result<(), OxenError> {
+    // try to download file from workspace
+    match api::client::workspaces::files::download(
+        remote_repo,
+        &workspace.id,
+        file_path,
+        Some(output_path),
+    )
+    .await
+    {
+        // found it in the workspace!
+        Ok(_) => Ok(()),
+        // file doesn't exist in workspace
+        Err(OxenError::PathDoesNotExist(_)) => {
+            // try to download from the workspace's base commit
+            match api::client::entries::download_entry(
+                remote_repo,
+                Path::new(file_path),
+                output_path,
+                &workspace.commit.id,
+            )
+            .await
+            {
+                // found it in the commit!
+                Ok(_) => Ok(()),
+                // did not find it :(
+                Err(OxenError::PathDoesNotExist(_)) => Err(OxenError::basic_str(
+                    "File not found in workspace staged DB or base repo",
+                )),
+                unexpected_error => unexpected_error,
+            }
+        }
+        unexpected_error => unexpected_error,
     }
 }

--- a/oxen-rust/src/lib/src/api/client/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/api/client/workspaces/files.rs
@@ -1063,7 +1063,7 @@ pub async fn download(
     if response.status().is_success() {
         // Save the raw file contents from the response stream
         let output_path = output_path.unwrap_or_else(|| Path::new(path));
-        let output_dir = output_path.parent().unwrap_or(Path::new(""));
+        let output_dir = output_path.parent().unwrap_or_else(|| Path::new(""));
 
         if !output_dir.exists() {
             util::fs::create_dir_all(output_dir)?;
@@ -1079,12 +1079,12 @@ pub async fn download(
         file.flush().await?;
     } else {
         let status = response.status();
-        log::error!("api::client::workspace::files::download failed with status: {status}");
 
         if status == reqwest::StatusCode::NOT_FOUND {
-            return Err(OxenError::resource_not_found(path));
+            return Err(OxenError::path_does_not_exist(path));
         }
 
+        log::error!("api::client::workspace::files::download failed with status: {status}");
         let body = client::parse_json_body(&url, response).await?;
         return Err(OxenError::basic_str(format!(
             "Error: Could not download file {body:?}"
@@ -2047,6 +2047,37 @@ mod tests {
         .await
     }
 
+    // Test that downloading a non-existent file returns OxenError::ResourceNotFound
+    #[tokio::test]
+    async fn test_download_file_from_nonexistent_workspace() -> Result<(), OxenError> {
+        test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
+            let non_existent_workspace_id = "workspace_does_not_exist";
+
+            // Verify the workspace doesn't exist
+            let workspace =
+                api::client::workspaces::get(&remote_repo, non_existent_workspace_id).await?;
+            assert!(workspace.is_none());
+
+            // Try to download a file from the non-existent workspace
+            let temp_dir = TempDir::new()?;
+            let output_path = temp_dir.path().join("output.md");
+
+            let result = api::client::workspaces::files::download(
+                &remote_repo,
+                non_existent_workspace_id,
+                "README.md",
+                Some(&output_path),
+            )
+            .await;
+
+            assert!(result.is_err());
+            assert!(!output_path.exists());
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
     async fn make_workspace(
         remote_repo: &RemoteRepository,
     ) -> Result<WorkspaceResponseWithStatus, OxenError> {
@@ -2063,6 +2094,181 @@ mod tests {
             workspace_id, workspace.id
         );
         Ok(workspace)
+    }
+
+    // Test that downloading a file uploaded to the workspace works
+    #[tokio::test]
+    async fn test_download_uploaded_file_from_workspace() -> Result<(), OxenError> {
+        test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
+            let workspace_id = make_workspace(&remote_repo).await?.id;
+            let temp_dir = TempDir::new()?;
+
+            let test_filename = "file_to_upload.txt";
+            let test_file = {
+                let p = temp_dir.path().join(test_filename);
+                tokio::fs::write(&p, b"Hello world! How are you today?").await?;
+                p
+            };
+
+            let upload_path = {
+                let upload_path = "images";
+                api::client::workspaces::files::upload_single_file(
+                    &remote_repo,
+                    &workspace_id,
+                    upload_path,
+                    &test_file,
+                )
+                .await?;
+                upload_path
+            };
+
+            let output_path = {
+                let output_path = temp_dir.path().join("downloaded.jpeg");
+                let file_path = format!("{upload_path}/{test_filename}");
+                api::client::workspaces::files::download(
+                    &remote_repo,
+                    &workspace_id,
+                    &file_path,
+                    Some(&output_path),
+                )
+                .await?;
+                assert!(
+                    output_path.exists(),
+                    "Expecting to have downloaded file to: {}",
+                    output_path.display()
+                );
+                output_path
+            };
+
+            let downloaded_contents = tokio::fs::read_to_string(&output_path).await?;
+            assert_eq!(downloaded_contents, "Hello world! How are you today?");
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    // Test that downloading a non-existent file from workspace fails
+    #[tokio::test]
+    async fn test_download_nonexistent_file_from_workspace() -> Result<(), OxenError> {
+        test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
+            let workspace_id = make_workspace(&remote_repo).await?.id;
+            let temp_dir = TempDir::new()?;
+
+            let output_path = temp_dir.path().join("output.txt");
+
+            let result = api::client::workspaces::files::download(
+                &remote_repo,
+                &workspace_id,
+                "this_file_does_not_exist.txt",
+                Some(&output_path),
+            )
+            .await;
+
+            assert!(result.is_err(), "{result:?}");
+            assert!(
+                !output_path.exists(),
+                "Not expecting '{}' to exist",
+                output_path.display()
+            );
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    // Test the fallback path: download from commit when file not in workspace
+    // This tests the download_entry function which is used as fallback in CLI
+    #[tokio::test]
+    async fn test_download_entry_fallback_for_committed_file() -> Result<(), OxenError> {
+        test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
+            let workspace = make_workspace(&remote_repo).await?;
+            let temp_dir = TempDir::new()?;
+
+            // Download the README.md (which is in the commit, not uploaded to workspace)
+            // using download_entry (the fallback path in CLI)
+            let output_path = {
+                let output_path = temp_dir.path().join("fallback_readme.md");
+                api::client::entries::download_entry(
+                    &remote_repo,
+                    Path::new("README.md"),
+                    &output_path,
+                    &workspace.commit.id,
+                )
+                .await?;
+                assert!(
+                    output_path.exists(),
+                    "Expecting to have downloaded output to: {}",
+                    output_path.display()
+                );
+                output_path
+            };
+
+            let content = std::fs::read_to_string(&output_path)?;
+            assert!(!content.is_empty(), "Expecting non-empty README.md file");
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    // Test workspace lookup by name for download scenario
+    #[tokio::test]
+    async fn test_workspace_lookup_by_name_for_download() -> Result<(), OxenError> {
+        test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
+            let workspace_name = "my-download-workspace";
+            let workspace = {
+                let workspace_id = uuid::Uuid::new_v4().to_string();
+                let workspace = api::client::workspaces::create_with_name(
+                    &remote_repo,
+                    &constants::DEFAULT_BRANCH_NAME,
+                    &workspace_id,
+                    workspace_name,
+                )
+                .await?;
+                assert_eq!(workspace.id, workspace_id);
+                assert_eq!(workspace.name, Some(workspace_name.to_string()));
+                workspace
+            };
+
+            // Look up workspace by name (as CLI does)
+            let found_workspace =
+                api::client::workspaces::get_by_name(&remote_repo, workspace_name).await?;
+            assert!(found_workspace.is_some());
+            let found_workspace = found_workspace.unwrap();
+            assert_eq!(found_workspace.id, workspace.id);
+
+            let temp_dir = TempDir::new()?;
+            let output_path = temp_dir.path().join("readme_by_name.md");
+
+            api::client::workspaces::files::download(
+                &remote_repo,
+                &found_workspace.id,
+                "README.md",
+                Some(&output_path),
+            )
+            .await?;
+
+            assert!(output_path.exists());
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    // Test that workspace lookup by non-existent name returns None
+    #[tokio::test]
+    async fn test_workspace_lookup_by_nonexistent_name() -> Result<(), OxenError> {
+        test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
+            let non_existent_name = "workspace_name_does_not_exist";
+
+            let workspace =
+                api::client::workspaces::get_by_name(&remote_repo, non_existent_name).await?;
+            assert!(workspace.is_none());
+
+            Ok(remote_repo)
+        })
+        .await
     }
 
     // Test that downloading a non-existent file returns OxenError::ResourceNotFound


### PR DESCRIPTION
**`oxen-cli`**
Changes `oxen workspace download` so that:
- Workspace downloads now support lookup by workspace name in addition to ID.
- File downloads fall back to workspace commit when not found in the workspace.
- File downloads from named workspaces always work, even if the workspace is committed.
- Downloading from a non-existent workspace or a non-existent file in the workspace or the commit is an error.
  
**Bug Fixes**
- Improved error handling and messaging for missing workspaces and files
- Enhanced output path resolution for downloads
  
**Tests**
- Added comprehensive test coverage for workspace file download scenarios.