### PR TITLE
Fix: Docker target is "amd64" not "x86_64"

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -3,10 +3,6 @@ name: 🐂📝 Continuous integration - Test Suite
 on:
   workflow_call:
 
-defaults:
-  run:
-    shell: bash -leo pipefail {0}
-
 jobs:
   test:
     name: Test Suite

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -3,6 +3,10 @@ name: 🐂📝 Continuous integration - Test Suite
 on:
   workflow_call:
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
 jobs:
   test:
     name: Test Suite

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -7,10 +7,7 @@ on:
         description: "The architecture to build for. Either 'amd64' (for x86_64) or 'arm64'"
         required: true
         default: "amd64"
-        type: choice
-        options:
-          - arm64
-          - amd64
+        type: string
       AWS_ROLE:
         description: "AWS role to assume"
         required: true
@@ -39,7 +36,19 @@ env:
   EC2_INSTANCE_TYPE_ARM64: m7g.4xlarge
 
 jobs:
+  validate-inputs:
+    name: Validate inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate ARCHITECTURE
+        run: |
+          if [ "${{ inputs.ARCHITECTURE }}" != "amd64" ] && [ "${{ inputs.ARCHITECTURE }}" != "arm64" ]; then
+            echo "::error::ARCHITECTURE must be 'amd64' or 'arm64', got: '${{ inputs.ARCHITECTURE }}'"
+            exit 1
+          fi
+
   start-self-hosted-runner:
+    needs: validate-inputs
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -4,10 +4,13 @@ on:
   workflow_call:
     inputs:
       ARCHITECTURE:
-        description: "The architecture to build for. Either 'x86_64' or 'arm64'"
+        description: "The architecture to build for. Either 'amd64' (for x86_64) or 'arm64'"
         required: true
-        default: "x86_64"
-        type: string
+        default: "amd64"
+        type: choice
+        options:
+          - arm64
+          - amd64
       AWS_ROLE:
         description: "AWS role to assume"
         required: true
@@ -103,7 +106,8 @@ jobs:
             --label "org.opencontainers.image.created=${{ steps.metadata.outputs.BUILD_DATE_UTC }}" \
             --label "org.opencontainers.image.architecture=${{ inputs.ARCHITECTURE }}" \
             --label "org.opencontainers.image.title=oxen-server" \
-            -t oxen/oxen-server .
+            -t oxen/oxen-server \
+            --platform linux/${{ inputs.ARCHITECTURE }} .
 
       - name: Save Docker
         run: docker save oxen/oxen-server -o oxen-server-docker-${{ inputs.ARCHITECTURE }}.tar


### PR DESCRIPTION
The Docker platform target for x86_64 processor architectures is "amd64".
Fixes the `release_docker` workflow to use this. Also enables it to correctly
build for either "arm64" or "amd64" architectures. Fails-fast if arch is invalid.