### PR TITLE
Install the prereqs for ffmpeg on macOS

### DIFF
--- a/scripts/install-pre-reqs.sh
+++ b/scripts/install-pre-reqs.sh
@@ -77,7 +77,7 @@ if [ "$PLATFORM" = "macos" ]; then
         ok "Homebrew already installed"
     fi
 
-    brew install cmake
+    brew install cmake pkg-config ffmpeg@7 imagemagick
 
 elif [ "$PLATFORM" = "linux" ]; then
     if ! command_exists apt-get || ! command_exists dpkg; then


### PR DESCRIPTION
This installs the prereqs you need to build oxen server with the `-F ffmpeg` feature on macOS.

Note that (so far) actually enabling the above feature is left to an exercise for the reader.