### PR TITLE
Cancel CI job on PR if new commit is pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ on:
 
 name: 🐂 Continuous integration
 
+# Each CI job on a branch gets a unique key name like "lint-refs/head/your-feature-branch".
+# GH actions will only let one job per unique key run if cancel-in-progress is true.
+# cancel-in-progress is awlays true unless the branch name is `main` - `main` jobs are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   lint:
     if: github.event.pull_request.draft != true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 name: 🐂 Continuous integration
 
-# Each CI job on a branch gets a unique key name like "lint-refs/head/your-feature-branch".
+# Each CI job on a branch gets a unique key name like "lint-refs/heads/your-feature-branch".
 # GH actions will only let one job per unique key run if cancel-in-progress is true.
 # cancel-in-progress is always true unless the branch name is `main` - `main` jobs are never cancelled.
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ name: 🐂 Continuous integration
 
 # Each CI job on a branch gets a unique key name like "lint-refs/head/your-feature-branch".
 # GH actions will only let one job per unique key run if cancel-in-progress is true.
-# cancel-in-progress is awlays true unless the branch name is `main` - `main` jobs are never cancelled.
+# cancel-in-progress is always true unless the branch name is `main` - `main` jobs are never cancelled.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
Adds GitHub actions concurrency control for CI jobs. Each job running on a
branch is identified uniquely (regardless of commit). GH actions will cancel
an in-progress job that is running on a branch if a new commit is pushed.

However, this limitation does not exist for the `main` branch. CI jobs
running on `main` are excluded from the new concurrency control.