### PR TITLE
Use VersionStore trait to compute paths

### DIFF
--- a/oxen-rust/src/cli/src/cmd/pack.rs
+++ b/oxen-rust/src/cli/src/cmd/pack.rs
@@ -1,17 +1,8 @@
-// use std::collections::HashMap;
-// use std::fs::File;
-// use std::io::Read;
-// use std::path::Path;
 use std::path::PathBuf;
 
 use async_trait::async_trait;
 use clap::{Arg, Command};
 use liboxen::error::OxenError;
-// use liboxen::model::{CommitEntry, LocalRepository};
-// use liboxen::util::hasher;
-// use liboxen::{repositories, util};
-// use rocksdb::DBWithThreadMode;
-// use rocksdb::MultiThreaded;
 
 use crate::cmd::RunCmd;
 pub const NAME: &str = "pack";
@@ -75,136 +66,6 @@ impl RunCmd for PackCmd {
         if _paths.len() != 1 {
             return Err(OxenError::basic_str("Must supply exactly one file"));
         }
-        /*
-
-        let _path = &paths[0];
-
-        // Traverse back in file history, split file into chunks.
-        let _repo = LocalRepository::from_current_dir()?;
-        let _commits = repositories::commits::list(&repo)?;
-
-        // Take first n commits
-        let commits = commits.into_iter().take(n);
-        let mut entries: Vec<CommitEntry> = vec![];
-        for commit in commits {
-            let commit_entry_reader = CommitEntryReader::new(&repo, &commit)?;
-            let Some(entry) = commit_entry_reader.get_entry(path)? else {
-                continue;
-            };
-            entries.push(entry);
-        }
-
-        // Time the total time taken to read the files
-        let start = std::time::Instant::now();
-
-        // Chunk each file into 16kb chunks
-        let mut chunks: HashMap<u128, Vec<u8>> = HashMap::new();
-        let mut version_to_chunks: HashMap<String, Vec<(usize, u128)>> = HashMap::new();
-        let chunk_size = chunk_size * 1024;
-        let mut latest_size: u64 = 0;
-        let mut total_size: u64 = 0;
-        let mut compressed_size: u64 = 0;
-        println!("Compressing {} versions of {:?}...", n, path);
-        // enumerate with index
-        for (i, entry) in entries.into_iter().enumerate() {
-            let version_file = util::fs::version_path(&repo, &entry);
-
-            // Open File
-            let mut file = File::open(&version_file)?;
-
-            // Read chunks
-            let mut chunk_idx = 0;
-            let mut buffer = vec![0; chunk_size]; // 16KB buffer
-            while let Ok(bytes_read) = file.read(&mut buffer) {
-                if bytes_read == 0 {
-                    if i == 0 {
-                        latest_size = total_size;
-                    }
-                    break; // End of file
-                }
-                // Shrink buffer to size of bytes read
-                buffer.truncate(bytes_read);
-
-                // Process the buffer here
-                // println!("Read {} bytes from {:?}", bytes_read, version_file);
-                let hash = hasher::hash_buffer_128bit(&buffer);
-
-                let pair = (chunk_idx, hash);
-                if !version_to_chunks.contains_key(&entry.hash) {
-                    version_to_chunks.insert(entry.hash.clone(), vec![pair]);
-                } else {
-                    version_to_chunks
-                        .entry(entry.hash.clone())
-                        .or_default()
-                        .push(pair);
-                }
-
-                // Add to chunks
-                if let std::collections::hash_map::Entry::Vacant(e) = chunks.entry(hash) {
-                    e.insert(buffer.clone());
-                    compressed_size += bytes_read as u64;
-                }
-                total_size += bytes_read as u64;
-                chunk_idx += 1;
-            }
-        }
-
-        // Time the total time taken to read the files
-        let end = std::time::Instant::now();
-        println!("Time to compress: {:?}", end.duration_since(start));
-
-        println!("Writing chunks to disk...");
-
-        // TODO: Write all chunks to our u128 kv db
-        // TODO: Write another db of idx -> hash so that we can reconstruct the file
-        // TODO: Time the reconstruction of the file from chunks to Polars DF
-
-        // Write all the chunks to the chunks db
-        let output_dir = Path::new("chunks");
-        let chunks_db = output_dir.join("db");
-        // mkdir if not exists
-        util::fs::create_dir_all(output_dir)?;
-
-        let opts = liboxen::core::db::key_val::opts::default();
-        let db: DBWithThreadMode<MultiThreaded> = DBWithThreadMode::open(&opts, chunks_db)?;
-        for (hash, chunk) in &chunks {
-            // liboxen::core::db::u128_kv_db::put(&db, *hash, chunk)?;
-            db.put(hash.to_be_bytes(), chunk)?;
-        }
-
-        // Write all the chunk ids to the chunks db
-        let chunks_idx = output_dir.join("idx");
-        for (file_hash, ids) in &version_to_chunks {
-            let ids_db_path = chunks_idx.join(file_hash);
-            let idx_db: DBWithThreadMode<MultiThreaded> =
-                DBWithThreadMode::open(&opts, &ids_db_path)?;
-            println!("Writing {} indices to {:?}", ids.len(), ids_db_path);
-            for (idx, block_hash) in ids {
-                let block_hash = block_hash.to_be_bytes().to_vec();
-                let idx = idx.to_be_bytes().to_vec();
-                idx_db.put(block_hash, idx)?;
-            }
-        }
-
-        // Time the total time taken to read the files
-        let end = std::time::Instant::now();
-        println!("Total time taken: {:?}", end.duration_since(start));
-
-        println!("Uncompressed size: {}", bytesize::ByteSize::b(total_size));
-        println!(
-            "Compressed size: {}",
-            bytesize::ByteSize::b(compressed_size)
-        );
-        println!(
-            "Latest version size: {}",
-            bytesize::ByteSize::b(latest_size)
-        );
-        println!(
-            "🎉 Total space saved: {}",
-            bytesize::ByteSize::b(total_size - compressed_size)
-        );
-         */
-
         Ok(())
     }
 }

--- a/oxen-rust/src/lib/src/core/v_latest/data_frames.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/data_frames.rs
@@ -10,7 +10,7 @@ use crate::model::metadata::generic_metadata::GenericMetadata;
 use crate::model::metadata::metadata_tabular::MetadataTabularImpl;
 use crate::model::{Commit, DataFrameSize, LocalRepository, Schema, Workspace};
 use crate::opts::DFOpts;
-use crate::{repositories, util};
+use crate::repositories;
 use polars::prelude::IntoLazy as _;
 
 use std::path::Path;
@@ -94,7 +94,8 @@ pub async fn get_slice(
         return Ok(response);
     }
     // Read the data frame from the version path
-    let version_path = util::fs::version_path_from_hash(repo, file_node.hash().to_string());
+    let version_store = repo.version_store()?;
+    let version_path = version_store.get_version_path(&file_node.hash().to_string())?;
     let df = tabular::read_df_with_extension(version_path, file_node.extension(), opts).await?;
     log::debug!("get_slice df {:?}", df.height());
 

--- a/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -139,7 +139,8 @@ pub fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
     };
     util::fs::create_dir_all(parent)?;
 
-    let version_path = util::fs::version_path_from_node(repo, file_hash.to_string(), path);
+    let version_store = repo.version_store()?;
+    let version_path = version_store.get_version_path(&file_hash.to_string())?;
 
     log::debug!(
         "core::v_latest::index::workspaces::data_frames::index({path:?}) got version path: {version_path:?}"
@@ -212,11 +213,9 @@ pub async fn rename(
         if let Some(existing_file_node) =
             repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
         {
-            let version_path = util::fs::version_path_from_node(
-                &workspace.base_repo,
-                existing_file_node.hash().to_string(),
-                path,
-            );
+            let version_store = workspace.base_repo.version_store()?;
+            let version_path =
+                version_store.get_version_path(&existing_file_node.hash().to_string())?;
             log::debug!(
                 "rename: copying version path: {version_path:?} to {workspace_file_path:?}"
             );

--- a/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -22,7 +22,6 @@ use crate::model::diff::DiffResult;
 use crate::model::staged_row_status::StagedRowStatus;
 use crate::model::{Commit, LocalRepository, Workspace};
 use crate::repositories;
-use crate::util;
 use crate::view::JsonDataFrameView;
 
 use std::collections::HashMap;
@@ -275,8 +274,8 @@ pub async fn prepare_modified_or_removed_row(
     );
 
     // let scan_rows = 10000 as usize;
-    let committed_df_path =
-        util::fs::version_path_from_node(repo, commit_merkle_tree.hash.to_string(), path.as_ref());
+    let version_store = repo.version_store()?;
+    let committed_df_path = version_store.get_version_path(&commit_merkle_tree.hash.to_string())?;
 
     log::debug!("prepare_modified_or_removed_row() committed_df_path: {committed_df_path:?}");
 

--- a/oxen-rust/src/lib/src/model/diff/tabular_diff_summary.rs
+++ b/oxen-rust/src/lib/src/model/diff/tabular_diff_summary.rs
@@ -140,10 +140,12 @@ impl TabularDiffWrapper {
     ) -> Option<DataFrame> {
         match node {
             Some(node) => {
-                let version_store = repo.version_store().expect("version store not initialized");
+                let version_store = repo.version_store().expect(
+                    "invariant violation: version store not found in maybe_get_df_from_file_node",
+                );
                 let version_path = version_store
                     .get_version_path(&node.hash().to_string())
-                    .expect("version path not found");
+                    .expect("invariant violation: version path not found in maybe_get_df_from_file_node");
                 tabular::read_df_with_extension(version_path, node.extension(), &DFOpts::empty())
                     .await
                     .ok()
@@ -160,10 +162,10 @@ impl TabularDiffWrapper {
             Some(entry) => {
                 let version_store = repo
                     .version_store()
-                    .expect("version store missing in maybe_get_df_from_commit_entry");
-                let version_path = version_store
-                    .get_version_path(&entry.hash)
-                    .expect("version path not found");
+                    .expect("invariant violation: version store not found in maybe_get_df_from_commit_entry");
+                let version_path = version_store.get_version_path(&entry.hash).expect(
+                    "invariant violation: version path not found in maybe_get_df_from_commit_entry",
+                );
                 tabular::read_df(version_path, DFOpts::empty()).await.ok()
             }
             None => None,

--- a/oxen-rust/src/lib/src/model/diff/tabular_diff_summary.rs
+++ b/oxen-rust/src/lib/src/model/diff/tabular_diff_summary.rs
@@ -8,7 +8,6 @@ use crate::model::merkle_tree::node::FileNode;
 use crate::model::metadata::generic_metadata::GenericMetadata;
 use crate::model::{CommitEntry, DataFrameSize, LocalRepository};
 use crate::opts::DFOpts;
-use crate::util;
 
 // THE DIFFERENCE BETWEEN WRAPPER AND SUMMARY IS JUST THE KEY NAME IN THE JSON RESPONSE
 #[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
@@ -141,7 +140,10 @@ impl TabularDiffWrapper {
     ) -> Option<DataFrame> {
         match node {
             Some(node) => {
-                let version_path = util::fs::version_path_from_hash(repo, node.hash().to_string());
+                let version_store = repo.version_store().expect("version store not initialized");
+                let version_path = version_store
+                    .get_version_path(&node.hash().to_string())
+                    .expect("version path not found");
                 tabular::read_df_with_extension(version_path, node.extension(), &DFOpts::empty())
                     .await
                     .ok()
@@ -156,7 +158,12 @@ impl TabularDiffWrapper {
     ) -> Option<DataFrame> {
         match entry {
             Some(entry) => {
-                let version_path = util::fs::version_path(repo, entry);
+                let version_store = repo
+                    .version_store()
+                    .expect("version store missing in maybe_get_df_from_commit_entry");
+                let version_path = version_store
+                    .get_version_path(&entry.hash)
+                    .expect("version path not found");
                 tabular::read_df(version_path, DFOpts::empty()).await.ok()
             }
             None => None,

--- a/oxen-rust/src/lib/src/repositories/checkout.rs
+++ b/oxen-rust/src/lib/src/repositories/checkout.rs
@@ -142,11 +142,8 @@ pub async fn checkout_combine<P: AsRef<Path>>(
         .find(|c| c.merge_entry.path == path.as_ref())
     {
         if util::fs::is_tabular(&conflict.base_entry.path) {
-            let df_base_path = util::fs::version_path_from_hash_and_filename(
-                repo,
-                &conflict.base_entry.hash,
-                &conflict.base_entry.filename,
-            );
+            let version_store = repo.version_store()?;
+            let df_base_path = version_store.get_version_path(&conflict.base_entry.hash)?;
             let df_base = tabular::maybe_read_df_with_extension(
                 repo,
                 &df_base_path,
@@ -155,11 +152,7 @@ pub async fn checkout_combine<P: AsRef<Path>>(
                 &DFOpts::empty(),
             )
             .await?;
-            let df_merge_path = util::fs::version_path_from_hash_and_filename(
-                repo,
-                &conflict.merge_entry.hash,
-                &conflict.merge_entry.filename,
-            );
+            let df_merge_path = version_store.get_version_path(&conflict.merge_entry.hash)?;
             let df_merge = tabular::maybe_read_df_with_extension(
                 repo,
                 df_merge_path,

--- a/oxen-rust/src/lib/src/repositories/diffs.rs
+++ b/oxen-rust/src/lib/src/repositories/diffs.rs
@@ -661,8 +661,8 @@ pub async fn diff_tabular_file_and_file_node(
 ) -> Result<TabularDiff, OxenError> {
     let (df_1, df_2) = match file_node {
         Some(file_node) => {
-            let file_node_path =
-                util::fs::version_path_from_hash(repo, file_node.hash().to_string());
+            let version_store = repo.version_store()?;
+            let file_node_path = version_store.get_version_path(&file_node.hash().to_string())?;
             let df_1 = tabular::read_df_with_extension(
                 file_node_path,
                 file_node.extension(),
@@ -697,8 +697,9 @@ pub async fn diff_tabular_file_nodes(
 ) -> Result<TabularDiff, OxenError> {
     match (file_1, file_2) {
         (Some(file_1), Some(file_2)) => {
-            let version_path_1 = util::fs::version_path_from_hash(repo, file_1.hash().to_string());
-            let version_path_2 = util::fs::version_path_from_hash(repo, file_2.hash().to_string());
+            let version_store = repo.version_store()?;
+            let version_path_1 = version_store.get_version_path(&file_1.hash().to_string())?;
+            let version_path_2 = version_store.get_version_path(&file_2.hash().to_string())?;
             let df_1 = tabular::read_df_with_extension(
                 version_path_1,
                 file_1.extension(),
@@ -717,7 +718,8 @@ pub async fn diff_tabular_file_nodes(
             diff_dfs(&df_1, &df_2, keys, targets, display)
         }
         (Some(file_1), None) => {
-            let version_path_1 = util::fs::version_path_from_hash(repo, file_1.hash().to_string());
+            let version_store = repo.version_store()?;
+            let version_path_1 = version_store.get_version_path(&file_1.hash().to_string())?;
             let df_1 = tabular::read_df_with_extension(
                 version_path_1,
                 file_1.extension(),
@@ -731,7 +733,8 @@ pub async fn diff_tabular_file_nodes(
             diff_dfs(&df_1, &df_2, keys, targets, display)
         }
         (None, Some(file_2)) => {
-            let version_path_2 = util::fs::version_path_from_hash(repo, file_2.hash().to_string());
+            let version_store = repo.version_store()?;
+            let version_path_2 = version_store.get_version_path(&file_2.hash().to_string())?;
             let df_1 = tabular::new_df();
             let df_2 = tabular::read_df_with_extension(
                 version_path_2,

--- a/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
+++ b/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
@@ -1325,7 +1325,8 @@ mod tests {
 
             // Make sure version file is updated
             let entry = repositories::entries::get_commit_entry(&repo, &commit, &path)?.unwrap();
-            let version_file = util::fs::version_path(&repo, &entry);
+            let version_store = repo.version_store()?;
+            let version_file = version_store.get_version_path(&entry.hash)?;
             let extension = entry.path.extension().unwrap().to_str().unwrap();
             let data_frame =
                 df::tabular::read_df_with_extension(version_file, extension, &DFOpts::empty()).await?;

--- a/oxen-rust/src/lib/src/storage/version_store.rs
+++ b/oxen-rust/src/lib/src/storage/version_store.rs
@@ -170,7 +170,8 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// Get the path to a version file (sync operation)
     ///
     /// # Arguments
-    /// * `hash` - The content hash of the version to retrieve
+    /// * `hash` - The content hash of the version file to compute the path for
+    // TODO: See if we can make this infallible
     fn get_version_path(&self, hash: &str) -> Result<PathBuf, OxenError>;
 
     /// Copy a version to a destination path
@@ -209,7 +210,7 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     fn storage_settings(&self) -> HashMap<String, String>;
 }
 
-// This only creates a version store struct, it does not initialize it
+/// This only creates a version store struct, it does not initialize it
 pub fn create_version_store(
     repo_dir: &Path,
     storage_opts: &StorageOpts,

--- a/oxen-rust/src/lib/src/storage/version_store.rs
+++ b/oxen-rust/src/lib/src/storage/version_store.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::io::{Read, Seek};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -8,7 +7,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use image::DynamicImage;
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_stream::Stream;
 
 use crate::constants;
@@ -28,24 +27,6 @@ pub struct StorageConfig {
     #[serde(default)]
     pub settings: HashMap<String, String>,
 }
-
-/// Trait for async read and seek operations
-pub trait AsyncReadSeek: AsyncRead + AsyncSeek + Send + Sync + Unpin {}
-
-/// Implement AsyncReadSeek for any type that implements both AsyncRead and AsyncSeek
-impl<T: AsyncRead + AsyncSeek + Send + Sync + Unpin> AsyncReadSeek for T {}
-
-/// Trait for async write operations
-pub trait AsyncWriteSeek: AsyncWrite + AsyncSeek + Send + Sync + Unpin {}
-
-/// Implement AsyncWriteSeek for any type that implements both AsyncWrite and AsyncSeek
-impl<T: AsyncWrite + AsyncSeek + Send + Sync + Unpin> AsyncWriteSeek for T {}
-
-/// Trait for sync read and seek operations
-pub trait ReadSeek: Read + Seek + Send + Sync {}
-
-/// Implement ReadSeek for any type that implements both Read and Seek
-impl<T: Read + Seek + Send + Sync> ReadSeek for T {}
 
 /// Trait defining operations for version file storage backends
 #[async_trait]

--- a/oxen-rust/src/lib/src/util/fs.rs
+++ b/oxen-rust/src/lib/src/util/fs.rs
@@ -28,15 +28,13 @@ use crate::constants::CONTENT_IS_VALID;
 use crate::constants::HISTORY_DIR;
 use crate::constants::OXEN_HIDDEN_DIR;
 use crate::constants::TREE_DIR;
-use crate::constants::VERSION_FILE_NAME;
-use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::Commit;
 use crate::model::MerkleHash;
 use crate::model::merkle_tree::node::FileNode;
 use crate::model::metadata::metadata_image::ImgResize;
 use crate::model::metadata::metadata_video::VideoThumbnail;
-use crate::model::{CommitEntry, EntryDataType, LocalRepository};
+use crate::model::{EntryDataType, LocalRepository};
 use crate::opts::CountLinesOpts;
 use crate::storage::version_store::VersionStore;
 use crate::view::health::DiskUsage;
@@ -149,126 +147,12 @@ pub fn chunk_path(repo: &LocalRepository, hash: impl AsRef<str>) -> PathBuf {
         .join("data")
 }
 
-pub fn version_path(repo: &LocalRepository, entry: &CommitEntry) -> PathBuf {
-    match repo.min_version() {
-        MinOxenVersion::V0_10_0 => version_path_from_hash_and_file_v0_10_0(
-            &repo.path,
-            entry.hash.clone(),
-            entry.filename(),
-        ),
-        _ => version_path_from_hash_and_file(&repo.path, entry.hash.clone(), entry.filename()),
-    }
-}
-
-pub fn version_path_from_hash_and_filename(
-    repo: &LocalRepository,
-    hash: impl AsRef<str>,
-    filename: impl AsRef<Path>,
-) -> PathBuf {
-    match repo.min_version() {
-        MinOxenVersion::V0_10_0 => {
-            version_path_from_hash_and_file_v0_10_0(&repo.path, hash, filename)
-        }
-        _ => version_path_from_hash_and_file(&repo.path, hash, filename),
-    }
-}
-
-pub fn version_path_from_node(
-    repo: &LocalRepository,
-    file_hash: impl AsRef<str>,
-    path: impl AsRef<Path>,
-) -> PathBuf {
-    match repo.min_version() {
-        MinOxenVersion::V0_10_0 => {
-            version_path_from_hash_and_file_v0_10_0(&repo.path, file_hash, path)
-        }
-        _ => version_path_from_hash_and_file(&repo.path, file_hash, path),
-    }
-}
-
-pub fn version_path_from_hash(repo: &LocalRepository, hash: impl AsRef<str>) -> PathBuf {
-    match repo.min_version() {
-        MinOxenVersion::V0_10_0 => {
-            version_path_from_hash_and_file_v0_10_0(&repo.path, hash, PathBuf::new())
-        }
-        _ => version_path_from_hash_and_file(&repo.path, hash, PathBuf::new()),
-    }
-}
-
-pub fn version_path_from_hash_and_file_v0_10_0(
-    dst: impl AsRef<Path>,
-    hash: impl AsRef<str>,
-    filename: impl AsRef<Path>,
-) -> PathBuf {
-    let hash = hash.as_ref();
-    let filename = filename.as_ref();
-    let version_dir = version_dir_from_hash(dst, hash);
-    // log::debug!(
-    //     "version_path_from_hash_and_file version_dir {:?}",
-    //     version_dir
-    // );
-    let extension = extension_from_path(filename);
-    version_dir.join(format!("{VERSION_FILE_NAME}.{extension}"))
-}
-
-pub fn version_path_from_hash_and_file(
-    dst: impl AsRef<Path>,
-    hash: impl AsRef<str>,
-    filename: impl AsRef<Path>,
-) -> PathBuf {
-    let hash = hash.as_ref();
-    let filename = filename.as_ref();
-    let version_dir = version_dir_from_hash(dst, hash);
-    // log::debug!(
-    //     "version_path_from_hash_and_file version_dir {:?}",
-    //     version_dir
-    // );
-    let extension = extension_from_path(filename);
-    if extension.is_empty() {
-        version_dir.join(VERSION_FILE_NAME)
-    } else {
-        // backwards compatibility
-        let path = version_dir.join(format!("{VERSION_FILE_NAME}.{extension}"));
-        if path.exists() {
-            // Older files have the extension in the filename
-            path
-        } else {
-            // Newer files do not have the extension in the filename
-            version_dir.join(VERSION_FILE_NAME)
-        }
-    }
-}
-
-pub fn version_path_from_schema_hash(dst: impl AsRef<Path>, hash: String) -> PathBuf {
-    // Save schemas as path with no extension
-    let version_dir = version_dir_from_hash(dst, hash);
-    version_dir.join(VERSION_FILE_NAME)
-}
-
 pub fn extension_from_path(path: &Path) -> String {
     if let Some(ext) = path.extension() {
         String::from(ext.to_str().unwrap_or(""))
     } else {
         String::from("")
     }
-}
-
-pub fn version_dir_from_hash(dst: impl AsRef<Path>, hash: impl AsRef<str>) -> PathBuf {
-    let hash = hash.as_ref();
-    let topdir = &hash[..2];
-    let subdir = &hash[2..];
-    oxen_hidden_dir(dst.as_ref())
-        .join(constants::VERSIONS_DIR)
-        .join(constants::FILES_DIR)
-        .join(topdir)
-        .join(subdir)
-}
-
-pub fn object_dir_suffix_from_hash(_dst: impl AsRef<Path>, hash: String) -> PathBuf {
-    let topdir = &hash[..2];
-    let subdir = &hash[2..];
-
-    PathBuf::from(topdir).join(subdir)
 }
 
 pub fn read_bytes_from_path(path: impl AsRef<Path>) -> Result<Vec<u8>, OxenError> {
@@ -2200,7 +2084,8 @@ mod tests {
                 last_modified_seconds: 0,
                 last_modified_nanoseconds: 0,
             };
-            let path = util::fs::version_path(&repo, &entry);
+            let version_store = repo.version_store()?;
+            let path = version_store.get_version_path(&entry.hash)?;
             let versions_dir = util::fs::oxen_hidden_dir(&repo.path).join(constants::VERSIONS_DIR);
             let relative_path = util::fs::path_relative_to_dir(path, versions_dir)?;
             assert_eq!(


### PR DESCRIPTION
This PR begins the work of having all storage access be done through the VersionStore trait. In this PR, I focused on moving path computation to use the trait.

I also cleaned up some dead code.

Resolves ENG-727