### PR TITLE
Allow Python Workspace.add to accept multiple files & dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ release/
 data/
 logs/
 **/.claude/settings.local.json
+*.pyc
+.superset

--- a/oxen-python/src/py_workspace.rs
+++ b/oxen-python/src/py_workspace.rs
@@ -132,21 +132,6 @@ impl PyWorkspace {
         Ok(PyStagedData::from(remote_status))
     }
 
-    fn add(&self, src: PathBuf, dst: String) -> Result<(), PyOxenError> {
-        pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            let paths = vec![src];
-            api::client::workspaces::files::add(
-                &self.repo.repo,
-                &self.get_identifier(),
-                &dst,
-                paths,
-                &None,
-            )
-            .await
-        })?;
-        Ok(())
-    }
-
     fn add_bytes(&self, src: PathBuf, buf: Vec<u8>, dst: String) -> Result<(), PyOxenError> {
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::files::add_bytes(
@@ -161,7 +146,7 @@ impl PyWorkspace {
         Ok(())
     }
 
-    fn add_many(&self, src: Vec<PathBuf>, dst: String) -> Result<(), PyOxenError> {
+    fn add(&self, src: Vec<PathBuf>, dst: String) -> Result<(), PyOxenError> {
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::files::add(
                 &self.repo.repo,

--- a/oxen-python/tests/test_workspace_add.py
+++ b/oxen-python/tests/test_workspace_add.py
@@ -1,37 +1,129 @@
 import os
-from oxen import RemoteRepo
-from oxen import Workspace
-from pathlib import PurePath
+from pathlib import Path
+
+from oxen import RemoteRepo, Workspace
+from oxen.workspace import _filepaths_from
+from pytest import raises
 
 
 def test_workspace_add_single_file(
     celeba_remote_repo_one_image_pushed: RemoteRepo, shared_datadir
 ):
-    images_path = str(PurePath("CelebA", "images", "1.jpg"))
-    full_path = os.path.join(shared_datadir, images_path)
-
     _, remote_repo = celeba_remote_repo_one_image_pushed
     workspace = Workspace(remote_repo, "main", "test-workspace")
 
+    full_path: Path = shared_datadir / "CelebA" / "images" / "1.jpg"
+
+    # test that this accepts a Path
     workspace.add(full_path, "a-folder")
     status = workspace.status()
     added_files = status.added_files()
 
-    added_path = str(PurePath("a-folder", "1.jpg"))
-    assert added_files == [added_path]
+    assert len(added_files) == 1
+    assert added_files[0] == str(Path("a-folder") / "1.jpg")
 
 
-def test_workspace_add_root_dir(
-    celeba_remote_repo_one_image_pushed: RemoteRepo, shared_datadir
-):
-    images_path = str(PurePath("CelebA", "images", "3.jpg"))
-    full_path = os.path.join(shared_datadir, images_path)
+def test_workspace_add_dir(celeba_remote_repo_one_image_pushed, shared_datadir):
+    _, remote_repo = celeba_remote_repo_one_image_pushed
+    workspace = Workspace(remote_repo, "main", "test-workspace")
+
+    full_path: Path = shared_datadir / "CelebA" / "images"
+
+    # test that this accepts a str
+    workspace.add(str(full_path), "")
+    status = workspace.status()
+    added_files = status.added_files()
+
+    assert len(added_files) == 9
+    assert sorted(added_files) == sorted([f"{i}.jpg" for i in range(1, 10)])
+
+
+def test_workspace_add_many(celeba_remote_repo_one_image_pushed, shared_datadir):
 
     _, remote_repo = celeba_remote_repo_one_image_pushed
     workspace = Workspace(remote_repo, "main", "test-workspace")
 
-    workspace.add(full_path, "")
+    shared_datadir = Path(shared_datadir)
+    image_paths: list[Path] = [
+        shared_datadir / "CelebA" / "images" / f"{i}.jpg" for i in [1, 2, 3]
+    ]
+    image_paths.append(shared_datadir / "Diffs")
+
+    # force it to actually work on an Iterable[str]
+    workspace.add(map(str, image_paths), "")
     status = workspace.status()
     added_files = status.added_files()
 
-    assert added_files == ["3.jpg"]
+    assert len(added_files) == 7
+
+    assert sorted(added_files) == sorted(
+        [
+            "1.jpg",
+            "2.jpg",
+            "3.jpg",
+            "prompts_added_row.csv",
+            "prompts_added_row.txt",
+            "prompts.csv",
+            "prompts.txt",
+        ]
+    )
+
+
+def test_workspace_add_invalid_path(tmp_path, celeba_remote_repo_one_image_pushed):
+    _, remote_repo = celeba_remote_repo_one_image_pushed
+    workspace = Workspace(remote_repo, "main", "test-workspace")
+
+    invalid_paths = [
+        tmp_path / invalid
+        for invalid in (
+            "not_real",
+            "not_here",
+            "oh_this_will_be_fun",
+        )
+    ]
+
+    # force it to actually work on an Iterable[Path]
+    with raises(ValueError):
+        workspace.add(invalid_paths, "")
+
+
+def test_filepaths_from(tmp_path):
+    dir_root = tmp_path / "dir_root"
+    dir_root.mkdir()
+
+    # test a few files in the directory root
+    (dir_root / "X").touch()
+    (dir_root / "Y").touch()
+
+    # test a few sub-directories, each with a file
+    for name, file in [("dir_a", "A"), ("dir_b", "B"), ("dir_c", "C")]:
+        d = dir_root / name
+        d.mkdir()
+        (d / file).touch()
+
+    # Test a very nested case
+    depth_2 = dir_root / "depth_0" / "depth_1" / "depth_2"
+    depth_2.mkdir(parents=True)
+    for file in ["D", "E", "F", "G", "H"]:
+        (depth_2 / file).touch()
+
+    result = sorted(str(p.relative_to(dir_root)) for p in _filepaths_from(dir_root))
+
+    expected = sorted(
+        [
+            "X",
+            "Y",
+            # NOTE: For windows, we can't use `/`,
+            #       so we use `os.path.join` to re-create the right string.
+            os.path.join("dir_a", "A"),
+            os.path.join("dir_b", "B"),
+            os.path.join("dir_c", "C"),
+            os.path.join("depth_0", "depth_1", "depth_2", "D"),
+            os.path.join("depth_0", "depth_1", "depth_2", "E"),
+            os.path.join("depth_0", "depth_1", "depth_2", "F"),
+            os.path.join("depth_0", "depth_1", "depth_2", "G"),
+            os.path.join("depth_0", "depth_1", "depth_2", "H"),
+        ]
+    )
+
+    assert result == expected


### PR DESCRIPTION
**Python `Workspace.add`**
Changes `class Workspace`'s `add` to accept multiple file or directory inputs.
For any directory encountered, it still recursively walks its contents and adds all accessible files.

Additionally, `add` now accepts `pathlib.Path` instances too. 
New tests cover the new add multiple behavior.

**Small, unrelated changes**:
- `api::client::workspaces::files::add_many` didn't need to take ownership of `paths`, so it is now a slice
- tweaks to the ignore file
- updated type annotations in `oxen-python/python/oxen/workspace.py`
- using `Path` in the Python workspace tests
