### PR TITLE
Pin rust image to Debian 12 (bookworm)

### DIFF
--- a/oxen-rust/Dockerfile
+++ b/oxen-rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.94 AS builder
+FROM rust:1.94-bookworm AS builder
 
 USER root
 RUN apt-get update


### PR DESCRIPTION
- The Rust image switched from Debian 12 to 13 between 1.88 and 1.94
- We need to pin to 12 to match the runtime image
- Potential follow-up to migrate all images to Debian 13 (trixie)