### PR TITLE
oxen-rust test script can select random free port or be explicit

### DIFF
--- a/oxen-rust/README.md
+++ b/oxen-rust/README.md
@@ -268,11 +268,13 @@ To run with all debug output and run a specific test
 env RUST_LOG=warn,liboxen=debug,integration_test=debug scripts/test-rust --no-capture test_command_push_clone_pull_push
 ```
 
-To set a different test host you can set the `OXEN_TEST_HOST` environment variable
+To explicitly set the port for the `oxen-server` used in tests, set `OXEN_PORT`:
 
 ```bash
-env OXEN_TEST_HOST=0.0.0.0:4000 scripts/test-rust
+env OXEN_PORT=4000 scripts/test-rust
 ```
+
+The script will select a random free port in [3000, 6000] if `OXEN_PORT` is unset.
 
 # Oxen Server
 

--- a/oxen-rust/README.md
+++ b/oxen-rust/README.md
@@ -274,7 +274,6 @@ To explicitly set the port for the `oxen-server` used in tests, set `OXEN_PORT`:
 env OXEN_PORT=4000 scripts/test-rust
 ```
 
-The script will select a random free port in [3000, 6000] if `OXEN_PORT` is unset.
 
 # Oxen Server
 

--- a/oxen-rust/scripts/test-rust
+++ b/oxen-rust/scripts/test-rust
@@ -103,7 +103,7 @@ fi
 echo "==> oxen-server running on port ${OXEN_PORT} (pid $SERVER_PID)."
 
 # ---------- 6. Run tests ----------
-echo "==> Running tests with 'cargo nextest run $@' ..."
+echo "==> Running tests with 'OXEN_TEST_HOST=${OXEN_TEST_HOST} cargo nextest run $@' ..."
 cargo nextest run "$@"
 
 # cleanup handled via the trapped cleanup function

--- a/oxen-rust/scripts/test-rust
+++ b/oxen-rust/scripts/test-rust
@@ -71,6 +71,7 @@ wait_for_server() {
 
 if ! wait_for_server || ! kill -0 "$SERVER_PID" 2>/dev/null; then
   echo "ERROR: oxen-server failed to start."
+	exit 1
 fi
 echo "==> oxen-server running (pid $SERVER_PID)."
 

--- a/oxen-rust/scripts/test-rust
+++ b/oxen-rust/scripts/test-rust
@@ -103,7 +103,7 @@ fi
 echo "==> oxen-server running on port ${OXEN_PORT} (pid $SERVER_PID)."
 
 # ---------- 6. Run tests ----------
-echo "==> Running tests with 'OXEN_TEST_HOST=${OXEN_TEST_HOST} cargo nextest run $@' ..."
+echo "==> Running tests with 'cargo nextest run $@' ..."
 cargo nextest run "$@"
 
 # cleanup handled via the trapped cleanup function

--- a/oxen-rust/scripts/test-rust
+++ b/oxen-rust/scripts/test-rust
@@ -61,7 +61,7 @@ SERVER_PID=$!
 # Give the server a moment to start
 wait_for_server() {
   for i in $(seq 1 30); do
-    if curl -s -o /dev/null --fail http://localhost:3001/api/health 2>/dev/null; then
+    if curl -s -o /dev/null --fail http://localhost:3000/api/health 2>/dev/null; then
       return 0
     fi
     sleep 0.5

--- a/oxen-rust/scripts/test-rust
+++ b/oxen-rust/scripts/test-rust
@@ -98,7 +98,7 @@ wait_for_server() {
 
 if ! wait_for_server || ! kill -0 "$SERVER_PID" 2>/dev/null; then
   echo "ERROR: oxen-server failed to start on port ${OXEN_PORT}."
-	exit 1
+  exit 1
 fi
 echo "==> oxen-server running on port ${OXEN_PORT} (pid $SERVER_PID)."
 

--- a/oxen-rust/scripts/test-rust
+++ b/oxen-rust/scripts/test-rust
@@ -53,15 +53,42 @@ else
     echo "==> Test user already configured, skipping."
 fi
 
-# ---------- 5. Start oxen-server ----------
-echo "==> Starting oxen-server..."
-./target/debug/oxen-server start &
+# ---------- 5. Select port and start oxen-server ----------
+port_is_free() {
+  ! lsof -i :"$1" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+if [ -n "${OXEN_PORT:-}" ]; then
+    if ! port_is_free "$OXEN_PORT"; then
+        echo "ERROR: Something is already listening on port $OXEN_PORT. Stop it before running tests."
+        exit 1
+    fi
+else
+    OXEN_PORT=""
+    for _ in $(seq 1 10); do
+        CANDIDATE=$(( RANDOM % 3001 + 3000 ))
+        if port_is_free "$CANDIDATE"; then
+            OXEN_PORT="$CANDIDATE"
+            break
+        fi
+    done
+    if [ -z "$OXEN_PORT" ]; then
+        echo "ERROR: Could not find an open port in range 3000-6000 after 10 attempts."
+        echo "Please supply OXEN_PORT directly, e.g.: OXEN_PORT=4567 $0 $*"
+        exit 1
+    fi
+fi
+
+export OXEN_TEST_HOST="localhost:${OXEN_PORT}"
+
+echo "==> Starting oxen-server on port ${OXEN_PORT}..."
+./target/debug/oxen-server start -p "${OXEN_PORT}" &
 SERVER_PID=$!
 
 # Give the server a moment to start
 wait_for_server() {
   for i in $(seq 1 30); do
-    if curl -s -o /dev/null --fail http://localhost:3000/api/health 2>/dev/null; then
+    if curl -s -o /dev/null --fail "http://localhost:${OXEN_PORT}/api/health" 2>/dev/null; then
       return 0
     fi
     sleep 0.5
@@ -70,10 +97,10 @@ wait_for_server() {
 }
 
 if ! wait_for_server || ! kill -0 "$SERVER_PID" 2>/dev/null; then
-  echo "ERROR: oxen-server failed to start."
+  echo "ERROR: oxen-server failed to start on port ${OXEN_PORT}."
 	exit 1
 fi
-echo "==> oxen-server running (pid $SERVER_PID)."
+echo "==> oxen-server running on port ${OXEN_PORT} (pid $SERVER_PID)."
 
 # ---------- 6. Run tests ----------
 echo "==> Running tests with 'cargo nextest run $@' ..."


### PR DESCRIPTION
**Bug Fixes**
- Test script does `exit 1` if the server isn't able to start.
- The health check now uses the right port for the server.

**New Features**
- An explicit server port can be specified via `OXEN_PORT`.
- If left unspecified, then the script selects a random port in [3000,6000]
    + if that port is not free, it tries up to 10 times to randomly select a free port
- If the selected port is in-use, it prints an error and does `exit 1`
