### PR TITLE
Remove client workspace add_many

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ logs/
 **/.claude/settings.local.json
 *.pyc
 .superset
+*.swp

--- a/oxen-rust/src/lib/src/api/client/entries.rs
+++ b/oxen-rust/src/lib/src/api/client/entries.rs
@@ -99,11 +99,12 @@ pub async fn upload_entries(
         api::client::workspaces::create(remote_repo, &branch_name, &workspace_id).await?;
     assert_eq!(workspace.id, workspace_id);
 
-    api::client::workspaces::files::add_many(
+    api::client::workspaces::files::add(
         remote_repo,
         &workspace_id,
         &opts.dst.to_string_lossy(),
         file_paths,
+        &None,
     )
     .await?;
 

--- a/oxen-rust/src/server/src/controllers/versions/chunks.rs
+++ b/oxen-rust/src/server/src/controllers/versions/chunks.rs
@@ -102,9 +102,8 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
         }
 
         // Combine all the chunks for a version file into a single file
-        let cleanup = true;
         let version_path = version_store
-            .combine_version_chunks(&version_id, cleanup)
+            .combine_version_chunks(&version_id, true)
             .await?;
 
         // If the workspace id is provided, stage the file
@@ -126,6 +125,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
                 &workspace,
                 &version_path,
                 &dst_path,
+                &version_id,
             )?;
         }
 

--- a/oxen-rust/src/server/src/controllers/workspaces/files.rs
+++ b/oxen-rust/src/server/src/controllers/workspaces/files.rs
@@ -250,7 +250,7 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
         let dst_path = PathBuf::from(&directory).join(file_name);
         let version_path = version_store.get_version_path(&upload_file.hash)?;
 
-        let ret_file = match core::v_latest::workspaces::files::add_version_file_with_hash(
+        let ret_file = match core::v_latest::workspaces::files::add_version_file(
             &workspace,
             &version_path,
             &dst_path,


### PR DESCRIPTION
Fix: `add_version_file` ignoring hashes & rm `add_many`, `get_status_and_add_file

**Replace `add_many` with `add`**
Remove client workspace's `add_many` function: replaced all uses of
`api::client::workspaces::files::add_many` with
`api::client::workspaces::files::add`, unifying upload behavior.

**Bugfix: workspace add ignoring file hashes**
The workspace add function was ignoring file hashes. This is because staged
files were being completed (`/complete` endpoint) with `add_version_file(s)`,
which was using `get_status_and_add_file` incorrectly. It was hardcoding the
merkle tree node input in its `get_status_and_add_file` call, which
and this function was ignoring the file contents when determining add status.

Instead, it was hardcoding the merkle tree node in the `get_status_and_add_file`
call to `None` (_which is supposed to be used when there's not a pervious version_).
This meant that it never got a file hash to compare against and thus incorrectly
thought it was a new file.

`get_status_and_add_file` and `add_version_file` have been removed. They are
not needed, because they were only used in one server route:
`oxen_server::controllers::versions::chunks::complete`. And this route already
has the hash of the file contents (parameter `version_id`), which means it
can use `add_version_file_with_hash`.

And, since there's only one way to add a file (with a hash), this function
has been renamed to replace `add_version_file`. This is now complimentary
with `add_version_files` (which also already expects a file hash).

**Breaking Change**
- Deleted `liboxen::api::client::workspaces::files::add_many`
- Deleted `liboxen::core::v_latest::add::get_status_and_add_file`
- Deleted `liboxen::core::v_latest::workspaces::files::add_version_file`
- Renamed `liboxen::core::v_latest::workspaces::files::add_version_file_with_hash` to `add_version_file`