### PR TITLE
Fix bump-version.sh to increment oxen-python/Cargo.toml's version

### DIFF
--- a/oxen-python/Cargo.lock
+++ b/oxen-python/Cargo.lock
@@ -4397,7 +4397,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "oxen"
-version = "0.44.2"
+version = "0.46.0"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/oxen-python/Cargo.toml
+++ b/oxen-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxen"
-version = "0.44.2"
+version = "0.46.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -121,6 +121,15 @@ else
 fi
 echo "  ✓ oxen-python/pyproject.toml" >&2
 
+# Update oxen-python/Cargo.toml
+echo "Updating oxen-python/Cargo.toml..." >&2
+if [[ "$(uname)" == "Darwin" ]]; then
+  sed -i '' '/^\[package\]/,/^\[/ s/^version = ".*"/version = "'"$VERSION"'"/' oxen-python/Cargo.toml
+else
+  sed -i '/^\[package\]/,/^\[/ s/^version = ".*"/version = "'"$VERSION"'"/' oxen-python/Cargo.toml
+fi
+echo "  ✓ oxen-python/Cargo.toml" >&2
+
 # Update lock files (only workspace packages, not all dependencies)
 echo "Updating lock files..." >&2
 echo "  Updating oxen-rust/Cargo.lock..." >&2
@@ -143,6 +152,7 @@ echo "" >&2
 echo "Committing changes..." >&2
 # Add only the files modified by this script
 git add oxen-python/pyproject.toml
+git add oxen-python/Cargo.toml
 git add oxen-rust/Cargo.toml
 git add oxen-rust/Cargo.lock
 git add oxen-rust/README.md


### PR DESCRIPTION
Now the script will update the version in all three files:
- `oxen-python/{Cargo, pyproject}.toml`
- `oxen-rust/Cargo.toml`

Also updates the version in `oxen-python/Cargo.toml` to 
`0.46.0` to  keep it in-line with the rest of the codebase.