### PR TITLE
`fsck` command to find corrupted version files. `--missing-files` flag for `pull` command

### DIFF
--- a/oxen-rust/src/cli/src/cmd.rs
+++ b/oxen-rust/src/cli/src/cmd.rs
@@ -117,6 +117,9 @@ pub use workspace::WorkspaceCmd;
 pub mod prune;
 pub use prune::PruneCmd;
 
+pub mod fsck;
+pub use fsck::FsckCmd;
+
 #[async_trait]
 pub trait RunCmd {
     fn name(&self) -> &str;

--- a/oxen-rust/src/cli/src/cmd/fsck.rs
+++ b/oxen-rust/src/cli/src/cmd/fsck.rs
@@ -1,0 +1,65 @@
+use async_trait::async_trait;
+use clap::{ArgMatches, Command};
+
+use crate::helpers::check_repo_migration_needed;
+use liboxen::error::OxenError;
+use liboxen::model::LocalRepository;
+
+use crate::cmd::RunCmd;
+
+pub const NAME: &str = "fsck";
+pub struct FsckCmd;
+
+pub fn fsck_args() -> Command {
+    Command::new(NAME)
+        .about("Check repository integrity and scan for corrupted version files")
+        .arg(
+            clap::Arg::new("clean")
+                .long("clean")
+                .help("Remove corrupted version files instead of just reporting them")
+                .action(clap::ArgAction::SetTrue),
+        )
+}
+
+#[async_trait]
+impl RunCmd for FsckCmd {
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn args(&self) -> Command {
+        fsck_args()
+    }
+
+    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+        let repository = LocalRepository::from_current_dir()?;
+        check_repo_migration_needed(&repository)?;
+
+        let clean = args.get_flag("clean");
+        let dry_run = !clean;
+
+        if dry_run {
+            println!("Scanning version files for corruption...");
+        } else {
+            println!("Scanning and cleaning corrupted version files...");
+        }
+
+        let version_store = repository.version_store()?;
+        let result = version_store.clean_corrupted_versions(dry_run).await?;
+
+        println!("\nResults:");
+        println!("  Scanned:   {}", result.scanned);
+        println!("  Corrupted: {}", result.corrupted);
+        if !dry_run {
+            println!("  Cleaned:   {}", result.cleaned);
+        }
+        println!("  Errors:    {}", result.errors);
+        println!("  Elapsed:   {:.2}s", result.elapsed.as_secs_f64());
+
+        if dry_run && result.corrupted > 0 {
+            println!("\nRun with --clean to remove corrupted version files.");
+        }
+
+        Ok(())
+    }
+}

--- a/oxen-rust/src/cli/src/cmd/pull.rs
+++ b/oxen-rust/src/cli/src/cmd/pull.rs
@@ -40,6 +40,12 @@ impl RunCmd for PullCmd {
                     .help("This pulls the full commit history, all the data files, and all the commit databases. Useful if you want to have the entire history locally or push to a new remote.")
                     .action(clap::ArgAction::SetTrue),
             )
+            .arg(
+                Arg::new("missing-files")
+                    .long("missing-files")
+                    .help("Re-download any version files that are missing locally (useful after fsck --clean or a failed pull)")
+                    .action(clap::ArgAction::SetTrue),
+            )
     }
 
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
@@ -60,6 +66,7 @@ impl RunCmd for PullCmd {
         };
 
         let all = args.get_flag("all");
+        let missing_files = args.get_flag("missing-files");
         let (scheme, host) = get_scheme_and_host_from_repo(&repo)?;
 
         check_repo_migration_needed(&repo)?;
@@ -72,6 +79,7 @@ impl RunCmd for PullCmd {
         fetch_opts.subtree_paths = repo.subtree_paths();
         fetch_opts.branch = branch;
         fetch_opts.all = all;
+        fetch_opts.missing_files = missing_files;
 
         repositories::pull_remote_branch(&repo, &fetch_opts).await?;
         Ok(())

--- a/oxen-rust/src/cli/src/main.rs
+++ b/oxen-rust/src/cli/src/main.rs
@@ -71,6 +71,7 @@ async fn async_main() -> ExitCode {
         Box::new(cmd::NodeCmd),
         // Box::new(cmd::PackCmd),
         Box::new(cmd::PruneCmd),
+        Box::new(cmd::FsckCmd),
         Box::new(cmd::PullCmd),
         Box::new(cmd::PushCmd),
         Box::new(cmd::RestoreCmd),

--- a/oxen-rust/src/lib/src/api/client/tree.rs
+++ b/oxen-rust/src/lib/src/api/client/tree.rs
@@ -627,6 +627,7 @@ mod tests {
                 remote: remote_repo_clone.url().to_string(),
                 branch: "main".to_string(),
                 should_update_branch_head: true,
+                missing_files: false,
             };
             api::client::tree::download_trees_from(
                 &download_local_repo_2,

--- a/oxen-rust/src/lib/src/opts/fetch_opts.rs
+++ b/oxen-rust/src/lib/src/opts/fetch_opts.rs
@@ -17,6 +17,8 @@ pub struct FetchOpts {
     pub all: bool,
     // Defaults to true, but on pull we want to only update the branch head if there are no conflicts
     pub should_update_branch_head: bool,
+    // If true, re-scan all commits for missing version files and download them
+    pub missing_files: bool,
 }
 
 impl Default for FetchOpts {
@@ -35,6 +37,7 @@ impl FetchOpts {
             depth: None,
             all: false,
             should_update_branch_head: true,
+            missing_files: false,
         }
     }
 

--- a/oxen-rust/src/lib/src/repositories.rs
+++ b/oxen-rust/src/lib/src/repositories.rs
@@ -36,6 +36,7 @@ pub mod download;
 pub mod entries;
 pub mod fetch;
 pub mod fork;
+pub mod fsck;
 pub mod init;
 pub mod load;
 pub mod merge;

--- a/oxen-rust/src/lib/src/repositories/fsck.rs
+++ b/oxen-rust/src/lib/src/repositories/fsck.rs
@@ -1,0 +1,94 @@
+//! # oxen fsck
+//!
+//! Check repository integrity
+//!
+
+#[cfg(test)]
+mod tests {
+    use crate::error::OxenError;
+    use crate::repositories;
+    use crate::test;
+
+    #[tokio::test]
+    async fn test_fsck_dry_run_detects_corrupted_version() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            // Add and commit a file so we have a version in the store
+            let file_path = repo.path.join("hello.txt");
+            test::write_txt_file_to_path(&file_path, "hello world")?;
+            repositories::add(&repo, &file_path).await?;
+            repositories::commit(&repo, "Adding hello.txt")?;
+
+            let version_store = repo.version_store()?;
+            let versions = version_store.list_versions().await?;
+            assert!(!versions.is_empty());
+
+            // Corrupt a version file by overwriting its data
+            let hash = &versions[0];
+            let version_path = version_store.get_version_path(hash)?;
+            std::fs::write(&version_path, b"corrupted data")?;
+
+            // Dry run should detect corruption but not delete
+            let result = version_store.clean_corrupted_versions(true).await?;
+            assert!(result.corrupted > 0);
+            assert_eq!(result.cleaned, 0);
+
+            // The corrupted file should still exist
+            assert!(version_store.version_exists(hash).await?);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_fsck_clean_removes_corrupted_version() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            // Add and commit a file so we have a version in the store
+            let file_path = repo.path.join("hello.txt");
+            test::write_txt_file_to_path(&file_path, "hello world")?;
+            repositories::add(&repo, &file_path).await?;
+            repositories::commit(&repo, "Adding hello.txt")?;
+
+            let version_store = repo.version_store()?;
+            let versions = version_store.list_versions().await?;
+            assert!(!versions.is_empty());
+
+            // Corrupt a version file by overwriting its data
+            let hash = &versions[0];
+            let version_path = version_store.get_version_path(hash)?;
+            std::fs::write(&version_path, b"corrupted data")?;
+
+            // Clean should detect and remove the corrupted file
+            let result = version_store.clean_corrupted_versions(false).await?;
+            assert!(result.corrupted > 0);
+            assert!(result.cleaned > 0);
+
+            // The corrupted file should be gone
+            assert!(!version_store.version_exists(hash).await?);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_fsck_no_corruption_on_clean_repo() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            // Add and commit a file
+            let file_path = repo.path.join("hello.txt");
+            test::write_txt_file_to_path(&file_path, "hello world")?;
+            repositories::add(&repo, &file_path).await?;
+            repositories::commit(&repo, "Adding hello.txt")?;
+
+            let version_store = repo.version_store()?;
+
+            // No corruption on a clean repo
+            let result = version_store.clean_corrupted_versions(true).await?;
+            assert_eq!(result.corrupted, 0);
+            assert!(result.scanned > 0);
+
+            Ok(())
+        })
+        .await
+    }
+}

--- a/oxen-rust/src/lib/src/storage/s3.rs
+++ b/oxen-rust/src/lib/src/storage/s3.rs
@@ -435,7 +435,10 @@ impl VersionStore for S3VersionStore {
         ))
     }
 
-    async fn clean_corrupted_versions(&self) -> Result<CleanCorruptedVersionsResult, OxenError> {
+    async fn clean_corrupted_versions(
+        &self,
+        _dry_run: bool,
+    ) -> Result<CleanCorruptedVersionsResult, OxenError> {
         // TODO: Implement S3 version chunk combination
         Err(OxenError::basic_str(
             "S3VersionStore clean_corrupted_versions not yet implemented",

--- a/oxen-rust/src/lib/src/storage/version_store.rs
+++ b/oxen-rust/src/lib/src/storage/version_store.rs
@@ -215,7 +215,11 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     async fn list_versions(&self) -> Result<Vec<String>, OxenError>;
 
     /// Clean corrupted version files
-    async fn clean_corrupted_versions(&self) -> Result<CleanCorruptedVersionsResult, OxenError>;
+    /// If `dry_run` is true, only scan and report without deleting
+    async fn clean_corrupted_versions(
+        &self,
+        dry_run: bool,
+    ) -> Result<CleanCorruptedVersionsResult, OxenError>;
 
     /// Get the storage type identifier (e.g., "local", "s3")
     fn storage_type(&self) -> &str;

--- a/oxen-rust/src/server/src/controllers/versions.rs
+++ b/oxen-rust/src/server/src/controllers/versions.rs
@@ -79,7 +79,7 @@ pub async fn clean(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let repo_name = path_param(&req, "repo_name")?;
     let repo = get_repo(&app_data.path, namespace, &repo_name)?;
     let version_store = repo.version_store()?;
-    let result = version_store.clean_corrupted_versions().await?;
+    let result = version_store.clean_corrupted_versions(false).await?;
 
     Ok(HttpResponse::Ok().json(CleanCorruptedVersionsResponse {
         status: StatusMessage::resource_found(),


### PR DESCRIPTION
…g for pull

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new fsck command to scan repositories for corrupted/missing version files; run with --clean to perform repairs.
  * Added a --missing-files flag to pull to re-download missing version files during pulls.

* **Behavior**
  * fsck defaults to a non-destructive dry-run, reporting scanned, corrupted, cleaned (if --clean), errors, and elapsed time with guidance to rerun with --clean to repair.

* **Tests**
  * Added tests validating fsck dry-run/clean behavior and pull re-download of missing files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->