### PR TITLE
File-serving routes to 404 instead of 500 for missing resources & CLI uses ResourceNotFound errors

### DIFF
--- a/oxen-rust/src/cli/src/cmd/workspace/download.rs
+++ b/oxen-rust/src/cli/src/cmd/workspace/download.rs
@@ -3,10 +3,13 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 
+use liboxen::view::workspaces::WorkspaceResponse;
 use liboxen::{api, error::OxenError, model::LocalRepository};
 
 use crate::cmd::RunCmd;
+
 pub const NAME: &str = "download";
+
 pub struct WorkspaceDownloadCmd;
 
 #[async_trait]
@@ -23,16 +26,16 @@ impl RunCmd for WorkspaceDownloadCmd {
                     .long("workspace-id")
                     .short('w')
                     .required_unless_present("workspace-name")
-                    .help("The workspace ID of the workspace")
-                    .conflicts_with("workspace-name"),
+                    .conflicts_with("workspace-name")
+                    .help("The workspace ID of the workspace"),
             )
             .arg(
                 Arg::new("workspace-name")
                     .long("workspace-name")
                     .short('n')
                     .required_unless_present("workspace-id")
-                    .help("The name of the workspace")
-                    .conflicts_with("workspace-id"),
+                    .conflicts_with("workspace-id")
+                    .help("The name of the workspace"),
             )
             .arg(
                 Arg::new("file")
@@ -52,7 +55,9 @@ impl RunCmd for WorkspaceDownloadCmd {
 
     async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
         // Parse Args
-        let file_path = args.get_one::<String>("file").expect("Must supply file");
+        let file_path = args
+            .get_one::<String>("file")
+            .map_or_else(|| Err(OxenError::basic_str("Must supply --file (-f)")), Ok)?;
 
         let workspace_name = args.get_one::<String>("workspace-name");
         let workspace_id = args.get_one::<String>("workspace-id");
@@ -61,31 +66,54 @@ impl RunCmd for WorkspaceDownloadCmd {
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(file_path));
 
-        let workspace_identifier = match workspace_id {
-            Some(id) => id,
-            None => {
-                // If no ID is provided, try to get the workspace by name
-                if let Some(name) = workspace_name {
-                    name
-                } else {
-                    return Err(OxenError::basic_str(
-                        "Either workspace-id or workspace-name must be provided.",
-                    ));
-                }
-            }
-        };
-
         let repository = LocalRepository::from_current_dir()?;
         let remote_repo = api::client::repositories::get_default_remote(&repository).await?;
 
-        api::client::workspaces::files::download(
+        let workspace: WorkspaceResponse = match (workspace_id, workspace_name) {
+            (Some(workspace_id), None) => api::client::workspaces::get(&remote_repo, workspace_id)
+                .await
+                .and_then(|w| match w {
+                    Some(workspace) => Ok(workspace),
+                    None => Err(workspace_not_found(&format!("ID={workspace_id}"))),
+                })?,
+            (None, Some(workspace_name)) => {
+                api::client::workspaces::get_by_name(&remote_repo, workspace_name)
+                    .await
+                    .and_then(|w| match w {
+                        Some(workspace) => Ok(workspace),
+                        None => Err(workspace_not_found(&format!("name={workspace_name}"))),
+                    })?
+            }
+            // This should never be reached due to clap's required_unless_present
+            _ => Err(OxenError::basic_str(
+                "Either --workspace-id or --workspace-name must be provided.",
+            ))?,
+        };
+
+        match api::client::workspaces::files::download(
             &remote_repo,
-            workspace_identifier,
+            &workspace.id,
             file_path,
             Some(&output_path),
         )
-        .await?;
-
-        Ok(())
+        .await
+        {
+            Ok(_) => Ok(()),
+            Err(OxenError::PathDoesNotExist(_)) => Err(OxenError::basic_str(
+                "File not found in workspace staged DB or base repo",
+            )),
+            unexpected_error => unexpected_error,
+        }
     }
+}
+
+/// CLI-facing error message for when a workspace is not found.
+fn workspace_not_found(message: &str) -> OxenError {
+    // TODO: should be a `OxenError::WorkspaceNotFound` but this is debug-rendered in the CLI at the moment.
+    //       To control formatting exactly, it's an `OxenError::Basic`.
+    //
+    //       CLI error rendering needs to be updated so we can use error variants properly & have precise
+    //       error message formatting control.
+    // OxenError::WorkspaceNotFound(Box::new(StringError::new(format!("Workspace {message} does not exist"))))
+    OxenError::basic_str(format!("Workspace {message} does not exist"))
 }

--- a/oxen-rust/src/server/src/errors.rs
+++ b/oxen-rust/src/server/src/errors.rs
@@ -554,7 +554,9 @@ impl error::ResponseError for OxenHttpError {
             OxenHttpError::InternalOxenError(error) => match error {
                 OxenError::RepoNotFound(_) => StatusCode::NOT_FOUND,
                 OxenError::RevisionNotFound(_) => StatusCode::NOT_FOUND,
+                OxenError::ResourceNotFound(_) => StatusCode::NOT_FOUND,
                 OxenError::InvalidSchema(_) => StatusCode::BAD_REQUEST,
+                OxenError::PathDoesNotExist(_) => StatusCode::NOT_FOUND,
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
             },
         }


### PR DESCRIPTION
**oxen-server**
Return proper 404 responses in:
- `versions::{download, download_streaming}`
- `workspaces::files::get`
- `workspaces::data_frames::download`

This makes these routes mirror existing behavior on other routes.
The server is now consistent in its responses for handling non-existent resources.

Routes `download` and `download_streaming` now client error if the `path` parameter
is malformed.

**oxen-cli**
Check HTTP status in:
- `workspaces::files::download`
- `workspaces::data_frames::download`
Mapping both function's detection of a 404 response to `OxenError::ResourceNotFound`.

**Testing**
Added new client & server tests to ensure proper handling of 404s.