### PR TITLE
Add repository and namespace name validation

### DIFF
--- a/oxen-rust/src/lib/src/error.rs
+++ b/oxen-rust/src/lib/src/error.rs
@@ -151,6 +151,10 @@ impl fmt::Display for OxenError {
             OxenError::OxenUpdateRequired(err)
             | OxenError::Basic(err)
             | OxenError::ThumbnailingNotEnabled(err) => write!(f, "{err}"),
+            OxenError::InvalidRepoName(name) => write!(
+                f,
+                "Invalid repository or namespace name '{name}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+"
+            ),
             _ => {
                 write!(f, "{self:?}")
             }

--- a/oxen-rust/src/lib/src/error.rs
+++ b/oxen-rust/src/lib/src/error.rs
@@ -47,6 +47,7 @@ pub enum OxenError {
     LocalRepoNotFound(Box<PathBufError>),
     RepoAlreadyExists(Box<RepoNew>),
     RepoAlreadyExistsAtDestination(Box<StringError>),
+    InvalidRepoName(StringError),
 
     // Fork
     ForkStatusNotFound(StringError),
@@ -255,6 +256,10 @@ impl OxenError {
 
     pub fn parsed_resource_not_found(resource: ParsedResource) -> Self {
         OxenError::ParsedResourceNotFound(Box::new(resource.resource.into()))
+    }
+
+    pub fn invalid_repo_name(s: impl AsRef<str>) -> Self {
+        OxenError::InvalidRepoName(StringError::from(s.as_ref()))
     }
 
     pub fn repo_already_exists(repo: RepoNew) -> Self {

--- a/oxen-rust/src/lib/src/repositories.rs
+++ b/oxen-rust/src/lib/src/repositories.rs
@@ -203,22 +203,38 @@ pub fn transfer_namespace(
     }
 }
 
+/// Validates that a name matches the pattern `^[[:alnum:]][[:alnum:]_.-]+$`:
+/// - Starts with an alphanumeric character
+/// - Followed by one or more alphanumeric characters, underscores, dots, or hyphens
+/// - At least 2 characters total
+fn is_valid_repo_name(name: &str) -> bool {
+    if name.len() < 2 {
+        return false;
+    }
+    let mut chars = name.chars();
+    let first = chars.next().unwrap();
+    if !first.is_ascii_alphanumeric() {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-')
+}
+
 pub async fn create(
     root_dir: &Path,
     new_repo: RepoNew,
 ) -> Result<LocalRepositoryWithEntries, OxenError> {
-    // Validate repo name does not contain spaces
-    if new_repo.name.contains(' ') {
+    // Validate repo name matches ^[[:alnum:]][[:alnum:]_.-]+$
+    if !is_valid_repo_name(&new_repo.name) {
         return Err(OxenError::invalid_repo_name(format!(
-            "Repository name '{}' cannot contain spaces",
+            "Invalid repository name '{}'. Names must be at least 2 characters and match [a-zA-Z0-9][a-zA-Z0-9_.-]+",
             new_repo.name
         )));
     }
 
-    // Validate namespace does not contain spaces
-    if new_repo.namespace.contains(' ') {
+    // Validate namespace matches the same pattern
+    if !is_valid_repo_name(&new_repo.namespace) {
         return Err(OxenError::invalid_repo_name(format!(
-            "Namespace '{}' cannot contain spaces",
+            "Invalid namespace '{}'. Namespaces must be at least 2 characters and match [a-zA-Z0-9][a-zA-Z0-9_.-]+",
             new_repo.namespace
         )));
     }
@@ -464,8 +480,39 @@ mod tests {
         .await
     }
 
+    #[test]
+    fn test_is_valid_repo_name_accepts_valid_names() {
+        // Basic alphanumeric
+        assert!(repositories::is_valid_repo_name("my-repo"));
+        assert!(repositories::is_valid_repo_name("my_repo"));
+        assert!(repositories::is_valid_repo_name("my.repo"));
+        assert!(repositories::is_valid_repo_name("MyRepo123"));
+        assert!(repositories::is_valid_repo_name("a1"));
+        assert!(repositories::is_valid_repo_name("Cat-Dog-Classifier"));
+        assert!(repositories::is_valid_repo_name("v2.0.1"));
+        assert!(repositories::is_valid_repo_name("test_repo.v2"));
+    }
+
+    #[test]
+    fn test_is_valid_repo_name_rejects_invalid_names() {
+        // Spaces
+        assert!(!repositories::is_valid_repo_name("repo with spaces"));
+        // Starts with non-alphanumeric
+        assert!(!repositories::is_valid_repo_name("-repo"));
+        assert!(!repositories::is_valid_repo_name(".repo"));
+        assert!(!repositories::is_valid_repo_name("_repo"));
+        // Too short (must be at least 2 chars)
+        assert!(!repositories::is_valid_repo_name("a"));
+        assert!(!repositories::is_valid_repo_name(""));
+        // Contains special characters
+        assert!(!repositories::is_valid_repo_name("repo/name"));
+        assert!(!repositories::is_valid_repo_name("repo@name"));
+        assert!(!repositories::is_valid_repo_name("repo name"));
+        assert!(!repositories::is_valid_repo_name("repo!name"));
+    }
+
     #[tokio::test]
-    async fn test_local_repository_api_create_rejects_name_with_spaces() -> Result<(), OxenError> {
+    async fn test_local_repository_api_create_rejects_invalid_name() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|sync_dir| async move {
             let namespace = "test-namespace";
             let name = "repo with spaces";
@@ -474,12 +521,7 @@ mod tests {
 
             assert!(result.is_err());
             match result.unwrap_err() {
-                OxenError::InvalidRepoName(msg) => {
-                    assert!(
-                        msg.to_string().contains("cannot contain spaces"),
-                        "Error message should mention spaces, got: {msg}"
-                    );
-                }
+                OxenError::InvalidRepoName(_) => {}
                 other => panic!("Expected InvalidRepoName error, got: {other:?}"),
             }
 
@@ -489,22 +531,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_local_repository_api_create_rejects_namespace_with_spaces(
-    ) -> Result<(), OxenError> {
+    async fn test_local_repository_api_create_rejects_invalid_namespace() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|sync_dir| async move {
-            let namespace = "namespace with spaces";
+            let namespace = "-invalid-namespace";
             let name = "valid-repo";
             let repo_new = RepoNew::from_namespace_name(namespace, name, None);
             let result = repositories::create(&sync_dir, repo_new).await;
 
             assert!(result.is_err());
             match result.unwrap_err() {
-                OxenError::InvalidRepoName(msg) => {
-                    assert!(
-                        msg.to_string().contains("cannot contain spaces"),
-                        "Error message should mention spaces, got: {msg}"
-                    );
-                }
+                OxenError::InvalidRepoName(_) => {}
                 other => panic!("Expected InvalidRepoName error, got: {other:?}"),
             }
 

--- a/oxen-rust/src/server/src/controllers/repositories.rs
+++ b/oxen-rust/src/server/src/controllers/repositories.rs
@@ -332,9 +332,11 @@ async fn handle_json_creation(
             log::debug!("Repo already exists: {path:?}");
             Ok(HttpResponse::Conflict().json(StatusMessage::error("Repo already exists.")))
         }
-        Err(OxenError::InvalidRepoName(msg)) => {
-            log::debug!("Invalid repo name: {msg}");
-            Ok(HttpResponse::BadRequest().json(StatusMessage::error(msg.to_string())))
+        Err(OxenError::InvalidRepoName(name)) => {
+            log::debug!("Invalid repo name: {name}");
+            Ok(HttpResponse::BadRequest().json(StatusMessage::error(format!(
+                "Invalid repository or namespace name '{name}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+"
+            ))))
         }
         Err(err) => {
             println!("Err repositories::create: {err:?}");
@@ -475,9 +477,11 @@ async fn handle_multipart_creation(
             log::debug!("Repo already exists: {path:?}");
             Ok(HttpResponse::Conflict().json(StatusMessage::error("Repo already exists.")))
         }
-        Err(OxenError::InvalidRepoName(msg)) => {
-            log::debug!("Invalid repo name: {msg}");
-            Ok(HttpResponse::BadRequest().json(StatusMessage::error(msg.to_string())))
+        Err(OxenError::InvalidRepoName(name)) => {
+            log::debug!("Invalid repo name: {name}");
+            Ok(HttpResponse::BadRequest().json(StatusMessage::error(format!(
+                "Invalid repository or namespace name '{name}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+"
+            ))))
         }
         Err(err) => {
             log::error!("Err repositories::create: {err:?}");

--- a/oxen-rust/src/server/src/controllers/repositories.rs
+++ b/oxen-rust/src/server/src/controllers/repositories.rs
@@ -332,6 +332,10 @@ async fn handle_json_creation(
             log::debug!("Repo already exists: {path:?}");
             Ok(HttpResponse::Conflict().json(StatusMessage::error("Repo already exists.")))
         }
+        Err(OxenError::InvalidRepoName(msg)) => {
+            log::debug!("Invalid repo name: {msg}");
+            Ok(HttpResponse::BadRequest().json(StatusMessage::error(msg.to_string())))
+        }
         Err(err) => {
             println!("Err repositories::create: {err:?}");
             log::error!("Err repositories::create: {err:?}");
@@ -470,6 +474,10 @@ async fn handle_multipart_creation(
         Err(OxenError::RepoAlreadyExists(path)) => {
             log::debug!("Repo already exists: {path:?}");
             Ok(HttpResponse::Conflict().json(StatusMessage::error("Repo already exists.")))
+        }
+        Err(OxenError::InvalidRepoName(msg)) => {
+            log::debug!("Invalid repo name: {msg}");
+            Ok(HttpResponse::BadRequest().json(StatusMessage::error(msg.to_string())))
         }
         Err(err) => {
             log::error!("Err repositories::create: {err:?}");

--- a/oxen-rust/src/server/src/errors.rs
+++ b/oxen-rust/src/server/src/errors.rs
@@ -428,13 +428,13 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::BadRequest().json(error_json)
                     }
-                    OxenError::InvalidRepoName(msg) => {
-                        log::debug!("Invalid repo name: {msg}");
+                    OxenError::InvalidRepoName(name) => {
+                        log::debug!("Invalid repo name: {name}");
                         let error_json = json!({
                             "error": {
                                 "type": "invalid_repo_name",
                                 "title": "Invalid Repository Name",
-                                "detail": format!("{}", msg),
+                                "detail": format!("Invalid repository or namespace name '{name}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+"),
                             },
                             "status": STATUS_ERROR,
                             "status_message": MSG_BAD_REQUEST,

--- a/oxen-rust/src/server/src/errors.rs
+++ b/oxen-rust/src/server/src/errors.rs
@@ -428,6 +428,19 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::BadRequest().json(error_json)
                     }
+                    OxenError::InvalidRepoName(msg) => {
+                        log::debug!("Invalid repo name: {msg}");
+                        let error_json = json!({
+                            "error": {
+                                "type": "invalid_repo_name",
+                                "title": "Invalid Repository Name",
+                                "detail": format!("{}", msg),
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_BAD_REQUEST,
+                        });
+                        HttpResponse::BadRequest().json(error_json)
+                    }
                     OxenError::ImportFileError(desc) => {
                         let error_json = json!({
                             "error": {
@@ -556,6 +569,7 @@ impl error::ResponseError for OxenHttpError {
                 OxenError::RevisionNotFound(_) => StatusCode::NOT_FOUND,
                 OxenError::ResourceNotFound(_) => StatusCode::NOT_FOUND,
                 OxenError::InvalidSchema(_) => StatusCode::BAD_REQUEST,
+                OxenError::InvalidRepoName(_) => StatusCode::BAD_REQUEST,
                 OxenError::PathDoesNotExist(_) => StatusCode::NOT_FOUND,
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
             },


### PR DESCRIPTION
I saw some flaky unit tests caused by trying to create a repository with a space in the name. This adds validation for repo and namespace names to match what we currently require on OxenHub (`^[[:alnum:]][[:alnum:]_.-]+$`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository creation now validates names and namespaces (start with alphanumeric, only alphanumeric/underscore/dot/hyphen, min length 2).
  * Invalid names are rejected with descriptive error messages during creation.

* **Bug Fixes**
  * Creation endpoints now return a clear 400 Bad Request with a standardized "invalid_repo_name" error when names are invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->