### PR TITLE
New Test PyPI publish workflow for any commit

### DIFF
--- a/.github/workflows/build_and_publish_test_pypi.yml
+++ b/.github/workflows/build_and_publish_test_pypi.yml
@@ -1,0 +1,153 @@
+name: 🧪 Build & Publish to Test PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit SHA to build from"
+        required: true
+        type: string
+
+concurrency:
+  group: test-pypi-publish
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_ROLE: arn:aws:iam::213020545630:role/github-runner-role
+  AWS_REGION: us-west-1
+  PYTHON_VERSIONS: "3.13 3.12 3.11 3.10"
+
+jobs:
+  set_env:
+    name: Set env
+    runs-on: ubuntu-latest
+    outputs:
+      aws_role: ${{ steps.set-env.outputs.aws_role }}
+      aws_region: ${{ steps.set-env.outputs.aws_region }}
+      python_versions: ${{ steps.set-env.outputs.python_versions }}
+
+    steps:
+      - name: Set env
+        id: set-env
+        run: |
+          echo "aws_role=${{ env.AWS_ROLE }}" >> $GITHUB_OUTPUT
+          echo "aws_region=${{ env.AWS_REGION }}" >> $GITHUB_OUTPUT
+          echo "python_versions=${{ env.PYTHON_VERSIONS }}" >> $GITHUB_OUTPUT
+
+  compute_version:
+    name: Compute dev version
+    needs: set_env
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit }}
+          sparse-checkout: oxen-python/pyproject.toml
+          sparse-checkout-cone-mode: false
+
+      - name: Compute next dev version
+        id: compute
+        run: |
+          BASE_VERSION=$(grep -m1 '^version = ' oxen-python/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "Base version: ${BASE_VERSION}"
+
+          ESCAPED=$(echo "$BASE_VERSION" | sed 's/\./\\./g')
+          NEXT_DEV=0
+          MAX_DEV=$(curl -sf "https://test.pypi.org/pypi/oxenai/json" \
+            | jq -r ".releases | keys[]" \
+            | grep -oP "^${ESCAPED}\.dev\K[0-9]+" \
+            | sort -n | tail -1) && [ -n "$MAX_DEV" ] && NEXT_DEV=$((MAX_DEV + 1))
+
+          VERSION="${BASE_VERSION}.dev${NEXT_DEV}"
+          echo "Computed version: ${VERSION}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+  build_linux_x86_64:
+    name: Linux x86_64 wheels
+    needs: [set_env, compute_version]
+    uses: ./.github/workflows/build_wheels_linux.yml
+    with:
+      ARCHITECTURE: x86_64
+      AWS_ROLE: ${{ needs.set_env.outputs.aws_role }}
+      AWS_REGION: ${{ needs.set_env.outputs.aws_region }}
+      PYTHON_VERSIONS: ${{ needs.set_env.outputs.python_versions }}
+      CHECKOUT_REF: ${{ inputs.commit }}
+      VERSION_OVERRIDE: ${{ needs.compute_version.outputs.version }}
+    secrets:
+      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+  build_linux_arm64:
+    name: Linux arm64 wheels
+    needs: [set_env, compute_version]
+    uses: ./.github/workflows/build_wheels_linux.yml
+    with:
+      ARCHITECTURE: arm64
+      AWS_ROLE: ${{ needs.set_env.outputs.aws_role }}
+      AWS_REGION: ${{ needs.set_env.outputs.aws_region }}
+      PYTHON_VERSIONS: ${{ needs.set_env.outputs.python_versions }}
+      CHECKOUT_REF: ${{ inputs.commit }}
+      VERSION_OVERRIDE: ${{ needs.compute_version.outputs.version }}
+    secrets:
+      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+  build_macos:
+    name: macOS wheels
+    needs: [set_env, compute_version]
+    uses: ./.github/workflows/build_wheels_macos.yml
+    with:
+      PYTHON_VERSIONS: ${{ needs.set_env.outputs.python_versions }}
+      CHECKOUT_REF: ${{ inputs.commit }}
+      VERSION_OVERRIDE: ${{ needs.compute_version.outputs.version }}
+
+  build_windows:
+    name: Windows wheels
+    needs: [set_env, compute_version]
+    uses: ./.github/workflows/build_wheels_windows.yml
+    with:
+      ARCHITECTURE: x86_64
+      AWS_ROLE: ${{ needs.set_env.outputs.aws_role }}
+      AWS_REGION: ${{ needs.set_env.outputs.aws_region }}
+      PYTHON_VERSIONS: ${{ needs.set_env.outputs.python_versions }}
+      CHECKOUT_REF: ${{ inputs.commit }}
+      VERSION_OVERRIDE: ${{ needs.compute_version.outputs.version }}
+    secrets:
+      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+  publish_wheels:
+    name: Publish to Test PyPI
+    runs-on: ubuntu-latest
+    needs:
+      - compute_version
+      - build_linux_x86_64
+      - build_linux_arm64
+      - build_macos
+      - build_windows
+    if: ${{ !cancelled() }}
+
+    steps:
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: wheels
+
+      - name: List wheels
+        run: ls -la wheels/
+
+      - name: Publish to Test PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        with:
+          command: upload
+          args: --repository-url https://test.pypi.org/legacy/ --skip-existing wheels/*.whl
+          maturin-version: v1.8.5

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -1,0 +1,161 @@
+name: 🐧 Build Linux Wheels
+
+on:
+  workflow_call:
+    inputs:
+      ARCHITECTURE:
+        description: "The architecture to build for"
+        required: true
+        type: string
+      AWS_ROLE:
+        description: "AWS role to assume"
+        required: true
+        type: string
+      AWS_REGION:
+        description: "AWS region"
+        required: true
+        type: string
+      PYTHON_VERSIONS:
+        description: "Python versions to build"
+        required: true
+        type: string
+      CHECKOUT_REF:
+        description: "Git ref (SHA or branch) to checkout"
+        required: true
+        type: string
+      VERSION_OVERRIDE:
+        description: "Version string to set in pyproject.toml (e.g. 0.44.1.dev0)"
+        required: true
+        type: string
+    secrets:
+      GH_PERSONAL_ACCESS_TOKEN:
+        description: "GitHub personal access token"
+        required: true
+
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
+env:
+  EC2_IMAGE_ID_X86_64: ami-0823857dea006a2fa
+  EC2_IMAGE_ID_ARM64: ami-05fa76c95fcf3d338
+  EC2_INSTANCE_TYPE_X86_64: m7i.4xlarge
+  EC2_INSTANCE_TYPE_ARM64: m7g.4xlarge
+
+jobs:
+  start-self-hosted-runner:
+    name: Start self-hosted EC2 runner
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.AWS_ROLE }}
+          role-duration-seconds: 900
+          aws-region: ${{ inputs.AWS_REGION }}
+
+      - name: Set image and instance type
+        run: |
+          if [ "${{ inputs.ARCHITECTURE }}" = "arm64" ]; then
+            echo "EC2_IMAGE_ID=${{ env.EC2_IMAGE_ID_ARM64 }}" >> $GITHUB_ENV
+            echo "EC2_INSTANCE_TYPE=${{ env.EC2_INSTANCE_TYPE_ARM64 }}" >> $GITHUB_ENV
+          else
+            echo "EC2_IMAGE_ID=${{ env.EC2_IMAGE_ID_X86_64 }}" >> $GITHUB_ENV
+            echo "EC2_INSTANCE_TYPE=${{ env.EC2_INSTANCE_TYPE_X86_64 }}" >> $GITHUB_ENV
+          fi
+
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          ec2-image-id: ${{ env.EC2_IMAGE_ID }}
+          ec2-instance-type: ${{ env.EC2_INSTANCE_TYPE }}
+          subnet-id: subnet-0e28805edbdad482f
+          security-group-id: sg-09c8aa5830122d671
+          aws-resource-tags: >
+            [
+              {"Key": "Name", "Value": "ec2-github-runner"}
+            ]
+
+  build_wheels:
+    name: Build Python wheels
+    needs: start-self-hosted-runner
+    runs-on: ${{ needs.start-self-hosted-runner.outputs.label }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.CHECKOUT_REF }}
+
+      - name: Patch version in pyproject.toml and Cargo.toml
+        run: |
+          bash ${{ github.workspace }}/scripts/patch_dev_version.sh "${{ inputs.VERSION_OVERRIDE }}"
+
+      - name: Setup Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install system dependencies
+        run: |
+          dnf group install "Development Tools" -y
+          dnf install -y \
+            openssl-devel \
+            cmake \
+            clang \
+            rubygems \
+            pkg-config
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release-python"
+          workspaces: "oxen-python -> target"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Build Python wheels
+        run: |
+          uv python install ${{ inputs.PYTHON_VERSIONS }}
+
+          cd ${{ github.workspace }}/oxen-python
+
+          for version in ${{ inputs.PYTHON_VERSIONS }}; do
+            uvx --from 'maturin[patchelf]' maturin build --release --interpreter /root/.local/bin/python${version}
+          done
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ inputs.ARCHITECTURE }}
+          path: ${{ github.workspace }}/oxen-python/target/wheels/*.whl
+          retention-days: 1
+
+  stop-self-hosted-runner:
+    name: Stop self-hosted EC2 runner
+    needs:
+      - start-self-hosted-runner
+      - build_wheels
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.AWS_ROLE }}
+          role-duration-seconds: 900
+          aws-region: ${{ inputs.AWS_REGION }}
+
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          label: ${{ needs.start-self-hosted-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-self-hosted-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -1,0 +1,67 @@
+name: 🍏 Build macOS Wheels
+
+on:
+  workflow_call:
+    inputs:
+      PYTHON_VERSIONS:
+        description: "Python versions to build"
+        required: true
+        type: string
+      CHECKOUT_REF:
+        description: "Git ref (SHA or branch) to checkout"
+        required: true
+        type: string
+      VERSION_OVERRIDE:
+        description: "Version string to set in pyproject.toml (e.g. 0.44.1.dev0)"
+        required: true
+        type: string
+
+env:
+  MACOSX_DEPLOYMENT_TARGET: 10.13
+
+jobs:
+  build_wheels:
+    name: Build Python wheels
+    runs-on: macos-15-xlarge
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.CHECKOUT_REF }}
+
+      - name: Patch version in pyproject.toml and Cargo.toml
+        run: |
+          bash ${{ github.workspace }}/scripts/patch_dev_version.sh "${{ inputs.VERSION_OVERRIDE }}"
+
+      - name: Setup Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release-python"
+          workspaces: "oxen-python -> target"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Build Python wheels
+        run: |
+          uv python install ${{ inputs.PYTHON_VERSIONS }}
+
+          cd ${{ github.workspace }}/oxen-python
+
+          rustup target add aarch64-apple-darwin
+          rustup target add x86_64-apple-darwin
+
+          for version in ${{ inputs.PYTHON_VERSIONS }}; do
+            uvx maturin build --release --interpreter /Users/runner/.local/bin/python${version} --target aarch64-apple-darwin
+            uvx maturin build --release --interpreter /Users/runner/.local/bin/python${version} --target x86_64-apple-darwin
+          done
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos
+          path: ${{ github.workspace }}/oxen-python/target/wheels/*.whl
+          retention-days: 1

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -1,4 +1,4 @@
-name: 🚀 Release Windows
+name: 🪟 Build Windows Wheels
 
 on:
   workflow_call:
@@ -6,7 +6,6 @@ on:
       ARCHITECTURE:
         description: "The architecture to build for"
         required: true
-        default: "x86_64"
         type: string
       AWS_ROLE:
         description: "AWS role to assume"
@@ -18,6 +17,14 @@ on:
         type: string
       PYTHON_VERSIONS:
         description: "Python versions to build"
+        required: true
+        type: string
+      CHECKOUT_REF:
+        description: "Git ref (SHA or branch) to checkout"
+        required: true
+        type: string
+      VERSION_OVERRIDE:
+        description: "Version string to set in pyproject.toml (e.g. 0.44.1.dev0)"
         required: true
         type: string
     secrets:
@@ -62,21 +69,45 @@ jobs:
               {"Key": "Name", "Value": "ec2-github-runner"}
             ]
 
-  release_windows:
-    name: Build Oxen CLI, Server, and Python wheels
+  build_wheels:
+    name: Build Python wheels
     needs: start-self-hosted-runner
     runs-on: ${{ needs.start-self-hosted-runner.outputs.label }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.CHECKOUT_REF }}
 
-      - name: Create release directory
-        run: mkdir ${{ github.workspace }}\release
+      - name: Patch version in pyproject.toml and Cargo.toml
+        run: |
+          $pyprojectPath = "${{ github.workspace }}\oxen-python\pyproject.toml"
+          $content = Get-Content "$pyprojectPath" -Raw
+          $content = $content -replace '(?m)^version = ".*"', 'version = "${{ inputs.VERSION_OVERRIDE }}"'
+          Set-Content "$pyprojectPath" $content
+
+          $cargoVersion = "${{ inputs.VERSION_OVERRIDE }}" -replace '\.dev', '-dev.'
+          $cargoPath = "${{ github.workspace }}\oxen-python\Cargo.toml"
+          $cargoLines = Get-Content "$cargoPath"
+          $inPackage = $false
+          $patched = $false
+          $newLines = foreach ($line in $cargoLines) {
+              if ($line -match '^\[package\]') { $inPackage = $true }
+              elseif ($line -match '^\[') { $inPackage = $false }
+              if ($inPackage -and !$patched -and $line -match '^version = ".*"') {
+                  "version = `"$cargoVersion`""
+                  $patched = $true
+              } else { $line }
+          }
+          Set-Content "$cargoPath" $newLines
+
+      - name: Setup Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install dependencies
         run: |
-          choco install -y cmake llvm uv rustup.install
+          choco install -y cmake llvm uv
           # Install vcpkg for FFmpeg development libraries
           git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
           cd C:\vcpkg
@@ -85,11 +116,11 @@ jobs:
           # Set VCPKG_ROOT for cargo to find FFmpeg libraries
           echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
 
-      - name: Build oxen binaries
-        run: |
-          refreshenv
-          cd ${{ github.workspace }}\oxen-rust
-          cargo build --release
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release-python"
+          workspaces: "oxen-python -> target"
 
       - name: Build Python wheels
         run: |
@@ -100,34 +131,23 @@ jobs:
 
           $versions = "${{ inputs.PYTHON_VERSIONS }}" -split ' '
           foreach ($version in $versions) {
-              uvx maturin build --release --interpreter "C:\Users\Administrator\AppData\Roaming\uv\python\cpython-$version.*\python.exe"
+              $interpDir = Get-ChildItem "C:\Users\Administrator\AppData\Roaming\uv\python" -Directory -Filter "cpython-$version.*" | Select-Object -First 1
+              if (-not $interpDir) { throw "No uv python found for cpython-$version.*" }
+              uvx maturin build --release --interpreter "$($interpDir.FullName)\python.exe"
           }
 
-      - name: Create zip with oxen binaries
-        run: |
-          Compress-Archive -Path "${{ github.workspace }}\oxen-rust\target\release\oxen.exe" -DestinationPath "${{ github.workspace }}\release\oxen-windows-${{ inputs.ARCHITECTURE }}.exe.zip"
-          Compress-Archive -Path "${{ github.workspace }}\oxen-rust\target\release\oxen-server.exe" -DestinationPath "${{ github.workspace }}\release\oxen-server-windows-${{ inputs.ARCHITECTURE }}.exe.zip"
-
-      - name: Create zip with Python wheels
-        run: |
-          Compress-Archive -Path ${{ github.workspace }}\oxen-python\target\wheels\* -DestinationPath ${{ github.workspace }}\release\oxen-wheels-windows-${{ inputs.ARCHITECTURE }}.zip
-
-      - name: Create zip with all artifacts
-        run: |
-          Compress-Archive -Path "${{ github.workspace }}\release\*" -DestinationPath "${{ github.workspace }}\release\oxen-windows-${{ inputs.ARCHITECTURE }}-release.zip"
-
-      - name: Upload all artifacts
+      - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: oxen-windows-release-${{ inputs.ARCHITECTURE }}.zip
-          path: ${{ github.workspace }}\release\oxen-windows-${{ inputs.ARCHITECTURE }}-release.zip
+          name: wheels-windows-${{ inputs.ARCHITECTURE }}
+          path: ${{ github.workspace }}\oxen-python\target\wheels\*.whl
           retention-days: 1
 
   stop-self-hosted-runner:
     name: Stop self-hosted EC2 runner
     needs:
       - start-self-hosted-runner
-      - release_windows
+      - build_wheels
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:

--- a/scripts/patch_dev_version.sh
+++ b/scripts/patch_dev_version.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Patch oxen-python's pyproject.toml and Cargo.toml with a PEP 440 dev version.
+#
+# Usage: scripts/patch_dev_version.sh <PEP440_VERSION>
+# Example: scripts/patch_dev_version.sh 0.44.1.dev3
+#
+# The PEP 440 version (e.g. 0.44.1.dev3) is written directly into pyproject.toml.
+# For Cargo.toml, it is converted to a semver pre-release (e.g. 0.44.1-dev.3).
+#
+# This script is used by:
+#   - scripts/publish_test_pypi.sh  (local dev builds)
+#   - CI workflows (build_wheels_linux.yml, build_wheels_macos.yml)
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]] || [[ -z "$1" ]]; then
+    echo "Usage: $0 <PEP440_VERSION>" >&2
+    echo "  e.g. $0 0.44.1.dev3" >&2
+    exit 1
+fi
+
+PEP440_VERSION="$1"
+CARGO_VERSION="${PEP440_VERSION/.dev/-dev.}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PYPROJECT="$SCRIPT_DIR/../oxen-python/pyproject.toml"
+CARGO_TOML="$SCRIPT_DIR/../oxen-python/Cargo.toml"
+
+# --- Patch pyproject.toml ---
+echo "Patching pyproject.toml → $PEP440_VERSION"
+if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' 's/^version = ".*"/version = "'"$PEP440_VERSION"'"/' "$PYPROJECT"
+else
+    sed -i  's/^version = ".*"/version = "'"$PEP440_VERSION"'"/' "$PYPROJECT"
+fi
+
+# --- Patch Cargo.toml (scoped to [package] section) ---
+echo "Patching Cargo.toml    → $CARGO_VERSION"
+if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' '/^\[package\]/,/^\[/ s/^version = ".*"/version = "'"$CARGO_VERSION"'"/' "$CARGO_TOML"
+else
+    sed -i  '/^\[package\]/,/^\[/ s/^version = ".*"/version = "'"$CARGO_VERSION"'"/' "$CARGO_TOML"
+fi

--- a/scripts/publish_test_pypi.sh
+++ b/scripts/publish_test_pypi.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Build a .devN Python wheel for oxen-python and publish it to Test PyPI.
+#
+# Usage:
+#   TEST_PYPI_API_TOKEN=pypi-... ./scripts/publish_test_pypi.sh <N>
+#
+# The published version will be <V>.dev<N>, where V is the version currently
+# set in oxen-python/pyproject.toml.
+#
+# Example:
+#   If pyproject.toml has version 0.44.1 and N=3, publishes 0.44.1.dev3
+#
+# Requirements:
+#   - maturin   (pip install maturin)
+#   - cargo
+#   - TEST_PYPI_API_TOKEN env var set to a valid Test PyPI API token
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PYPROJECT="$REPO_ROOT/oxen-python/pyproject.toml"
+CARGO_TOML="$REPO_ROOT/oxen-python/Cargo.toml"
+CARGO_LOCK="$REPO_ROOT/oxen-python/Cargo.lock"
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+if [[ $# -ne 1 ]] || ! [[ "$1" =~ ^[0-9]+$ ]]; then
+    echo "Usage: $0 <N>" >&2
+    echo "  N  - non-negative integer for the .devN suffix" >&2
+    exit 1
+fi
+
+DEV_N="$1"
+
+# ---------------------------------------------------------------------------
+# Auth check
+# ---------------------------------------------------------------------------
+if [[ -z "${TEST_PYPI_API_TOKEN:-}" ]]; then
+    echo "Error: TEST_PYPI_API_TOKEN env var is not set." >&2
+    echo "Generate a token at https://test.pypi.org/manage/account/token/" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Read current version from pyproject.toml
+# ---------------------------------------------------------------------------
+CURRENT_VERSION=$(grep -m1 '^version' "$PYPROJECT" | sed 's/version *= *"\(.*\)"/\1/')
+if [[ -z "$CURRENT_VERSION" ]]; then
+    echo "Error: could not read version from $PYPROJECT" >&2
+    exit 1
+fi
+
+PEP440_VERSION="${CURRENT_VERSION}.dev${DEV_N}"   # e.g. 0.44.1.dev3
+CARGO_VERSION="${CURRENT_VERSION}-dev.${DEV_N}"    # e.g. 0.44.1-dev.3
+
+echo "Current version : $CURRENT_VERSION"
+echo "Test PyPI version: $PEP440_VERSION  (Cargo: $CARGO_VERSION)"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Backup originals & set up cleanup trap
+# ---------------------------------------------------------------------------
+cp "$PYPROJECT"  "$PYPROJECT.bak"
+cp "$CARGO_TOML" "$CARGO_TOML.bak"
+cp "$CARGO_LOCK" "$CARGO_LOCK.bak"
+
+cleanup() {
+    echo ""
+    echo "Restoring original files..."
+    mv -f "$PYPROJECT.bak"  "$PYPROJECT"
+    mv -f "$CARGO_TOML.bak" "$CARGO_TOML"
+    mv -f "$CARGO_LOCK.bak" "$CARGO_LOCK"
+    echo "Done."
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Patch versions
+# ---------------------------------------------------------------------------
+"$REPO_ROOT/scripts/patch_dev_version.sh" "$PEP440_VERSION"
+
+echo "Updating Cargo.lock..."
+(cd "$REPO_ROOT/oxen-python" && cargo update -p oxen --quiet)
+
+# ---------------------------------------------------------------------------
+# Build wheel
+# ---------------------------------------------------------------------------
+echo ""
+echo "Building wheel with maturin..."
+(cd "$REPO_ROOT/oxen-python" && maturin build --release)
+
+# ---------------------------------------------------------------------------
+# Locate the built wheel(s)
+# ---------------------------------------------------------------------------
+WHEEL_DIR="$REPO_ROOT/oxen-python/target/wheels"
+shopt -s nullglob
+WHEELS=("$WHEEL_DIR"/*"${PEP440_VERSION}"*.whl)
+shopt -u nullglob
+
+if [[ ${#WHEELS[@]} -eq 0 ]]; then
+    echo "Error: no wheels found matching version $PEP440_VERSION in $WHEEL_DIR" >&2
+    exit 1
+fi
+
+echo ""
+echo "Built wheel(s):"
+printf '  %s\n' "${WHEELS[@]}"
+
+# ---------------------------------------------------------------------------
+# Upload to Test PyPI
+# ---------------------------------------------------------------------------
+echo ""
+echo "Uploading to Test PyPI..."
+MATURIN_PYPI_TOKEN="$TEST_PYPI_API_TOKEN" \
+    maturin upload \
+        --repository-url https://test.pypi.org/legacy/ \
+        --skip-existing \
+        "${WHEELS[@]}"
+
+echo ""
+echo "Published $PEP440_VERSION to Test PyPI."
+echo "Install with:"
+echo "  pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ oxenai==$PEP440_VERSION"


### PR DESCRIPTION
Adds a new Test PyPI publishing workflow that allows building and publishing
`oxen-python` wheels to Test PyPI (https://test.pypi.org/) for any single commit.

The published version is a _development_ version. If the version is `0.5.0` then
the dev version is `0.5.0.devN` where `N` is the iteration number. `N` starts at 0
and is incremented for each change on a version. The last published version dev
version on Test PyPI is used to calculate the incremented `N`.

This workflow makes use of two new scripts:
- `patch_dev_version.sh`: updates `oxen-python`'s versions to use the `.devN` suffix
- `publish_test_pypi.sh`: builds `oxen-python` and publishes it to Test PyPI