### PR TITLE
Only run CI if `main` or PR is marked as not a draft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ name: 🐂 Continuous integration
 
 jobs:
   lint:
+    if: github.event.pull_request.draft == false
     name: Lint
     uses: ./.github/workflows/ci_lint.yml
 
   test:
+    if: github.event.pull_request.draft == false
     name: Test Suite
     uses: ./.github/workflows/ci_test.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,22 @@
 on:
-  push
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    # opened: A new pull request is created.
+    # synchronize: New commits are pushed to the PR's head branch, or the base branch is changed (i.e. a 'push' event on the PR branch).
+    # reopened: The PR is reopened.
+    # ready_for_review: The PR is marked as ready for review.
 
 name: 🐂 Continuous integration
 
 jobs:
   lint:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft != true
     name: Lint
     uses: ./.github/workflows/ci_lint.yml
 
   test:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft != true
     name: Test Suite
     uses: ./.github/workflows/ci_test.yml


### PR DESCRIPTION
Changes the CI to only run on `push` events to the `main` branch.
`main` branch pushes always run the full CI `lint` and `test` jobs.

Branches associated with pull requests will still be built. However, 
_only_ branches associated with a PR will be built. Previously, CI
was building _every_ branch, even those never associated with a PR.

Now, the CI  will only run on PRs that are not marked as "draft."