### PR TITLE
get_version_path() encapsulation

### DIFF
--- a/oxen-rust/crates/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/oxen-rust/crates/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -214,12 +214,10 @@ pub async fn rename(
             repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
         {
             let version_store = workspace.base_repo.version_store()?;
-            let version_path =
-                version_store.get_version_path(&existing_file_node.hash().to_string())?;
-            log::debug!(
-                "rename: copying version path: {version_path:?} to {workspace_file_path:?}"
-            );
-            util::fs::copy_mkdir(version_path, &workspace_file_path)?;
+            let hash = existing_file_node.hash().to_string();
+            version_store
+                .copy_version_to_path(&hash, &workspace_file_path)
+                .await?;
         }
 
         // Check if the new path exists in the merkle tree, if it does, it is modified

--- a/oxen-rust/crates/lib/src/storage/local.rs
+++ b/oxen-rust/crates/lib/src/storage/local.rs
@@ -185,9 +185,11 @@ impl VersionStore for LocalVersionStore {
         Ok(self.version_path(hash))
     }
 
+    // TODO: (CleanCut) Do we need to make sure the destination path is outside the version store?
     async fn copy_version_to_path(&self, hash: &str, dest_path: &Path) -> Result<(), OxenError> {
         let version_path = self.version_path(hash);
-        fs::copy(&version_path, dest_path).await?;
+        log::debug!("copying version path: {version_path:?} to {dest_path:?}");
+        util::fs::copy_mkdir(&version_path, dest_path).await?;
         Ok(())
     }
 

--- a/oxen-rust/crates/lib/src/storage/version_store.rs
+++ b/oxen-rust/crates/lib/src/storage/version_store.rs
@@ -174,7 +174,7 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     // TODO: See if we can make this infallible
     fn get_version_path(&self, hash: &str) -> Result<PathBuf, OxenError>;
 
-    /// Copy a version to a destination path
+    /// Copy a versioned file from the version store to a destination path on the local filesystem
     ///
     /// # Arguments
     /// * `hash` - The content hash of the version to retrieve

--- a/oxen-rust/crates/lib/src/util/fs.rs
+++ b/oxen-rust/crates/lib/src/util/fs.rs
@@ -599,14 +599,12 @@ pub fn rename(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), OxenEr
     }
 }
 
-/// Wrapper around the std::fs::copy which makes the parent directory of the dst if it doesn't exist
-pub fn copy_mkdir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), OxenError> {
-    let src = src.as_ref();
-    let dst = dst.as_ref();
+/// Wrapper around the tokio::fs::copy which makes the parent directory of the dst if it doesn't exist
+pub async fn copy_mkdir(src: &Path, dst: &Path) -> Result<(), OxenError> {
     if let Some(parent) = dst.parent() {
-        create_dir_all(parent)?;
+        tokio::fs::create_dir_all(parent).await?;
     }
-    match std::fs::copy(src, dst) {
+    match tokio::fs::copy(src, dst).await {
         Ok(_) => Ok(()),
         Err(err) => {
             if !src.exists() {

--- a/oxen-rust/crates/server/src/controllers/versions.rs
+++ b/oxen-rust/crates/server/src/controllers/versions.rs
@@ -368,27 +368,15 @@ pub async fn stream_versions_zip(
 
             let hash = &file.hash;
 
-            let version_path = match version_store_clone.get_version_path(hash) {
-                Ok(path) => path,
+            let file_size = match version_store_clone.get_version_size(hash).await {
+                Ok(size) => size,
                 Err(e) => {
-                    log::error!("Failed to get path for {hash}: {e}");
+                    log::error!("Failed to get version file size for {hash}: {e}");
                     error_tx.send(e).ok();
                     had_error = true;
                     break;
                 }
             };
-
-            let metadata = match util::fs::metadata(&version_path) {
-                Ok(metadata) => metadata,
-                Err(e) => {
-                    log::error!("Failed to get metadata for {version_path:?}: {e}");
-                    error_tx.send(e).ok();
-                    had_error = true;
-                    break;
-                }
-            };
-
-            let file_size = metadata.len();
 
             match version_store_clone.get_version_stream(hash).await {
                 Ok(data) => {


### PR DESCRIPTION
Encapsulate some external usage/manipulation of get_version_path() behind the `VersionStore` trait / implementation.

This is not a comprehensive sweep for this situation. Similar PR(s) will be coming up.