### PR TITLE
Emojiify + Docker Labels + GHA Shell + Image Build Arch

### DIFF
--- a/.github/workflows/build_and_publish_test_pypi.yml
+++ b/.github/workflows/build_and_publish_test_pypi.yml
@@ -21,6 +21,10 @@ env:
   AWS_REGION: us-west-1
   PYTHON_VERSIONS: "3.13 3.12 3.11 3.10"
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
 jobs:
   set_env:
     name: Set env

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -6,6 +6,14 @@ on:
       branch:
         description: "Branch to build"
         required: true
+      ARCHITECTURE:
+        description: "The architecture to build for"
+        required: true
+        default: "arm64"
+        type: choice
+        options:
+          - arm64
+          - x86_64
 
 env:
   AWS_REGION: us-west-1
@@ -51,7 +59,7 @@ jobs:
               {"Key": "Name", "Value": "ec2-github-runner"}
             ]
 
-  release_docker_arm64:
+  release_docker:
     needs: start-self-hosted-runner
     runs-on: ${{ needs.start-self-hosted-runner.outputs.label }}
 
@@ -73,32 +81,32 @@ jobs:
           echo "COMMIT=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "BUILD_DATE_UTC=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
-      - name: Build oxen-server Docker Image (arm64)
+      - name: Build oxen-server Docker Image (${{ inputs.ARCHITECTURE }})
         run: |
           cd oxen-rust
           docker build \
             --label "org.opencontainers.image.revision=${{ steps.metadata.outputs.COMMIT }}" \
             --label "org.opencontainers.image.version=${{ steps.metadata.outputs.VERSION }}" \
             --label "org.opencontainers.image.created=${{ steps.metadata.outputs.BUILD_DATE_UTC }}" \
-            --label "org.opencontainers.image.architecture=arm64 \
+            --label "org.opencontainers.image.architecture=${{ inputs.ARCHITECTURE }}" \
             --label "org.opencontainers.image.title=oxen-server" \
-            -t oxen/oxen-server --platform linux/arm64 .
+            -t oxen/oxen-server --platform linux/${{ inputs.ARCHITECTURE }} .
 
       - name: Save Docker
-        run: docker save oxen/oxen-server -o oxen-server-docker-arm64-${{ env.RELEASE_VERSION }}.tar
+        run: docker save oxen/oxen-server -o oxen-server-docker-${{ inputs.ARCHITECTURE }}-${{ env.RELEASE_VERSION }}.tar
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: oxen-server-docker-arm64-${{ env.RELEASE_VERSION }}.tar
-          path: oxen-server-docker-arm64-${{ env.RELEASE_VERSION }}.tar
+          name: oxen-server-docker-${{ inputs.ARCHITECTURE }}-${{ env.RELEASE_VERSION }}.tar
+          path: oxen-server-docker-${{ inputs.ARCHITECTURE }}-${{ env.RELEASE_VERSION }}.tar
           retention-days: 1
 
   stop-self-hosted-runner:
     name: Stop self-hosted EC2 runner
     needs:
       - start-self-hosted-runner
-      - release_docker_arm64
+      - release_docker
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -7,13 +7,13 @@ on:
         description: "Branch to build. Also accepts commit sha and tag name."
         required: true
       ARCHITECTURE:
-        description: "The architecture to build for"
+        description: "The architecture to build for. Either amd64 (for x86_64) or arm64."
         required: true
         default: "arm64"
         type: choice
         options:
           - arm64
-          - x86_64
+          - amd64
 
 env:
   AWS_REGION: us-west-1
@@ -90,7 +90,8 @@ jobs:
             --label "org.opencontainers.image.created=${{ steps.metadata.outputs.BUILD_DATE_UTC }}" \
             --label "org.opencontainers.image.architecture=${{ inputs.ARCHITECTURE }}" \
             --label "org.opencontainers.image.title=oxen-server" \
-            -t oxen/oxen-server --platform linux/${{ inputs.ARCHITECTURE }} .
+            -t oxen/oxen-server \
+            --platform linux/${{ inputs.ARCHITECTURE }} .
 
       - name: Save Docker
         run: docker save oxen/oxen-server -o oxen-server-docker-${{ inputs.ARCHITECTURE }}-${{ env.RELEASE_VERSION }}.tar

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           VERSION=$(grep -m1 '^version = ' ${{ github.workspace }}/oxen-rust/src/server/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "COMMIT=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "COMMIT=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "BUILD_DATE_UTC=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - name: Build oxen-server Docker Image (arm64)

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch to build"
+        description: "Branch to build. Also accepts commit sha and tag name."
         required: true
       ARCHITECTURE:
         description: "The architecture to build for"

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -16,6 +16,10 @@ permissions:
   id-token: write
   contents: write
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
 jobs:
   start-self-hosted-runner:
     name: Start self-hosted EC2 runner

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -1,4 +1,4 @@
-name: Build branch for docker
+name: 🐳 Build branch for docker
 
 on:
   workflow_dispatch:
@@ -61,7 +61,7 @@ jobs:
         run: |
           echo "RELEASE_VERSION=nightly-$(date +'%Y-%m-%d-%H_%M_%S')" >> $GITHUB_ENV
 
-      - name: Build Docker Image
+      - name: Build oxen-server Docker Image (arm64)
         run: cd oxen-rust && docker build -t oxen/oxen-server --platform linux/arm64 .
 
       - name: Save Docker

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -61,8 +61,23 @@ jobs:
         run: |
           echo "RELEASE_VERSION=nightly-$(date +'%Y-%m-%d-%H_%M_%S')" >> $GITHUB_ENV
 
+      - name: Get build metadata
+        id: metadata
+        run: |
+          VERSION=$(grep -m1 '^version = ' ${{ github.workspace }}/oxen-rust/src/server/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "COMMIT=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "BUILD_DATE_UTC=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
       - name: Build oxen-server Docker Image (arm64)
-        run: cd oxen-rust && docker build -t oxen/oxen-server --platform linux/arm64 .
+        run: |
+          cd oxen-rust
+          docker build \
+            --label "COMMIT=${{ steps.metadata.outputs.COMMIT }}" \
+            --label "VERSION=${{ steps.metadata.outputs.VERSION }}" \
+            --label "BUILD_DATE_UTC=${{ steps.metadata.outputs.BUILD_DATE_UTC }}" \
+            --label "ARCHITECTURE=arm64" \
+            -t oxen/oxen-server --platform linux/arm64 .
 
       - name: Save Docker
         run: docker save oxen/oxen-server -o oxen-server-docker-arm64-${{ env.RELEASE_VERSION }}.tar

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -77,10 +77,11 @@ jobs:
         run: |
           cd oxen-rust
           docker build \
-            --label "COMMIT=${{ steps.metadata.outputs.COMMIT }}" \
-            --label "VERSION=${{ steps.metadata.outputs.VERSION }}" \
-            --label "BUILD_DATE_UTC=${{ steps.metadata.outputs.BUILD_DATE_UTC }}" \
-            --label "ARCHITECTURE=arm64" \
+            --label "org.opencontainers.image.revision=${{ steps.metadata.outputs.COMMIT }}" \
+            --label "org.opencontainers.image.version=${{ steps.metadata.outputs.VERSION }}" \
+            --label "org.opencontainers.image.created=${{ steps.metadata.outputs.BUILD_DATE_UTC }}" \
+            --label "org.opencontainers.image.architecture=arm64 \
+            --label "org.opencontainers.image.title=oxen-server" \
             -t oxen/oxen-server --platform linux/arm64 .
 
       - name: Save Docker

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -1,4 +1,4 @@
-name: 🐧 Build Linux Wheels
+name: 🧪🐧 Build Linux Wheels
 
 on:
   workflow_call:

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -19,6 +19,10 @@ on:
 env:
   MACOSX_DEPLOYMENT_TARGET: 10.13
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
 jobs:
   build_wheels:
     name: Build Python wheels

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -1,4 +1,4 @@
-name: 🍏 Build macOS Wheels
+name: 🧪🍏 Build macOS Wheels
 
 on:
   workflow_call:

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -1,4 +1,4 @@
-name: 🪟 Build Windows Wheels
+name: 🧪🪟 Build Windows Wheels
 
 on:
   workflow_call:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
 jobs:
   bump-version:
     name: Bump version and create tag

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,4 +1,4 @@
-name: Bump Version
+name: ⬆️ Bump Version
 
 run-name: Bump Oxen version (${{ github.event.inputs.version }})
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
 jobs:
   lint:
     if: github.event.pull_request.draft != true

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -3,6 +3,10 @@ name: 🐂🔎 Continuous integration - Lint
 on:
   workflow_call:
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
 jobs:
   check:
     name: Cargo check, format, clippy + Ruff

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -1,4 +1,4 @@
-name: 🐂 Continuous integration - Lint
+name: 🐂🔎 Continuous integration - Lint
 
 on:
   workflow_call:

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -1,4 +1,4 @@
-name: 🐂 Continuous integration - Test Suite
+name: 🐂📝 Continuous integration - Test Suite
 
 on:
   workflow_call:

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -7,16 +7,22 @@ jobs:
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             platform: linux
+            shell: bash -leo pipefail {0}
           - os: macos-latest
             platform: macos
+            shell: bash -leo pipefail {0}
           - os: windows-latest
             platform: windows
+            shell: powershell
       fail-fast: false
 
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   pull-requests: write
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
 jobs:
   publish_wheels:
     name: 🐍 Publish wheels to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   publish_wheels:
-    name: Publish wheels to PyPI
+    name: 🐍 Publish wheels to PyPI
     runs-on: ubuntu-latest
     steps:
       - uses: robinraju/release-downloader@v1.12
@@ -39,7 +39,7 @@ jobs:
 
   publish_liboxen_crate:
     # See https://crates.io/docs/trusted-publishing for details
-    name: Publish liboxen crate to crates.io
+    name: 🦀 Publish liboxen crate to crates.io
     runs-on: ubuntu-latest
     permissions:
       id-token: write     # Required for OIDC token exchange
@@ -56,7 +56,7 @@ jobs:
           cargo publish
 
   publish_homebrew_oxen:
-    name: Update oxen formula on homebrew-core
+    name: 🍺 Update oxen formula on homebrew-core
     runs-on: ubuntu-latest
     steps:
       - name: Update oxen formula on homebrew-core
@@ -75,7 +75,7 @@ jobs:
           COMMITTER_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
   publish_homebrew_oxen_server:
-    name: Update oxen-server formula on Oxen-AI/homebrew-oxen-server
+    name: 🍺 Update oxen-server formula on Oxen-AI/homebrew-oxen-server
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ env:
   AWS_REGION: us-west-1
   PYTHON_VERSIONS: "3.13 3.12 3.11 3.10"
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
 jobs:
   set_env:
     name: Set env

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -1,10 +1,10 @@
-name: 🚀 Release Docker
+name: 🚀🐳 Release Docker
 
 on:
   workflow_call:
     inputs:
       ARCHITECTURE:
-        description: "The architecture to build for"
+        description: "The architecture to build for. Either 'x86_64' or 'arm64'"
         required: true
         default: "x86_64"
         type: string

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Get build metadata
         id: metadata
         run: |
+          # https://github.com/opencontainers/image-spec
           VERSION=$(grep -m1 '^version = ' ${{ github.workspace }}/oxen-rust/src/server/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "COMMIT=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
@@ -97,10 +98,11 @@ jobs:
         run: |
           cd ${{ github.workspace }}/oxen-rust
           docker build \
-            --label "COMMIT=${{ steps.metadata.outputs.COMMIT }}" \
-            --label "VERSION=${{ steps.metadata.outputs.VERSION }}" \
-            --label "BUILD_DATE_UTC=${{ steps.metadata.outputs.BUILD_DATE_UTC }}" \
-            --label "ARCHITECTURE=${{ inputs.ARCHITECTURE }}" \
+            --label "org.opencontainers.image.revision=${{ steps.metadata.outputs.COMMIT }}" \
+            --label "org.opencontainers.image.version=${{ steps.metadata.outputs.VERSION }}" \
+            --label "org.opencontainers.image.created=${{ steps.metadata.outputs.BUILD_DATE_UTC }}" \
+            --label "org.opencontainers.image.architecture=${{ inputs.ARCHITECTURE }}" \
+            --label "org.opencontainers.image.title=oxen-server" \
             -t oxen/oxen-server .
 
       - name: Save Docker

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -85,10 +85,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Get build metadata
+        id: metadata
+        run: |
+          VERSION=$(grep -m1 '^version = ' ${{ github.workspace }}/oxen-rust/src/server/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "COMMIT=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "BUILD_DATE_UTC=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
       - name: Build Docker Image
         run: |
           cd ${{ github.workspace }}/oxen-rust
-          docker build -t oxen/oxen-server .
+          docker build \
+            --label "COMMIT=${{ steps.metadata.outputs.COMMIT }}" \
+            --label "VERSION=${{ steps.metadata.outputs.VERSION }}" \
+            --label "BUILD_DATE_UTC=${{ steps.metadata.outputs.BUILD_DATE_UTC }}" \
+            --label "ARCHITECTURE=${{ inputs.ARCHITECTURE }}" \
+            -t oxen/oxen-server .
 
       - name: Save Docker
         run: docker save oxen/oxen-server -o oxen-server-docker-${{ inputs.ARCHITECTURE }}.tar

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           VERSION=$(grep -m1 '^version = ' ${{ github.workspace }}/oxen-rust/src/server/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "COMMIT=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "COMMIT=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "BUILD_DATE_UTC=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - name: Build Docker Image

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -1,4 +1,4 @@
-name: 🚀 Release Linux
+name: 🚀🐧 Release Linux
 
 on:
   workflow_call:

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -1,4 +1,4 @@
-name: 🚀 Release MacOS
+name: 🚀🍏 Release MacOS
 
 on:
   workflow_call:

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -11,6 +11,10 @@ on:
 env:
   MACOSX_DEPLOYMENT_TARGET: 10.13
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
 jobs:
   release_macos:
     name: Release Oxen MacOS

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -66,6 +66,9 @@ jobs:
     name: Build Oxen CLI, Server, and Python wheels
     needs: start-self-hosted-runner
     runs-on: ${{ needs.start-self-hosted-runner.outputs.label }}
+    defaults:
+      run:
+        shell: powershell
 
     steps:
       - name: Checkout

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -1,4 +1,4 @@
-name: 🚀 Release Windows
+name: 🚀🪟 Release Windows
 
 on:
   workflow_call:


### PR DESCRIPTION
**Workflow Organization via Emojis**
Adds emojis to workflow names for fun and for organization! Emojis sort together in the GH actions UI.
- 🧪: test or development
- 🐂: continuous integration
- ⬆️: git-tagged version bump
- 🚀: building a release
- 📢: publishing a release
- 🍺: homebrew
- 🐳: docker
- 🦀: rust
- 🐍: python
- 🪟: windows
- 🐧: linux
- 🍏: macos

**Docker Image Labels**
All docker image build workflow steps now attach the following set of labels to the image
(all have the `org.opencontainers.image` prefix as per OCI Image format spec):
- `.revision`: the git commit being built (matching `git rev-parse HEAD`)
- `.version` the semantic version of the oxen code (matching `cargo version`)
- `.created` (when the build was started, in UTC, an ISO 8601 timestamp)
- `.architecture` (either "x86_64" or "arm64")

**Consistent GitHub Actions Shell Settings**
Make all *nix workflows use the same bash shell settings: `bash -leo pipefail {0}`
- (_already set by default_) exit on error (`-e`) and treat failing in a pipe as an error (`-o pipefail`)
- use the login shell (`-l`)

**Build Image Branch**
Made the architecture customizable in the `build_branch.yml` workflow. It still defaults to
`"arm64"`, but it now accepts `"x86_64"` as an alternative. Updates the target and the
label to use this parameter. Also documented that it can build a commit or git tag too.