### PR TITLE
Standardized keep-alive and retry logic for http clients

### DIFF
--- a/oxen-rust/src/lib/src/api/client.rs
+++ b/oxen-rust/src/lib/src/api/client.rs
@@ -6,7 +6,6 @@ use crate::config::RuntimeConfig;
 use crate::config::runtime_config::runtime::Runtime;
 use crate::constants;
 use crate::error::OxenError;
-use crate::model::RemoteRepository;
 use crate::view::OxenResponse;
 use crate::view::http;
 pub use reqwest::Url;
@@ -29,6 +28,7 @@ pub mod metadata;
 pub mod oxen_version;
 pub mod prune;
 pub mod repositories;
+pub mod retry;
 pub mod revisions;
 pub mod schemas;
 pub mod stats;
@@ -48,73 +48,100 @@ pub fn get_scheme_and_host_from_url<U: IntoUrl>(url: U) -> Result<(String, Strin
     Ok((parsed_url.scheme().to_owned(), host_str))
 }
 
-// TODO: we probably want to create a pool of clients instead of constructing a
-// new one for each request so we can take advantage of keep-alive
+// Note: reqwest::Client already maintains an internal HTTP connection pool with keep-alive.
+// The 3 upload paths that matter most (push, version chunks, workspace files) already share
+// clients via Arc<Client>. A global per-host cache (OnceCell + RwLock<HashMap>) would add
+// complexity for little gain since per-request client overhead for metadata/query paths is minimal.
 pub fn new_for_url<U: IntoUrl>(url: U) -> Result<Client, OxenError> {
     let (_scheme, host) = get_scheme_and_host_from_url(url)?;
-    new_for_host(host, true)
+    new_for_host(&host, true)
 }
 
 pub fn new_for_url_no_user_agent<U: IntoUrl>(url: U) -> Result<Client, OxenError> {
     let (_scheme, host) = get_scheme_and_host_from_url(url)?;
-    new_for_host(host, false)
+    new_for_host(&host, false)
 }
 
-fn new_for_host<S: AsRef<str>>(host: S, should_add_user_agent: bool) -> Result<Client, OxenError> {
-    match builder_for_host(host.as_ref(), should_add_user_agent)?
-        .timeout(time::Duration::from_secs(constants::timeout()))
-        .build()
-    {
-        Ok(client) => Ok(client),
-        Err(reqwest_err) => Err(OxenError::HTTP(reqwest_err)),
-    }
+/// Has connection timeout and TCP keep-alives, but also imposes a per-request timeout.
+/// NOT SUITABLE FOR LONG-LIVED TRANSFERS! Use `new_for_url_transfer` instead.
+fn new_for_host(host: &str, should_add_user_agent: bool) -> Result<Client, OxenError> {
+    builder_for_host(
+        host,
+        should_add_user_agent,
+        time::Duration::from_secs(constants::connect_timeout()),
+        time::Duration::from_secs(constants::tcp_keepalive()),
+        time::Duration::from_secs(20),
+    )?
+    .timeout(time::Duration::from_secs(constants::timeout()))
+    .build()
+    .map_err(OxenError::HTTP)
 }
 
-pub fn new_for_remote_repo(remote_repo: &RemoteRepository) -> Result<Client, OxenError> {
-    let (_scheme, host) = get_scheme_and_host_from_url(remote_repo.url())?;
-    new_for_host(host, true)
-}
-
-pub fn builder_for_remote_repo(remote_repo: &RemoteRepository) -> Result<ClientBuilder, OxenError> {
-    let (_scheme, host) = get_scheme_and_host_from_url(remote_repo.url())?;
-    builder_for_host(host, true)
-}
-
-pub fn builder_for_url<U: IntoUrl>(url: U) -> Result<ClientBuilder, OxenError> {
+/// Create a client for long-lived transfers (uploads/downloads).
+/// No overall timeout; uses connect_timeout + tcp_keepalive + HTTP/2 keep-alive
+/// to detect hung connections without capping total transfer time.
+pub fn new_for_url_transfer<U: IntoUrl>(url: U) -> Result<Client, OxenError> {
     let (_scheme, host) = get_scheme_and_host_from_url(url)?;
-    builder_for_host(host, true)
+    builder_for_host(
+        &host,
+        true,
+        time::Duration::from_secs(constants::connect_timeout()),
+        time::Duration::from_secs(constants::tcp_keepalive()),
+        time::Duration::from_secs(20),
+    )?
+    .build()
+    .map_err(OxenError::HTTP)
 }
 
-fn builder_for_host<S: AsRef<str>>(
-    host: S,
+fn new_for_host_transfer(host: &str) -> Result<Client, OxenError> {
+    builder_for_host(
+        host,
+        true,
+        time::Duration::from_secs(constants::connect_timeout()),
+        time::Duration::from_secs(constants::tcp_keepalive()),
+        time::Duration::from_secs(20),
+    )?
+    .build()
+    .map_err(OxenError::HTTP)
+}
+
+fn builder_for_host(
+    host: &str,
     should_add_user_agent: bool,
+    connect_timeout: time::Duration,
+    keep_alive_interval: time::Duration,
+    http2_keep_alive_timeout: time::Duration,
 ) -> Result<ClientBuilder, OxenError> {
-    let builder = if should_add_user_agent {
-        builder()
-    } else {
-        Ok(builder_no_user_agent())
-    };
+    let mut builder = Client::builder();
+
+    if should_add_user_agent {
+        let user_agent = build_user_agent()?;
+        builder = builder.user_agent(user_agent);
+    }
+
+    builder = builder
+        .connect_timeout(connect_timeout)
+        .tcp_keepalive(keep_alive_interval)
+        .http2_keep_alive_interval(keep_alive_interval)
+        .http2_keep_alive_timeout(http2_keep_alive_timeout);
 
     // If auth_config.toml isn't found, return without authorizing
     let config = match AuthConfig::get() {
         Ok(config) => config,
         Err(e) => {
-            log::debug!(
-                "Error getting config: {}. No auth token found for host {}",
-                e,
-                host.as_ref()
-            );
-            return builder;
+            log::debug!("Error getting config: {e}. No auth token found for host {host}");
+            return Ok(builder);
         }
     };
-    if let Some(auth_token) = config.auth_token_for_host(host.as_ref()) {
-        log::debug!("Setting auth token for host: {}", host.as_ref());
+
+    if let Some(auth_token) = config.auth_token_for_host(host) {
+        log::debug!("Setting auth token for host: {}", host);
         let auth_header = format!("Bearer {auth_token}");
         let mut auth_value = match header::HeaderValue::from_str(auth_header.as_str()) {
             Ok(header) => header,
             Err(e) => {
                 log::debug!("Invalid header value: {e}");
-                return Err(OxenError::basic_str(
+                return Err(OxenError::authentication(
                     "Error setting request auth. Please check your Oxen config.",
                 ));
             }
@@ -122,20 +149,13 @@ fn builder_for_host<S: AsRef<str>>(
         auth_value.set_sensitive(true);
         let mut headers = header::HeaderMap::new();
         headers.insert(header::AUTHORIZATION, auth_value);
-        Ok(builder?.default_headers(headers))
+
+        builder = builder.default_headers(headers);
     } else {
-        log::trace!("No auth token found for host: {}", host.as_ref());
-        builder
+        log::trace!("No auth token found for host: {host}");
     }
-}
 
-fn builder() -> Result<ClientBuilder, OxenError> {
-    let user_agent = build_user_agent()?;
-    Ok(Client::builder().user_agent(user_agent))
-}
-
-fn builder_no_user_agent() -> ClientBuilder {
-    Client::builder()
+    Ok(builder)
 }
 
 fn build_user_agent() -> Result<String, OxenError> {

--- a/oxen-rust/src/lib/src/api/client/commits.rs
+++ b/oxen-rust/src/lib/src/api/client/commits.rs
@@ -719,7 +719,7 @@ pub async fn post_commit_dir_hashes_to_server(
 
     let quiet_bar = Arc::new(ProgressBar::hidden());
 
-    let client = client::new_for_remote_repo(remote_repo)?;
+    let client = client::new_for_host_transfer(remote_repo.url())?;
     post_data_to_server_with_client(
         &client,
         remote_repo,
@@ -763,18 +763,15 @@ pub async fn post_commits_dir_hashes_to_server(
 
     let buffer: Vec<u8> = tar.into_inner()?.finish()?;
 
-    let is_compressed = true;
-    let filename = None;
-
     let quiet_bar = Arc::new(ProgressBar::hidden());
 
-    let client = client::new_for_remote_repo(remote_repo)?;
+    let client = client::new_for_host_transfer(remote_repo.url())?;
     post_data_to_server_with_client(
         &client,
         remote_repo,
         buffer,
-        is_compressed,
-        &filename,
+        true,  // compression
+        &None, // filename
         quiet_bar,
     )
     .await
@@ -838,33 +835,15 @@ pub async fn upload_single_tarball_to_server_with_client_with_retry(
     buffer: &[u8],
     bar: Arc<ProgressBar>,
 ) -> Result<(), OxenError> {
-    let mut total_tries = 0;
-
-    while total_tries < constants::NUM_HTTP_RETRIES {
-        match upload_single_tarball_to_server_with_client(
-            client,
-            remote_repo,
-            buffer,
-            bar.to_owned(),
-        )
-        .await
-        {
-            Ok(_) => {
-                return Ok(());
-            }
-            Err(err) => {
-                total_tries += 1;
-                // Exponentially back off
-                let sleep_time = total_tries * total_tries;
-                log::debug!(
-                    "upload_single_tarball_to_server_with_retry upload failed sleeping {sleep_time}: {err:?}"
-                );
-                std::thread::sleep(std::time::Duration::from_secs(sleep_time));
-            }
+    let config = crate::api::client::retry::RetryConfig::default();
+    crate::api::client::retry::with_retry(&config, |_attempt| {
+        let bar = bar.clone();
+        async move {
+            upload_single_tarball_to_server_with_client(client, remote_repo, buffer, bar).await?;
+            Ok(())
         }
-    }
-
-    Err(OxenError::basic_str("Upload retry failed."))
+    })
+    .await
 }
 
 async fn upload_single_tarball_to_server_with_client(
@@ -952,10 +931,9 @@ pub async fn upload_data_chunk_to_server_with_retry(
     is_compressed: bool,
     filename: &Option<String>,
 ) -> Result<(), OxenError> {
-    let mut total_tries = 0;
-    let mut last_error = String::from("");
-    while total_tries < constants::NUM_HTTP_RETRIES {
-        match upload_data_chunk_to_server(
+    let config = crate::api::client::retry::RetryConfig::default();
+    crate::api::client::retry::with_retry(&config, |_attempt| async move {
+        upload_data_chunk_to_server(
             client,
             remote_repo,
             chunk,
@@ -964,27 +942,10 @@ pub async fn upload_data_chunk_to_server_with_retry(
             is_compressed,
             filename,
         )
-        .await
-        {
-            Ok(_) => {
-                return Ok(());
-            }
-            Err(err) => {
-                total_tries += 1;
-                // Exponentially back off
-                let sleep_time = total_tries * total_tries;
-                log::debug!(
-                    "upload_data_chunk_to_server_with_retry upload failed sleeping {sleep_time}: {err}"
-                );
-                last_error = format!("{err}");
-                std::thread::sleep(std::time::Duration::from_secs(sleep_time));
-            }
-        }
-    }
-
-    Err(OxenError::basic_str(format!(
-        "Upload chunk retry failed. {last_error}"
-    )))
+        .await?;
+        Ok(())
+    })
+    .await
 }
 
 async fn upload_data_chunk_to_server(

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -1,11 +1,12 @@
-use crate::api;
 use crate::api::client;
 use crate::api::client::retry;
 use crate::error::OxenError;
 use crate::model::RemoteRepository;
 use crate::model::commit::NewCommitBody;
 use crate::view::CommitResponse;
+use crate::{api, util::internal_types::HasLen};
 
+use aws_config::default_provider::retry_config;
 use bytes::{Bytes, BytesMut};
 use futures_util::StreamExt;
 use reqwest::multipart::{Form, Part};
@@ -21,40 +22,102 @@ pub async fn put_file(
 ) -> Result<CommitResponse, OxenError> {
     let branch = branch.as_ref();
     let directory = directory.as_ref();
-    let file_path = file_path.as_ref();
-    let file_name_str = file_name.map(|f| f.as_ref().to_string());
-    let uri = format!("/file/{branch}/{directory}");
-    log::debug!("put_file {uri:?}, file_path {file_path:?}");
-    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+    put_multipart_file(
+        remote_repo,
+        &format!("/file/{branch}/{directory}"),
+        "files[]",
+        file_path.as_ref(),
+        file_name.as_ref().map(|s| s.as_ref()),
+        commit_body.as_ref(),
+        &retry::RetryConfig::default(),
+    )
+    .await
+}
 
-    let config = retry::RetryConfig::default();
-    retry::with_retry(&config, |_attempt| {
-        let url = url.clone();
-        let file_name_str = file_name_str.clone();
-        let commit_body = commit_body.clone();
+pub async fn put_file_to_path(
+    remote_repo: &RemoteRepository,
+    branch: impl AsRef<str>,
+    file_path_on_repo: impl AsRef<str>,
+    file_path: impl AsRef<Path>,
+    file_name: Option<impl AsRef<str>>,
+    commit_body: Option<NewCommitBody>,
+) -> Result<CommitResponse, OxenError> {
+    let branch = branch.as_ref();
+    let file_path_on_repo = file_path_on_repo.as_ref();
+    put_multipart_file(
+        remote_repo,
+        &format!("/file/{branch}/{file_path_on_repo}"),
+        "file",
+        file_path.as_ref(),
+        file_name.as_ref().map(|s| s.as_ref()),
+        commit_body.as_ref(),
+        &retry::RetryConfig::default(),
+    )
+    .await
+}
+async fn put_multipart_file(
+    remote_repo: &RemoteRepository,
+    uri: &str,
+    field_name: &'static str,
+    file_path: &Path,
+    file_name: Option<&str>,
+    commit_body: Option<&NewCommitBody>,
+    config: &retry::RetryConfig,
+) -> Result<CommitResponse, OxenError> {
+    log::debug!("put_multipart_file {uri:?}, file_path {file_path:?}");
+    let url = api::endpoint::url_from_repo(remote_repo, uri)?;
+    let client = client::new_for_host_transfer(&url)?;
+
+    let file_data = bytes::Bytes::from(tokio::fs::read(file_path).await?);
+
+    retry::with_retry(config, |_attempt| {
+        let file_data = file_data.clone(); // cloning is cheap: it's essentially an Arc<[u8]>
+        let client = client.clone(); // HTTP client is also an Arc<inner client>
+        let file_name = file_name.clone(); // cloning a string is cheap:
+        let url = url.clone(); // it's just the length + pointer
+        let commit_body = commit_body.clone(); // the Some(.) variant has a pointer: cheap clones
+
         async move {
-            let client = client::new_for_url_transfer(&url)?;
-            let file_part = Part::file(file_path).await?;
-            let file_part = if let Some(ref name) = file_name_str {
-                file_part.file_name(name.clone())
-            } else {
-                file_part
-            };
-            let mut form = Form::new().part("file", file_part);
-
-            if let Some(body) = commit_body {
-                form = form.text("name", body.author);
-                form = form.text("email", body.email);
-                form = form.text("message", body.message);
-            }
+            let file_part = make_file_part(file_data, file_name).await?;
+            let form = apply_commit_body(Form::new().part(field_name, file_part), commit_body);
 
             let res = client.put(&url).multipart(form).send().await?;
             let body = client::parse_json_body(&url, res).await?;
-            let response: CommitResponse = serde_json::from_str(&body)?;
-            Ok(response)
+
+            Ok(serde_json::from_str(&body)?)
         }
     })
     .await
+}
+
+/// Create a Part in a multipart Form from the specified data.
+/// Intended to be used for uploading a single file.
+async fn make_file_part<T: Into<reqwest::Body> + HasLen>(
+    file_data: T,
+    file_name: Option<&str>,
+) -> Result<Part, OxenError> {
+    let file_data_len = file_data.len() as u64;
+    let file_part = reqwest::multipart::Part::stream_with_length(file_data, file_data_len);
+    Ok(match file_name {
+        Some(file_name) => file_part.file_name(file_name.to_string()),
+        None => file_part,
+    })
+}
+
+/// Add the commit information as fields to the form.
+fn apply_commit_body(form: Form, commit_body: Option<&NewCommitBody>) -> Form {
+    if let Some(NewCommitBody {
+        message,
+        author,
+        email,
+    }) = commit_body
+    {
+        form.text("name", author.to_string())
+            .text("email", email.to_string())
+            .text("message", message.to_string())
+    } else {
+        form
+    }
 }
 
 pub async fn get_file(

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -33,7 +33,7 @@ pub async fn put_file(
         let file_name_str = file_name_str.clone();
         let commit_body = commit_body.clone();
         async move {
-            let client = client::new_for_url(&url)?;
+            let client = client::new_for_url_transfer(&url)?;
             let file_part = Part::file(file_path).await?;
             let file_part = if let Some(ref name) = file_name_str {
                 file_part.file_name(name.clone())

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -6,7 +6,6 @@ use crate::model::commit::NewCommitBody;
 use crate::view::CommitResponse;
 use crate::{api, util::internal_types::HasLen};
 
-use aws_config::default_provider::retry_config;
 use bytes::{Bytes, BytesMut};
 use futures_util::StreamExt;
 use reqwest::multipart::{Form, Part};
@@ -73,9 +72,7 @@ async fn put_multipart_file(
     retry::with_retry(config, |_attempt| {
         let file_data = file_data.clone(); // cloning is cheap: it's essentially an Arc<[u8]>
         let client = client.clone(); // HTTP client is also an Arc<inner client>
-        let file_name = file_name.clone(); // cloning a string is cheap:
         let url = url.clone(); // it's just the length + pointer
-        let commit_body = commit_body.clone(); // the Some(.) variant has a pointer: cheap clones
 
         async move {
             let file_part = make_file_part(file_data, file_name).await?;

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -1,5 +1,6 @@
 use crate::api;
 use crate::api::client;
+use crate::api::client::retry;
 use crate::error::OxenError;
 use crate::model::RemoteRepository;
 use crate::model::commit::NewCommitBody;
@@ -21,31 +22,39 @@ pub async fn put_file(
     let branch = branch.as_ref();
     let directory = directory.as_ref();
     let file_path = file_path.as_ref();
+    let file_name_str = file_name.map(|f| f.as_ref().to_string());
     let uri = format!("/file/{branch}/{directory}");
     log::debug!("put_file {uri:?}, file_path {file_path:?}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
-    let client = client::new_for_url(&url)?;
-    let file_part = Part::file(file_path).await?;
-    let file_part = if let Some(file_name) = file_name {
-        file_part.file_name(file_name.as_ref().to_string())
-    } else {
-        file_part
-    };
-    let mut form = Form::new().part("file", file_part);
+    let config = retry::RetryConfig::default();
+    retry::with_retry(&config, |_attempt| {
+        let url = url.clone();
+        let file_name_str = file_name_str.clone();
+        let commit_body = commit_body.clone();
+        async move {
+            let client = client::new_for_url(&url)?;
+            let file_part = Part::file(file_path).await?;
+            let file_part = if let Some(ref name) = file_name_str {
+                file_part.file_name(name.clone())
+            } else {
+                file_part
+            };
+            let mut form = Form::new().part("file", file_part);
 
-    if let Some(body) = commit_body {
-        form = form.text("name", body.author);
-        form = form.text("email", body.email);
-        form = form.text("message", body.message);
-    }
+            if let Some(body) = commit_body {
+                form = form.text("name", body.author);
+                form = form.text("email", body.email);
+                form = form.text("message", body.message);
+            }
 
-    let req = client.put(&url).multipart(form);
-
-    let res = req.send().await?;
-    let body = client::parse_json_body(&url, res).await?;
-    let response: CommitResponse = serde_json::from_str(&body)?;
-    Ok(response)
+            let res = client.put(&url).multipart(form).send().await?;
+            let body = client::parse_json_body(&url, res).await?;
+            let response: CommitResponse = serde_json::from_str(&body)?;
+            Ok(response)
+        }
+    })
+    .await
 }
 
 pub async fn get_file(

--- a/oxen-rust/src/lib/src/api/client/import.rs
+++ b/oxen-rust/src/lib/src/api/client/import.rs
@@ -61,7 +61,7 @@ pub async fn upload_zip(
                 commit_msg,
             );
 
-            let client = client::new_for_url(&url)?;
+            let client = client::new_for_url_transfer(&url)?;
             let response = client.post(&url).multipart(form).send().await?;
             let body = client::parse_json_body(&url, response).await?;
             let response: crate::view::CommitResponse = serde_json::from_str(&body)

--- a/oxen-rust/src/lib/src/api/client/import.rs
+++ b/oxen-rust/src/lib/src/api/client/import.rs
@@ -4,7 +4,6 @@ use crate::api::client::retry;
 use crate::error::OxenError;
 use crate::model::RemoteRepository;
 
-use std::borrow::Cow;
 use std::path::Path;
 
 /// Upload a ZIP file that gets extracted into the workspace directory
@@ -72,17 +71,18 @@ pub async fn upload_zip(
     .await
 }
 
-fn make_multipart_form<T: Into<reqwest::Body>, S: Into<Cow<'static, str>>>(
+fn make_multipart_form<T: Into<reqwest::Body>>(
     zip_data: T,
     len_zip_data: u64,
-    file_name: S,
-    name: S,
-    email: S,
-    directory: S,
-    commit_msg: Option<S>,
+    file_name: String,
+    name: String,
+    email: String,
+    directory: String,
+    commit_msg: Option<String>,
 ) -> reqwest::multipart::Form {
-    let file_part = reqwest::multipart::Part::stream_with_length(zip_data, len_zip_data)
-        .file_name(file_name.into());
+    let file_part =
+        reqwest::multipart::Part::stream_with_length(zip_data, len_zip_data).file_name(file_name);
+
     let mut form = reqwest::multipart::Form::new()
         .part("file", file_part)
         .text("name", name)

--- a/oxen-rust/src/lib/src/api/client/import.rs
+++ b/oxen-rust/src/lib/src/api/client/import.rs
@@ -1,8 +1,10 @@
 use crate::api;
 use crate::api::client;
+use crate::api::client::retry;
 use crate::error::OxenError;
 use crate::model::RemoteRepository;
 
+use std::borrow::Cow;
 use std::path::Path;
 
 /// Upload a ZIP file that gets extracted into the workspace directory
@@ -18,42 +20,79 @@ pub async fn upload_zip(
     let branch_name = branch_name.as_ref();
     let directory = directory.as_ref();
     let zip_path = zip_path.as_ref();
+
     let name = name.as_ref();
     let email = email.as_ref();
 
-    // Read the ZIP file
-    let zip_data = std::fs::read(zip_path)?;
+    // Read the ZIP file into memory once for potential retries
+    // NOTE: bytes::Bytes wraps the Vec<u8> into an Arc internally.
+    //       We need to move into `reqwest.multipart::Part::bytes`, but with retries, we don't want
+    //       to actually clone the data. This wrapper makes it cheap to clone as we're just
+    //       incrementing the arc's internal reference count.
+    let zip_data = bytes::Bytes::from(tokio::fs::read(zip_path).await?);
+    let len_zip_data = zip_data.len() as u64;
     let file_name = zip_path
         .file_name()
         .ok_or_else(|| OxenError::basic_str("Invalid ZIP file path"))?
-        .to_string_lossy();
+        .to_string_lossy()
+        .to_string();
 
-    // Create the URL for workspace ZIP upload endpoint
     let uri = format!("/import/upload/{branch_name}/{directory}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+    let commit_msg = commit_message.map(|m| m.as_ref().to_string());
 
-    // Create multipart form
-    let file_part = reqwest::multipart::Part::bytes(zip_data).file_name(file_name.to_string());
+    let config = retry::RetryConfig::default();
+    retry::with_retry(&config, |_attempt| {
+        let url = url.clone();
+        let zip_data = zip_data.clone();
+        let file_name = file_name.clone();
+        let name = name.to_string();
+        let email = email.to_string();
+        let directory = directory.to_string();
+        let commit_msg = commit_msg.clone();
+        async move {
+            let form = make_multipart_form(
+                zip_data,
+                len_zip_data,
+                file_name,
+                name,
+                email,
+                directory,
+                commit_msg,
+            );
+
+            let client = client::new_for_url(&url)?;
+            let response = client.post(&url).multipart(form).send().await?;
+            let body = client::parse_json_body(&url, response).await?;
+            let response: crate::view::CommitResponse = serde_json::from_str(&body)
+                .map_err(|e| OxenError::basic_str(format!("Failed to parse response: {e}")))?;
+            Ok(response.commit)
+        }
+    })
+    .await
+}
+
+fn make_multipart_form<T: Into<reqwest::Body>, S: Into<Cow<'static, str>>>(
+    zip_data: T,
+    len_zip_data: u64,
+    file_name: S,
+    name: S,
+    email: S,
+    directory: S,
+    commit_msg: Option<S>,
+) -> reqwest::multipart::Form {
+    let file_part = reqwest::multipart::Part::stream_with_length(zip_data, len_zip_data)
+        .file_name(file_name.into());
     let mut form = reqwest::multipart::Form::new()
         .part("file", file_part)
-        .text("name", name.to_string())
-        .text("email", email.to_string())
-        .text("resource_path", directory.to_string());
+        .text("name", name)
+        .text("email", email)
+        .text("resource_path", directory);
 
-    if let Some(msg) = commit_message {
-        form = form.text("commit_message", msg.as_ref().to_string());
+    if let Some(msg) = commit_msg {
+        form = form.text("commit_message", msg);
     }
-
-    // Send the request
-    let client = client::new_for_url(&url)?;
-    let response = client.post(&url).multipart(form).send().await?;
-    let body = client::parse_json_body(&url, response).await?;
-
-    // Parse the response
-    let response: crate::view::CommitResponse = serde_json::from_str(&body)
-        .map_err(|e| OxenError::basic_str(format!("Failed to parse response: {e}")))?;
-
-    Ok(response.commit)
+    form
 }
 
 #[cfg(test)]

--- a/oxen-rust/src/lib/src/api/client/retry.rs
+++ b/oxen-rust/src/lib/src/api/client/retry.rs
@@ -1,0 +1,130 @@
+use crate::constants;
+use crate::error::OxenError;
+use rand::Rng;
+use std::future::Future;
+
+pub struct RetryConfig {
+    pub max_retries: usize,
+    pub base_wait_ms: u64,
+    pub max_wait_ms: u64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: constants::max_retries(),
+            base_wait_ms: 300,
+            max_wait_ms: 10_000,
+        }
+    }
+}
+
+/// True exponential backoff: base_wait_ms * 2^attempt + jitter, clamped to max_wait_ms
+pub fn exponential_backoff(base_wait_ms: u64, attempt: usize, max_wait_ms: u64) -> u64 {
+    let exp = base_wait_ms.saturating_mul(1u64 << attempt.min(16));
+    let jitter = rand::thread_rng().gen_range(0..=500u64);
+    exp.saturating_add(jitter).min(max_wait_ms)
+}
+
+/// Retry an async operation with exponential backoff.
+/// Authentication errors are not retried.
+pub async fn with_retry<F, Fut, T>(config: &RetryConfig, mut operation: F) -> Result<T, OxenError>
+where
+    F: FnMut(usize) -> Fut,
+    Fut: Future<Output = Result<T, OxenError>>,
+{
+    let mut last_err = None;
+    for attempt in 0..=config.max_retries {
+        match operation(attempt).await {
+            Ok(val) => return Ok(val),
+            error @ Err(OxenError::Authentication(_)) => return error,
+            Err(err) => {
+                log::warn!(
+                    "Retry attempt {}/{} failed: {err}",
+                    attempt + 1,
+                    config.max_retries + 1
+                );
+                last_err = Some(err);
+                if attempt < config.max_retries {
+                    let wait =
+                        exponential_backoff(config.base_wait_ms, attempt, config.max_wait_ms);
+                    tokio::time::sleep(std::time::Duration::from_millis(wait)).await;
+                }
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| OxenError::basic_str("Retry failed with no attempts")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exponential_backoff_increases() {
+        let b0 = exponential_backoff(300, 0, 100_000);
+        let b1 = exponential_backoff(300, 1, 100_000);
+        let b2 = exponential_backoff(300, 2, 100_000);
+        // With jitter, we can't be exact, but the base doubles each time
+        // 300*1=300, 300*2=600, 300*4=1200 (plus jitter 0..500)
+        assert!(b0 <= 800, "b0={b0}");
+        assert!(b1 >= 300 && b1 <= 1100, "b1={b1}");
+        assert!(b2 >= 900 && b2 <= 1700, "b2={b2}");
+    }
+
+    #[test]
+    fn test_exponential_backoff_clamps_to_max() {
+        let val = exponential_backoff(300, 20, 5000);
+        assert!(val <= 5000, "val={val}");
+    }
+
+    #[tokio::test]
+    async fn test_with_retry_immediate_success() {
+        let config = RetryConfig {
+            max_retries: 3,
+            base_wait_ms: 10,
+            max_wait_ms: 100,
+        };
+        let result: Result<i32, OxenError> = with_retry(&config, |_attempt| async { Ok(42) }).await;
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn test_with_retry_exhaustion() {
+        let config = RetryConfig {
+            max_retries: 2,
+            base_wait_ms: 10,
+            max_wait_ms: 50,
+        };
+        let result: Result<i32, OxenError> = with_retry(&config, |_attempt| async {
+            Err(OxenError::basic_str("always fails"))
+        })
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_with_retry_succeeds_on_third_attempt() {
+        let config = RetryConfig {
+            max_retries: 3,
+            base_wait_ms: 10,
+            max_wait_ms: 50,
+        };
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter_clone = counter.clone();
+        let result: Result<i32, OxenError> = with_retry(&config, move |_attempt| {
+            let c = counter_clone.clone();
+            async move {
+                let prev = c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if prev < 2 {
+                    Err(OxenError::basic_str("not yet"))
+                } else {
+                    Ok(99)
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 99);
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 3);
+    }
+}

--- a/oxen-rust/src/lib/src/api/client/tree.rs
+++ b/oxen-rust/src/lib/src/api/client/tree.rs
@@ -6,7 +6,6 @@ use futures_util::TryStreamExt;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time;
 use tempfile::TempDir;
 
 use crate::api::client;
@@ -91,9 +90,7 @@ pub async fn create_nodes(
     // Upload the node
     let uri = "/tree/nodes".to_string();
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
-    let client = client::builder_for_url(&url)?
-        .timeout(time::Duration::from_secs(120))
-        .build()?;
+    let client = client::new_for_url_transfer(&url)?;
 
     let size = buffer.len() as u64;
     log::debug!(
@@ -357,9 +354,7 @@ async fn node_download_request(
 ) -> Result<(), OxenError> {
     let url = url.as_ref();
 
-    let client = client::builder_for_url(url)?
-        .timeout(time::Duration::from_secs(12000))
-        .build()?;
+    let client = client::new_for_url_transfer(url)?;
     log::debug!("node_download_request about to send request {url}");
     let res = client.get(url).send().await?;
     let res = client::handle_non_json_response(url, res).await?;

--- a/oxen-rust/src/lib/src/api/client/versions.rs
+++ b/oxen-rust/src/lib/src/api/client/versions.rs
@@ -471,34 +471,28 @@ pub async fn multipart_batch_upload_with_retry(
     chunk: &Vec<Entry>,
     client: &reqwest::Client,
 ) -> Result<(), OxenError> {
-    let mut files_to_retry: Vec<ErrorFileInfo> = vec![];
-    let mut first_try = true;
-    let mut retry_count: usize = 0;
     let max_retries = max_retries();
+    let mut files_to_retry: Vec<ErrorFileInfo> = vec![];
 
-    while (first_try || !files_to_retry.is_empty()) && retry_count < max_retries {
-        first_try = false;
-        retry_count += 1;
-
+    for attempt in 0..max_retries {
         files_to_retry =
             multipart_batch_upload(local_repo, remote_repo, chunk, client, files_to_retry).await?;
 
-        if !files_to_retry.is_empty() {
-            let wait_time = retry::exponential_backoff(
-                BASE_WAIT_TIME as u64,
-                retry_count,
-                MAX_WAIT_TIME as u64,
-            );
+        if files_to_retry.is_empty() {
+            return Ok(());
+        }
+
+        // Don't sleep after the last attempt
+        if attempt + 1 < max_retries {
+            let wait_time =
+                retry::exponential_backoff(BASE_WAIT_TIME as u64, attempt, MAX_WAIT_TIME as u64);
             sleep(Duration::from_millis(wait_time)).await;
         }
     }
-    if files_to_retry.is_empty() {
-        Ok(())
-    } else {
-        Err(OxenError::basic_str(format!(
-            "Failed to upload files: {files_to_retry:#?}"
-        )))
-    }
+
+    Err(OxenError::basic_str(format!(
+        "Failed to upload files: {files_to_retry:#?}"
+    )))
 }
 
 pub async fn multipart_batch_upload(

--- a/oxen-rust/src/lib/src/api/client/versions.rs
+++ b/oxen-rust/src/lib/src/api/client/versions.rs
@@ -1,6 +1,7 @@
 use crate::api;
 use crate::api::client;
 use crate::api::client::internal_types::LocalOrBase;
+use crate::api::client::retry;
 use crate::constants::{AVG_CHUNK_SIZE, max_retries};
 use crate::error::OxenError;
 use crate::model::entry::commit_entry::Entry;
@@ -21,7 +22,6 @@ use futures_util::StreamExt;
 use futures_util::stream::FuturesUnordered;
 use http::Method;
 use http::header::CONTENT_LENGTH;
-use rand::{Rng, thread_rng};
 use tokio_tar::Archive;
 use tokio_util::codec::{BytesCodec, FramedRead};
 
@@ -197,29 +197,15 @@ pub async fn download_data_from_version_paths(
     hashes: &[String],
     local_repo: &LocalRepository,
 ) -> Result<u64, OxenError> {
-    let total_retries = max_retries().try_into().unwrap_or(max_retries() as u64);
-    let mut num_retries = 0;
-
-    while num_retries < total_retries {
+    let config = retry::RetryConfig::default();
+    retry::with_retry(&config, |_attempt| async {
         match try_download_data_from_version_paths(remote_repo, hashes, local_repo).await {
-            Ok(val) => return Ok(val),
-            Err(OxenError::Authentication(val)) => return Err(OxenError::Authentication(val)),
-            Err(err) => {
-                num_retries += 1;
-                // Exponentially back off
-                let sleep_time = num_retries * num_retries;
-                log::warn!("Could not download content {err:?} sleeping {sleep_time}");
-                tokio::time::sleep(std::time::Duration::from_secs(sleep_time)).await;
-            }
+            Ok(val) => Ok(val),
+            Err(OxenError::Authentication(val)) => Err(OxenError::Authentication(val)),
+            Err(err) => Err(err),
         }
-    }
-
-    let err = format!(
-        "Err: Failed to download {} files after {} retries",
-        hashes.len(),
-        total_retries
-    );
-    Err(OxenError::basic_str(err))
+    })
+    .await
 }
 
 pub async fn try_download_data_from_version_paths(
@@ -312,7 +298,7 @@ async fn upload_chunks(
     max_retries: usize,
     progress: Option<&Arc<PushProgress>>,
 ) -> Result<Vec<HashMap<String, String>>, OxenError> {
-    let client = Arc::new(api::client::builder_for_remote_repo(remote_repo)?.build()?);
+    let client = Arc::new(api::client::new_for_host_transfer(remote_repo.url())?);
 
     // Figure out how many parts we need to upload
     let file_size = upload.size;
@@ -353,8 +339,8 @@ async fn upload_chunks(
                                 ))
                             })?;
 
-                            let wait_time = exponential_backoff(BASE_WAIT_TIME, i, MAX_WAIT_TIME);
-                            sleep(Duration::from_millis(wait_time as u64)).await;
+                            let wait_time = retry::exponential_backoff(BASE_WAIT_TIME as u64, i, MAX_WAIT_TIME as u64);
+                            sleep(Duration::from_millis(wait_time)).await;
 
                             chunk = upload_chunk(&client, &remote_repo, &upload, start, chunk_size).await;
                             i += 1;
@@ -498,8 +484,12 @@ pub async fn multipart_batch_upload_with_retry(
             multipart_batch_upload(local_repo, remote_repo, chunk, client, files_to_retry).await?;
 
         if !files_to_retry.is_empty() {
-            let wait_time = exponential_backoff(BASE_WAIT_TIME, retry_count, MAX_WAIT_TIME);
-            sleep(Duration::from_millis(wait_time as u64)).await;
+            let wait_time = retry::exponential_backoff(
+                BASE_WAIT_TIME as u64,
+                retry_count,
+                MAX_WAIT_TIME as u64,
+            );
+            sleep(Duration::from_millis(wait_time)).await;
         }
     }
     if files_to_retry.is_empty() {
@@ -780,8 +770,12 @@ pub(crate) async fn workspace_multipart_batch_upload_parts_with_retry(
         };
 
         if !files_to_retry.is_empty() {
-            let wait_time = exponential_backoff(BASE_WAIT_TIME, retry_count, MAX_WAIT_TIME);
-            sleep(Duration::from_millis(wait_time as u64)).await;
+            let wait_time = retry::exponential_backoff(
+                BASE_WAIT_TIME as u64,
+                retry_count,
+                MAX_WAIT_TIME as u64,
+            );
+            sleep(Duration::from_millis(wait_time)).await;
         }
     }
 
@@ -792,17 +786,6 @@ pub(crate) async fn workspace_multipart_batch_upload_parts_with_retry(
     }
 
     Ok(upload_result.err_files)
-}
-
-pub fn exponential_backoff(base_wait_time: usize, n: usize, max: usize) -> usize {
-    log::debug!(
-        "Exponential backoff got called with base_wait_time {base_wait_time}. n {n}, and max {max}"
-    );
-    (base_wait_time + n.pow(2) + jitter()).min(max)
-}
-
-fn jitter() -> usize {
-    thread_rng().gen_range(0..=500)
 }
 
 #[cfg(test)]

--- a/oxen-rust/src/lib/src/api/client/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/api/client/workspaces/files.rs
@@ -448,7 +448,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
     }
 
     // Create a client for uploading batches
-    let client = Arc::new(api::client::builder_for_remote_repo(remote_repo)?.build()?);
+    let client = Arc::new(api::client::new_for_host_transfer(remote_repo.url())?);
 
     // For individual files
     let err_files: Arc<Mutex<Vec<ErrorFileInfo>>> = Arc::new(Mutex::new(vec![]));

--- a/oxen-rust/src/lib/src/constants.rs
+++ b/oxen-rust/src/lib/src/constants.rs
@@ -194,6 +194,10 @@ pub const NUM_HTTP_RETRIES: u64 = 5;
 pub const DEFAULT_NUM_WORKERS: usize = 8;
 /// Default timeout for HTTP requests
 pub const DEFAULT_TIMEOUT_SECS: u64 = 120;
+/// Default connect timeout for HTTP requests
+pub const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
+/// Default TCP keep-alive interval
+pub const DEFAULT_TCP_KEEPALIVE_SECS: u64 = 30;
 /// Default vnode size
 pub const DEFAULT_VNODE_SIZE: u64 = 10_000;
 
@@ -270,3 +274,26 @@ pub fn chunk_size() -> u64 {
         AVG_CHUNK_SIZE
     }
 }
+
+// Parse the connect timeout from environment variable
+pub fn connect_timeout() -> u64 {
+    if let Ok(val) = std::env::var("OXEN_CONNECT_TIMEOUT_SECS")
+        && let Ok(val) = val.parse::<u64>()
+    {
+        return val;
+    }
+    DEFAULT_CONNECT_TIMEOUT_SECS
+}
+
+// Parse the TCP keep-alive interval from environment variable
+pub fn tcp_keepalive() -> u64 {
+    if let Ok(val) = std::env::var("OXEN_TCP_KEEPALIVE_SECS")
+        && let Ok(val) = val.parse::<u64>()
+    {
+        return val;
+    }
+    DEFAULT_TCP_KEEPALIVE_SECS
+}
+
+// Oxen request Id
+pub const OXEN_REQUEST_ID: &str = "x-oxen-request-id";

--- a/oxen-rust/src/lib/src/core/v_latest/push.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/push.rs
@@ -716,7 +716,7 @@ async fn bundle_and_send_small_entries(
     }
 
     // Create a client for uploading chunks
-    let client = Arc::new(api::client::builder_for_remote_repo(remote_repo)?.build()?);
+    let client = Arc::new(api::client::new_for_url_transfer(remote_repo.url())?);
 
     // Split into chunks, zip up, and post to server
     use tokio::time::sleep;

--- a/oxen-rust/src/lib/src/util.rs
+++ b/oxen-rust/src/lib/src/util.rs
@@ -6,6 +6,7 @@ pub mod fs;
 pub mod glob;
 pub mod hasher;
 pub mod image;
+pub(crate) mod internal_types;
 pub mod logging;
 pub mod oxen_version;
 pub mod paginate;

--- a/oxen-rust/src/lib/src/util/internal_types.rs
+++ b/oxen-rust/src/lib/src/util/internal_types.rs
@@ -1,0 +1,49 @@
+use std::collections::{HashMap, HashSet};
+
+/// Indicates that the type has a length.
+pub(crate) trait HasLen {
+    fn len(&self) -> usize;
+}
+
+macro_rules! impl_has_len_simple {
+    ($ty:ty) => {
+        impl HasLen for $ty {
+            fn len(&self) -> usize {
+                self.len()
+            }
+        }
+    };
+}
+
+macro_rules! impl_has_len_generic1 {
+  ($($ty:ident),*) => {
+    $(
+      impl<T> HasLen for $ty<T> {
+          fn len(&self) -> usize {
+              self.len()
+          }
+      }
+    )*
+  };
+}
+
+macro_rules! impl_has_len_generic2 {
+  ($($ty:ident),*) => {
+    $(
+      impl<K, V> HasLen for $ty<K, V> {
+          fn len(&self) -> usize {
+              self.len()
+          }
+      }
+    )*
+  };
+}
+
+impl_has_len_simple!(bytes::Bytes);
+impl_has_len_simple!(String);
+impl_has_len_simple!(str);
+
+impl_has_len_generic1!(Vec);
+impl_has_len_generic1!(HashSet);
+
+impl_has_len_generic2!(HashMap);


### PR DESCRIPTION
- Blocking sleep bug: `std::thread::sleep` in `async` context repalced with `tokio::time::sleep`
- True exponential backoff: `base * 2^attempt + jitter` instead of `base + attempt^2`
- Missing timeouts: All clients now get `connect_timeout(10s)` + `tcp_keepalive(30s)`
- Transfer clients: HTTP/2 keep-alive, no overall timeout cap for large transfers
- Unprotected uploads: `put_file` and `upload_zip` now have retry logic