### PR TITLE
Fix: Windows: server staging keys + oxen tests

### DIFF
--- a/oxen-rust/src/lib/src/core/df/tabular.rs
+++ b/oxen-rust/src/lib/src/core/df/tabular.rs
@@ -2045,7 +2045,18 @@ mod tests {
             .sorted()
             .collect::<Vec<_>>();
         assert_eq!(columns, vec!["caption", "media_path"]);
-        assert_eq!(df.column("caption").unwrap().get(0).unwrap().str_value().to_string().as_str(), "[VISUAL]: Jade Mills, a woman in her 60s with blonde shoulder-length hair, sits in a professional podcast interview setting. She wears a dusty pink blazer over a white high-neck lace top with intricate detailing. The background features a soft teal-green gradient with large windows showing blurred outdoor scenery. A professional black microphone on a boom arm is positioned to her right. Jade Mills gazes slightly upward and to her left with a contemplative expression, her eyes looking off-camera. Her posture is upright and engaged, seated on what appears to be a dark chair or couch with teal cushions visible at the edge of the frame.\n\n[CHARACTER_SPEECH]: Jade Mills: I don't want a baby in a wife on the road with me, and he left. So...");
+        let nl = if cfg!(windows) { "\r\n" } else { "\n" };
+        let expected = format!("[VISUAL]: Jade Mills, a woman in her 60s with blonde shoulder-length hair, sits in a professional podcast interview setting. She wears a dusty pink blazer over a white high-neck lace top with intricate detailing. The background features a soft teal-green gradient with large windows showing blurred outdoor scenery. A professional black microphone on a boom arm is positioned to her right. Jade Mills gazes slightly upward and to her left with a contemplative expression, her eyes looking off-camera. Her posture is upright and engaged, seated on what appears to be a dark chair or couch with teal cushions visible at the edge of the frame.{nl}{nl}[CHARACTER_SPEECH]: Jade Mills: I don't want a baby in a wife on the road with me, and he left. So...");
+        assert_eq!(
+            df.column("caption")
+                .unwrap()
+                .get(0)
+                .unwrap()
+                .str_value()
+                .to_string()
+                .as_str(),
+            expected
+        );
         Ok(())
     }
 

--- a/oxen-rust/src/lib/src/test.rs
+++ b/oxen-rust/src/lib/src/test.rs
@@ -1613,6 +1613,8 @@ pub fn maybe_cleanup_repo(repo_dir: &Path) -> Result<(), OxenError> {
     merkle_tree_node_cache::remove_from_cache(repo_dir)?;
     core::staged::remove_from_cache_with_children(repo_dir)?;
     core::refs::ref_manager::remove_from_cache_with_children(repo_dir)?;
+    core::db::data_frames::df_db::remove_df_db_from_cache_with_children(repo_dir)?;
+    core::db::dir_hashes::dir_hashes_db::remove_from_cache_with_children(repo_dir)?;
 
     if should_cleanup() {
         log::debug!("maybe_cleanup_repo: cleaning up repo: {repo_dir:?}");

--- a/oxen-rust/src/server/src/test.rs
+++ b/oxen-rust/src/server/src/test.rs
@@ -1,5 +1,7 @@
 use crate::app_data::OxenAppData;
 
+use liboxen::core::db::data_frames::df_db;
+use liboxen::core::db::dir_hashes::dir_hashes_db;
 use liboxen::core::{refs, staged};
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
@@ -29,6 +31,8 @@ pub fn cleanup_sync_dir(sync_dir: &Path) -> Result<(), OxenError> {
     // Close DB instances before trying to delete the directory
     staged::remove_from_cache_with_children(sync_dir)?;
     refs::ref_manager::remove_from_cache_with_children(sync_dir)?;
+    df_db::remove_df_db_from_cache_with_children(sync_dir)?;
+    dir_hashes_db::remove_from_cache_with_children(sync_dir)?;
     std::fs::remove_dir_all(sync_dir)?;
     Ok(())
 }


### PR DESCRIPTION
**Fix: Path separator mismatch in staged DB keys**
PathBuf::join uses `\` on Windows, so uploaded file keys get stored as `path\to\file` in
RocksDB. Downloads resolve via URL paths (always `/`), causing lookup misses. Fixed by
normalizing all keys, replacing `\` with `/`: implemented as `normalize_key()` and updated
all key accesses. Fixes `test_download_uploaded_file_from_workspace`.

**Test fix: CRLF line endings in test CSV**
Git's `core.autocrlf` converts `\n` to `\r\n` on Windows checkout. The test in 
`test_csv_video_captions_quoting` was comparing over lines, causing a mismatch. Fix is
to use `cfg!(windows)` to swap-out the newline sequence.

**Test fix: File locks from unclosed DB connections**
On Windows, open file handles prevent the file from being removed. The test cleanup 
function  was still holding on to the DuckDB and RocksDB connections, which was causing
the code  32 error ("...cannot access the file because it is being used by another process.").

Added `fn remove_from_cache_with_children` to `dir_hashes_db.rs` and updated both 
`fn cleanup_sync_dir` (server) and `fn maybe_cleanup_repo` (lib) to flush all 4 caches.
Fixes 7 tests in `controllers::workspaces::data_frames::tests::*`.