### PR TITLE
Set platform arm64 when building oxen-server image

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -62,7 +62,7 @@ jobs:
           echo "RELEASE_VERSION=nightly-$(date +'%Y-%m-%d-%H_%M_%S')" >> $GITHUB_ENV
 
       - name: Build Docker Image
-        run: cd oxen-rust && docker build -t oxen/oxen-server .
+        run: cd oxen-rust && docker build -t oxen/oxen-server --platform linux/arm64 .
 
       - name: Save Docker
         run: docker save oxen/oxen-server -o oxen-server-docker-arm64-${{ env.RELEASE_VERSION }}.tar


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image builds to support ARM64 architecture, enabling native image availability for ARM-based systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->