### PR TITLE
Refactor oxen-server: clap derives, ServerError, re-structure cmd exe

### DIFF
--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
+ "thiserror 2.0.18",
  "thumbnails",
  "time",
  "tokio",
@@ -1145,7 +1146,7 @@ dependencies = [
  "crc32fast",
  "futures-lite",
  "pin-project",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
 ]
@@ -1195,7 +1196,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "v_frame",
  "y4m",
 ]
@@ -5572,7 +5573,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -5738,6 +5739,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -6818,7 +6820,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls 0.23.35",
  "socket2 0.6.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -6839,7 +6841,7 @@ dependencies = [
  "rustls 0.23.35",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -7011,7 +7013,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -7151,7 +7153,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8015,7 +8017,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -8369,11 +8371,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -8389,9 +8391,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9968,7 +9970,7 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "xz2",
  "zeroize",

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -166,6 +166,7 @@ sqlparser = "0.53.0"
 sysinfo = "0.33.0"
 tar = "0.4.44"
 tempfile = "3.8.0"
+thiserror = "2.0.18"
 thumbnails = { version = "0.2.1", optional = true }
 time = { version = "0.3.28", features = ["serde"] }
 tokio = { version = "1.32.0", features = ["full", "tracing"] }

--- a/oxen-rust/src/server/Cargo.toml
+++ b/oxen-rust/src/server/Cargo.toml
@@ -44,6 +44,7 @@ sanitize-filename = "0.6.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
 tar = "0.4.44"
+thiserror = "2.0.18"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.16", features = ["io-util"] }


### PR DESCRIPTION
**Derive Clap Parser**
Major refactor of `oxen-server`'s CLI parsing with clap. It now uses a struct 
with `#[derive(Parser)]` and a new enum with `#[derive(Subcommand)]`.
This makes the CLI argument parsing safer: we don't have to manually poke
`clap` with `Option<.>`-inducing results and manually re-parsing its output
to figure out what command we want to run. Now, we have type-safe, ergonomic
structured argument and sub-command parsing.

**`ServerError` and `thiserror`**
Adds a new `ServerError` enum type, which uses `thiserror`'s `[#from]` macro
to automatically generate `Into` implementations. It uses `#[derive(Error)]` from
`thiserror` to automatically derive a `std::fmt::Display` and `std::errrors::Error` impl.

This PR adds a new dependency on `thiserror`.

**Refactor Server Main**
Refactors the logic of the server's main.rs to break-out logic for each command
into separate functions, increasing readability.