### PR TITLE
oxen-server flag to show a backtrace on stack-overflow

### DIFF
--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -269,6 +269,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1543,32 @@ dependencies = [
  "aws-smithy-types",
  "rustc_version",
  "tracing",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
+name = "backtrace-on-stack-overflow"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd2d70527f3737a1ad17355e260706c1badebabd1fa06a7a053407380df841b"
+dependencies = [
+ "backtrace",
+ "libc",
+ "nix",
 ]
 
 [[package]]
@@ -3436,6 +3471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4749,6 +4790,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4914,6 +4964,19 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "nom"
@@ -5251,6 +5314,7 @@ dependencies = [
  "astral-tokio-tar",
  "async-compression",
  "async_zip",
+ "backtrace-on-stack-overflow",
  "bytesize",
  "clap",
  "derive_more 1.0.0",
@@ -6869,6 +6933,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -39,6 +39,7 @@ async-std = { version = "1.12.0", features = ["unstable"] }
 async-tar = "0.5.0"
 async-trait = "0.1.80"
 async_zip = { version = "0.0.18", features = ["full"] }
+backtrace-on-stack-overflow = "0.3.0"
 aws-config = "1.8.11"
 aws-sdk-s3 = "1.118.0"
 bincode = "1.3.3"

--- a/oxen-rust/src/server/Cargo.toml
+++ b/oxen-rust/src/server/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 actix-http = { workspace = true }
+backtrace-on-stack-overflow = { workspace = true }
 actix-multipart = { workspace = true }
 actix-web = { workspace = true }
 actix-web-httpauth = { workspace = true }

--- a/oxen-rust/src/server/src/main.rs
+++ b/oxen-rust/src/server/src/main.rs
@@ -322,6 +322,13 @@ enum ServerCommand {
             help = "Start the server with token-based authentication enforced"
         )]
         auth: bool,
+
+        /// Enable backtrace on stack overflow. NOT for production use.
+        #[arg(
+            long = "backtrace-on-stack-overflow",
+            help = "Enable backtrace-on-stack-overflow for debugging. DO NOT use in production."
+        )]
+        backtrace_on_stack_overflow: bool,
     },
 
     /// Create a new user in the server and output the config file for that user
@@ -394,7 +401,20 @@ async fn main() -> Result<(), ServerError> {
     );
 
     match ServerCli::parse().command {
-        ServerCommand::Start { ip, port, auth } => {
+        ServerCommand::Start {
+            ip,
+            port,
+            auth,
+            backtrace_on_stack_overflow,
+        } => {
+            if backtrace_on_stack_overflow {
+                eprintln!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+                eprintln!("!!! WARNING: backtrace-on-stack-overflow is ENABLED  !!!");
+                eprintln!("!!! This should NOT be used in production.           !!!");
+                eprintln!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+                unsafe { backtrace_on_stack_overflow::enable() };
+            }
+
             println!("🐂 v{VERSION}");
             println!("{SUPPORT}");
 


### PR DESCRIPTION
Adds the `backtrace-on-stack-overflow` crate and a new flag in `oxen-server` to enable this.
Used for debugging stack overflow errors. Not for production use.