### PR TITLE
Have CI lint job run pre-commit hooks

### DIFF
--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -43,34 +43,12 @@ jobs:
           sudo apt-get update
           sudo apt install -y clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev pkg-config
 
-      - name: Cargo Check
+      - name: Install dev tools for pre-commit hooks
         run: |
-          cd ${{ github.workspace }}/oxen-rust
-          # cargo build
-          cargo check --all-features
+          cargo install cargo-sort
+          uv tool install pre-commit
 
-          cd ${{ github.workspace }}/oxen-python
-          cargo build
-          # cargo check --all-targets --all-features
-
-      - name: Cargo Format
+      - name: Run Pre-Commit Hooks
         run: |
-          cd ${{ github.workspace }}/oxen-rust
-          cargo fmt --all -- --check
-
-          cd ${{ github.workspace }}/oxen-python
-          cargo fmt --all -- --check
-
-      - name: Cargo Clippy
-        run: |
-          cd ${{ github.workspace }}/oxen-rust
-          cargo clippy --no-deps -- -D warnings
-
-          cd ${{ github.workspace }}/oxen-python
-          cargo clippy --no-deps -- -D warnings
-
-      - name: Ruff check
-        run: |
-          cd ${{ github.workspace }}/oxen-python
-
-          uvx ruff check .
+          cd ${{ github.workspace }}
+          pre-commit run --verbose --all-files

--- a/oxen-rust/docs/annotation/RemoteStaging.md
+++ b/oxen-rust/docs/annotation/RemoteStaging.md
@@ -81,7 +81,7 @@ Files to be committed:
 
 ## Delete Remotely Added File
 
-If you accidentally add a file to the remote staging area and want to remove it, no worries—you can unstage it with `oxen remote rm`.
+If you accidentally add file from the remote staging area and want to remove it, no worries! You can unstage it with `oxen remote rm`.
 
 (TODO: right now the functionality only operates on staging area regardless of the --staged flag, we might want to allow remote removing of files and directories).
 

--- a/oxen-rust/docs/annotation/RemoteStaging.md
+++ b/oxen-rust/docs/annotation/RemoteStaging.md
@@ -81,7 +81,7 @@ Files to be committed:
 
 ## Delete Remotely Added File
 
-If you accidentally add file from the remote staging area and want to remove it, no worries! You can unstage it with `oxen remote rm`.
+If you accidentally add a file to the remote staging area and want to remove it, no worries! You can unstage it with `oxen remote rm`.
 
 (TODO: right now the functionality only operates on staging area regardless of the --staged flag, we might want to allow remote removing of files and directories).
 


### PR DESCRIPTION
The CI lint job only runs `clippy` and `cargo format` on `oxen-rust`
and `ruff check` on `oxen-python`. The pre-commit hooks run `clippy`
and `format` on all Rust code and run both `ruff check` and `ruff format`
on `oxen-python`.

This updates the CI lint job to run pre-commit hooks instead of running 
individual commands.