### PR TITLE
Add missing async_zip dependency to oxen-server

### DIFF
--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -5716,6 +5716,7 @@ dependencies = [
  "actix-web-httpauth",
  "astral-tokio-tar",
  "async-compression",
+ "async_zip",
  "bytesize",
  "clap",
  "derive_more 1.0.0",

--- a/oxen-rust/src/server/Cargo.toml
+++ b/oxen-rust/src/server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 actix-files = "0.6.6"
 actix-http = "3.0.4"
 async-compression = { version = "0.4.0", features = ["tokio", "gzip"] }
+async_zip = { version = "0.0.18", features = ["full"] }
 astral-tokio-tar = "0.5"
 url = "2.5.0"
 actix-multipart = "0.7.2"


### PR DESCRIPTION
Adds a missing dependency on `async_zip` to `oxen-server`.