### PR TITLE
oxen commit prompts text editor to write commit message

### DIFF
--- a/oxen-rust/src/cli/src/cmd/commit.rs
+++ b/oxen-rust/src/cli/src/cmd/commit.rs
@@ -1,6 +1,9 @@
 use async_trait::async_trait;
 use clap::{Arg, Command};
+use std::io::Write;
+use tempfile::TempDir;
 
+use liboxen::config::UserConfig;
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
@@ -26,7 +29,7 @@ impl RunCmd for CommitCmd {
                     .help("The message for the commit. Should be descriptive about what changed.")
                     .long("message")
                     .short('m')
-                    .required(true)
+                    .required(false)
                     .action(clap::ArgAction::Set),
             )
             .arg(
@@ -38,11 +41,9 @@ impl RunCmd for CommitCmd {
     }
 
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
-        // Parse Args
-        let Some(message) = args.get_one::<String>("message") else {
-            return Err(OxenError::basic_str(
-                "Err: Usage `oxen commit -m <message>`",
-            ));
+        let message = match args.get_one::<String>("message") {
+            Some(msg) => msg.clone(),
+            None => get_message_from_editor(UserConfig::get().ok().as_ref())?,
         };
 
         let allow_empty = args.get_flag("allow_empty");
@@ -53,11 +54,112 @@ impl RunCmd for CommitCmd {
         println!("Committing with message: {message}");
 
         if allow_empty {
-            repositories::commits::commit_allow_empty(&repo, message)?;
+            repositories::commits::commit_allow_empty(&repo, &message)?;
         } else {
-            repositories::commit(&repo, message)?;
+            repositories::commit(&repo, &message)?;
         }
 
         Ok(())
     }
+}
+
+fn resolve_editor(maybe_config: Option<&UserConfig>) -> Option<String> {
+    // 1. Check UserConfig
+    if let Some(config) = maybe_config {
+        if let Some(ref editor) = config.editor {
+            if !editor.is_empty() {
+                return Some(editor.to_string());
+            }
+        }
+    }
+
+    // 2. Fall back to VISUAL env var
+    if let Ok(editor) = std::env::var("VISUAL") {
+        if !editor.is_empty() {
+            return Some(editor);
+        }
+    }
+
+    // 3. Fall back to EDITOR env var
+    if let Ok(editor) = std::env::var("EDITOR") {
+        if !editor.is_empty() {
+            return Some(editor);
+        }
+    }
+
+    None
+}
+
+fn get_message_from_editor(maybe_config: Option<&UserConfig>) -> Result<String, OxenError> {
+    let editor = resolve_editor(maybe_config).ok_or_else(|| {
+        OxenError::basic_str(
+            "No editor is configured and no commit message was provided via -m.\n\n\
+             To set your preferred editor, run:\n    \
+             oxen config --editor <EDITOR>\n\n\
+             Or manually add the following to ~/.config/oxen/user_config.toml:\n    \
+             editor = \"vim\"",
+        )
+    })?;
+
+    // Create a temp file with a comment template
+    // NOTE: when temp_dir is dropped the directory it made will be deleted
+    let temp_dir = TempDir::new()?;
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let temp_path = temp_dir
+        .path()
+        .join(format!("oxen_commit_msg_{timestamp}.txt"));
+
+    let template = "\n# Please enter the commit message for your changes.\n\
+                     # Lines starting with '#' will be ignored, and an empty message aborts the commit.\n";
+
+    {
+        let mut file = std::fs::File::create(&temp_path)
+            .map_err(|e| OxenError::basic_str(format!("Failed to create temp file: {e}")))?;
+        file.write_all(template.as_bytes())
+            .map_err(|e| OxenError::basic_str(format!("Failed to write to temp file: {e}")))?;
+    }
+
+    // Spawn the editor
+    // Split the editor string to support commands like "code --wait"
+    let parts: Vec<&str> = editor.split_whitespace().collect();
+    if parts.is_empty() {
+        return Err(OxenError::basic_str(
+            "Must supply valid editor path, not an empty/whitespace-only string.",
+        ));
+    }
+    let status = std::process::Command::new(parts[0])
+        .args(&parts[1..])
+        .arg(&temp_path)
+        .status()
+        .map_err(|e| OxenError::basic_str(format!("Failed to open editor '{editor}': {e}")))?;
+
+    if !status.success() {
+        return Err(OxenError::basic_str(format!(
+            "Editor '{editor}' exited with non-zero status."
+        )));
+    }
+
+    // Read the file and strip comments
+    let contents = std::fs::read_to_string(&temp_path)
+        .map_err(|e| OxenError::basic_str(format!("Failed to read temp file: {e}")))?;
+    let _ = std::fs::remove_file(&temp_path);
+
+    let message: String = contents
+        .lines()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .collect::<Vec<&str>>()
+        .join("\n");
+    let message = message.trim().to_string();
+
+    if message.is_empty() {
+        return Err(OxenError::basic_str(
+            "Aborting commit due to empty commit message.",
+        ));
+    }
+
+    Ok(message)
 }

--- a/oxen-rust/src/cli/src/cmd/config.rs
+++ b/oxen-rust/src/cli/src/cmd/config.rs
@@ -89,6 +89,12 @@ impl RunCmd for ConfigCmd {
                     .help("Sets the default host used to check version numbers. If empty, the CLI will not do a version check.")
                     .action(clap::ArgAction::Set),
             )
+            .arg(
+                Arg::new("editor")
+                    .long("editor")
+                    .help("Set the default text editor for commit messages (e.g. vim, nano, code --wait).")
+                    .action(clap::ArgAction::Set),
+            )
             .arg_required_else_help(true)
     }
 
@@ -127,6 +133,15 @@ impl RunCmd for ConfigCmd {
 
         if let Some(default_host) = args.get_one::<String>("default-host") {
             match self.set_default_host(default_host) {
+                Ok(_) => {}
+                Err(err) => {
+                    eprintln!("{err}")
+                }
+            }
+        }
+
+        if let Some(editor) = args.get_one::<String>("editor") {
+            match self.set_editor(editor) {
                 Ok(_) => {}
                 Err(err) => {
                     eprintln!("{err}")
@@ -259,6 +274,13 @@ impl ConfigCmd {
     pub fn set_user_email(&self, email: &str) -> Result<(), OxenError> {
         let mut config = UserConfig::get_or_create()?;
         config.email = String::from(email);
+        config.save_default()?;
+        Ok(())
+    }
+
+    pub fn set_editor(&self, editor: &str) -> Result<(), OxenError> {
+        let mut config = UserConfig::get_or_create()?;
+        config.editor = Some(String::from(editor));
         config.save_default()?;
         Ok(())
     }

--- a/oxen-rust/src/lib/src/config/user_config.rs
+++ b/oxen-rust/src/lib/src/config/user_config.rs
@@ -12,6 +12,8 @@ pub const USER_CONFIG_FILENAME: &str = "user_config.toml";
 pub struct UserConfig {
     pub name: String,
     pub email: String,
+    #[serde(default)]
+    pub editor: Option<String>,
 }
 
 impl UserConfig {
@@ -24,6 +26,7 @@ impl UserConfig {
         UserConfig {
             name: user.name.to_owned(),
             email: user.email.to_owned(),
+            editor: None,
         }
     }
 
@@ -38,6 +41,7 @@ impl UserConfig {
         UserConfig {
             name: String::from(""),
             email: String::from(""),
+            editor: None,
         }
     }
 

--- a/oxen-rust/src/lib/src/repositories/commits/commit_writer.rs
+++ b/oxen-rust/src/lib/src/repositories/commits/commit_writer.rs
@@ -95,6 +95,7 @@ pub fn commit_with_user(
     let cfg = UserConfig {
         name: user.name.clone(),
         email: user.email.clone(),
+        editor: None,
     };
     commit_with_cfg(repo, message, &cfg, None)
 }


### PR DESCRIPTION
All commits require a commit message. Previously, `oxen commit` required the 
`-m <MESSAGE>` flag, requiring that the user writes their commit message as a 
CLI argument.

Now, when called without `-m`, `oxen commit` will open up the user's configured
text editor to write the commit message. This UX is modeled after `git commit`.
There's a new `editor` user config option, which is the path to the text editing 
program that `oxen commit` uses. If that is unset, it, like `git`, checks first 
`VISUAL` then `EDITOR` environment variables to locate a suitable text editor. 
If those are not populated, then `oxen commit` emits an error message telling the
user to `oxen config --set editor=<TEXT EDITOR>`.