### PR TITLE
Encapsulate derived version file access behind the VersionStore trait

### DIFF
--- a/oxen-rust/crates/lib/src/storage/local.rs
+++ b/oxen-rust/crates/lib/src/storage/local.rs
@@ -1,6 +1,6 @@
 use std;
 use std::collections::HashMap;
-use std::io::{self};
+use std::io::{self, ErrorKind};
 use std::path::{Path, PathBuf};
 
 use crate::constants::{VERSION_CHUNK_FILE_NAME, VERSION_CHUNKS_DIR, VERSION_FILE_NAME};
@@ -11,11 +11,11 @@ use crate::view::versions::CleanCorruptedVersionsResult;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use image::{self, DynamicImage};
+use log;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use tokio::fs::{self, File};
+use tokio::fs::{self, File, metadata};
 use tokio::io::AsyncReadExt;
 use tokio::io::{BufReader, BufWriter};
 use tokio::sync::Semaphore;
@@ -123,25 +123,17 @@ impl VersionStore for LocalVersionStore {
 
     async fn store_version_derived(
         &self,
-        derived_image: DynamicImage,
-        _image_buf: Vec<u8>,
-        derived_path: &Path,
+        orig_hash: &str,
+        derived_filename: &str,
+        derived_data: &[u8],
     ) -> Result<(), OxenError> {
-        let path = PathBuf::from(derived_path);
-        // Todo: optimize for high concurrency writes
-        tokio::task::spawn_blocking(move || -> Result<(), OxenError> {
-            let derived_parent = path.parent().unwrap_or(Path::new(""));
-
-            if !derived_parent.exists() {
-                util::fs::create_dir_all(derived_parent)?;
-            }
-
-            derived_image.save(&path)?;
-
-            log::debug!("Saved derived version file {path:?}");
-            Ok(())
-        })
-        .await?
+        let dir = self.version_dir(orig_hash);
+        // TODO: Convert create_dir_all to async
+        util::fs::create_dir_all(&dir)?;
+        let path = dir.join(derived_filename);
+        fs::write(&path, derived_data).await?;
+        log::debug!("Saved derived version file {path:?}");
+        Ok(())
     }
 
     async fn get_version_size(&self, hash: &str) -> Result<u64, OxenError> {
@@ -171,14 +163,31 @@ impl VersionStore for LocalVersionStore {
 
     async fn get_version_derived_stream(
         &self,
-        derived_path: &Path,
+        orig_hash: &str,
+        derived_filename: &str,
     ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
     {
-        let file = File::open(derived_path).await?;
+        let path = self.version_dir(orig_hash).join(derived_filename);
+        let file = File::open(&path).await?;
         let reader = BufReader::new(file);
         let stream = ReaderStream::new(reader);
 
         Ok(Box::new(stream))
+    }
+
+    async fn derived_version_exists(
+        &self,
+        orig_hash: &str,
+        derived_filename: &str,
+    ) -> Result<bool, OxenError> {
+        let derived_path = self.version_dir(orig_hash).join(derived_filename);
+        match metadata(derived_path).await {
+            Ok(meta) => Ok(meta.is_file()),
+            Err(err) => match err.kind() {
+                ErrorKind::NotFound => Ok(false),
+                _ => Err(err)?,
+            },
+        }
     }
 
     fn get_version_path(&self, hash: &str) -> Result<PathBuf, OxenError> {
@@ -774,5 +783,61 @@ mod tests {
                 panic!("Unexpected error when getting non-existent chunk: {e:?}");
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_store_and_get_version_derived() {
+        let (_temp_dir, store) = setup().await;
+        let orig_hash = "aaaaaaaaaaaaaaaa";
+        let derived_filename = "100x200.jpg";
+        let derived_data = b"fake resized image bytes for hash aaaaaaaaaaaaaaaa";
+
+        // Store derived
+        store
+            .store_version_derived(orig_hash, derived_filename, derived_data)
+            .await
+            .unwrap();
+
+        // Retrieve via stream and verify content
+        use futures::StreamExt;
+        let mut stream = store
+            .get_version_derived_stream(orig_hash, derived_filename)
+            .await
+            .unwrap();
+        let mut collected = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            collected.extend_from_slice(&chunk.unwrap());
+        }
+        assert_eq!(collected, derived_data);
+    }
+
+    #[tokio::test]
+    async fn test_derived_version_exists() {
+        let (_temp_dir, store) = setup().await;
+        let orig_hash = "bbbbbbbbbbbbbbbb";
+        let derived_filename = "300x400.jpg";
+        let derived_data = b"fake resized image bytes for hash bbbbbbbbbbbbbbbb";
+
+        // Should not exist before store
+        assert_eq!(
+            store
+                .derived_version_exists(orig_hash, derived_filename)
+                .await
+                .unwrap(),
+            false
+        );
+
+        // Store and check again
+        store
+            .store_version_derived(orig_hash, derived_filename, derived_data)
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .derived_version_exists(orig_hash, derived_filename)
+                .await
+                .unwrap(),
+            true
+        );
     }
 }

--- a/oxen-rust/crates/lib/src/storage/s3.rs
+++ b/oxen-rust/crates/lib/src/storage/s3.rs
@@ -5,10 +5,10 @@ use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::head_object::HeadObjectError;
 use aws_sdk_s3::{Client, config::Region, primitives::ByteStream};
 use bytes::Bytes;
-use image::DynamicImage;
+use log;
 use std::collections::HashMap;
 use std::io::Read;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::OnceCell;
 use tokio_stream::Stream;
@@ -198,31 +198,24 @@ impl VersionStore for S3VersionStore {
 
     async fn store_version_derived(
         &self,
-        _derived_image: DynamicImage,
-        image_buf: Vec<u8>,
-        derived_path: &Path,
+        orig_hash: &str,
+        derived_filename: &str,
+        derived_data: &[u8],
     ) -> Result<(), OxenError> {
         let client = self.init_client().await?;
-        let key = derived_path
-            .components()
-            .filter_map(|c| match c {
-                Component::Normal(c) => Some(c.to_string_lossy()),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join("/");
+        let key = format!("{}/{}", self.version_dir(orig_hash), derived_filename);
 
         client
             .put_object()
             .bucket(&self.bucket)
             .key(&key)
-            .body(ByteStream::from(image_buf))
+            .body(ByteStream::from(derived_data.to_vec()))
             .send()
             .await
             .map_err(|e| {
                 OxenError::basic_str(format!("failed to store derived version file in S3: {e}"))
             })?;
-        log::debug!("Saved derived version file {derived_path:?}");
+        log::debug!("Saved derived version file {key}");
 
         Ok(())
     }
@@ -292,18 +285,12 @@ impl VersionStore for S3VersionStore {
 
     async fn get_version_derived_stream(
         &self,
-        derived_path: &Path,
+        orig_hash: &str,
+        derived_filename: &str,
     ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
     {
         let client = self.init_client().await?;
-        let key = derived_path
-            .components()
-            .filter_map(|c| match c {
-                Component::Normal(c) => Some(c.to_string_lossy()),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join("/");
+        let key = format!("{}/{}", self.version_dir(orig_hash), derived_filename);
 
         let resp = client
             .get_object()
@@ -315,6 +302,36 @@ impl VersionStore for S3VersionStore {
 
         let adapter = ByteStreamAdapter { inner: resp.body };
         Ok(Box::new(adapter) as Box<_>)
+    }
+
+    async fn derived_version_exists(
+        &self,
+        orig_hash: &str,
+        derived_filename: &str,
+    ) -> Result<bool, OxenError> {
+        let client = self.init_client().await?;
+        let key = format!("{}/{}", self.version_dir(orig_hash), derived_filename);
+
+        match client
+            .head_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(true),
+
+            Err(SdkError::ServiceError(err)) => match err.err() {
+                HeadObjectError::NotFound(_) => Ok(false),
+                err => Err(OxenError::basic_str(format!(
+                    "derived_exists failed with S3 head_object error: {err:?}"
+                ))),
+            },
+
+            Err(err) => Err(OxenError::basic_str(format!(
+                "derived_exists failed with S3 head_object error: {err:?}"
+            ))),
+        }
     }
 
     fn get_version_path(&self, hash: &str) -> Result<PathBuf, OxenError> {

--- a/oxen-rust/crates/lib/src/storage/version_store.rs
+++ b/oxen-rust/crates/lib/src/storage/version_store.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use image::DynamicImage;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_stream::Stream;
@@ -72,17 +71,17 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
         data: &[u8],
     ) -> Result<(), OxenError>;
 
-    /// Store a derived version file (resized, video thumbnail etc.)
+    /// Store a derived file (resized image, video thumbnail, etc.) corresponding to a file version
     ///
     /// # Arguments
-    /// * `derived_image` - The derived image to store, used for local processing
-    /// * `image_buf` - The raw bytes to store, used for S3
-    /// * `derived_path` - Path/key to the derived version file
+    /// * `orig_hash` - The content hash of the parent version
+    /// * `derived_filename` - Filename for the derived artifact (e.g. "200x300.jpg")
+    /// * `derived_data` - The raw bytes of the derived artifact to store
     async fn store_version_derived(
         &self,
-        derived_image: DynamicImage,
-        image_buf: Vec<u8>,
-        derived_path: &Path,
+        orig_hash: &str,
+        derived_filename: &str,
+        derived_data: &[u8],
     ) -> Result<(), OxenError>;
 
     /// Get a writer for a chunk of a version file
@@ -158,14 +157,27 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
         hash: &str,
     ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>;
 
-    /// Get stream of a derived version file (resized, video thumbnail etc.)
+    /// Get a stream of a derived file (resized, video thumbnail, etc.)
     ///
     /// # Arguments
-    /// * `derived_path` - Path/key to the derived version file
+    /// * `orig_hash` - The content hash of the parent version
+    /// * `derived_filename` - Filename for the derived artifact
     async fn get_version_derived_stream(
         &self,
-        derived_path: &Path,
+        orig_hash: &str,
+        derived_filename: &str,
     ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>;
+
+    /// Check if a derived file exists
+    ///
+    /// # Arguments
+    /// * `orig_hash` - The content hash of the parent version
+    /// * `derived_filename` - Filename for the derived artifact
+    async fn derived_version_exists(
+        &self,
+        orig_hash: &str,
+        derived_filename: &str,
+    ) -> Result<bool, OxenError>;
 
     /// Get the path to a version file (sync operation)
     ///

--- a/oxen-rust/crates/lib/src/util/fs.rs
+++ b/oxen-rust/crates/lib/src/util/fs.rs
@@ -93,50 +93,47 @@ pub async fn handle_image_resize(
     version_store: Arc<dyn VersionStore>,
     file_hash: String,
     file_path: &Path,
-    version_path: &Path,
     img_resize: ImgResize,
 ) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>, OxenError> {
     log::debug!("img_resize {img_resize:?}");
-    let resized_path = resized_path_for_version_store_file(
-        Arc::clone(&version_store),
-        &file_hash,
-        file_path,
-        img_resize.width,
-        img_resize.height,
-    )?;
+    let derived_filename = resized_filename(file_path, img_resize.width, img_resize.height);
 
-    let stream = resize_cache_image_version_store(
-        version_store,
-        &file_hash,
-        version_path,
-        &resized_path,
-        img_resize,
-    )
-    .await?;
-    log::debug!("Got the resize image! {resized_path:?}");
+    let stream =
+        resize_cache_image_version_store(version_store, &file_hash, &derived_filename, img_resize)
+            .await?;
+    log::debug!("Got the resized image! {derived_filename}");
 
     Ok(stream)
 }
 
-// TODO: Change the resized path from version store to a server location
-pub fn resized_path_for_version_store_file(
-    version_store: Arc<dyn VersionStore>,
-    img_hash: &str,
-    img_path: &Path,
-    width: Option<u32>,
-    height: Option<u32>,
-) -> Result<PathBuf, OxenError> {
-    let img_version_path = version_store.get_version_path(img_hash)?;
+pub fn resized_filename(img_path: &Path, width: Option<u32>, height: Option<u32>) -> String {
     let extension = img_path.extension().unwrap().to_str().unwrap();
     let width = width.map(|w| w.to_string());
     let height = height.map(|w| w.to_string());
-    let resized_path = img_version_path.parent().unwrap().join(format!(
+    format!(
         "{}x{}.{}",
         width.unwrap_or("".to_string()),
         height.unwrap_or("".to_string()),
         extension
-    ));
-    Ok(resized_path)
+    )
+}
+
+pub fn video_thumbnail_filename(
+    width: Option<u32>,
+    height: Option<u32>,
+    timestamp: Option<f64>,
+) -> String {
+    let extension = "jpg";
+    let (width_str, height_str) = match (width, height) {
+        (Some(w), Some(h)) => (w.to_string(), h.to_string()),
+        (Some(w), None) => (w.to_string(), "auto".to_string()),
+        (None, Some(h)) => ("auto".to_string(), h.to_string()),
+        (None, None) => ("320".to_string(), "240".to_string()),
+    };
+    let timestamp_str = timestamp
+        .map(|t| format!("t{t:.1}"))
+        .unwrap_or_else(|| "t1.0".to_string());
+    format!("thumbnail_{width_str}x{height_str}_{timestamp_str}.{extension}")
 }
 
 pub fn chunk_path(repo: &LocalRepository, hash: impl AsRef<str>) -> PathBuf {
@@ -1581,23 +1578,24 @@ async fn detect_image_format_from_version(
     Ok(format)
 }
 
-// Caller must provide out path because it differs between remote staged vs. committed files
 pub async fn resize_cache_image_version_store(
     version_store: Arc<dyn VersionStore>,
     img_hash: &str,
-    image_path: &Path,
-    resize_path: &Path,
+    derived_filename: &str,
     resize: ImgResize,
 ) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>, OxenError> {
-    if resize_path.exists() {
-        log::debug!("In the resize cache! {resize_path:?}");
+    if version_store
+        .derived_version_exists(img_hash, derived_filename)
+        .await?
+    {
+        log::debug!("In the resize cache! {derived_filename}");
         let stream = version_store
-            .get_version_derived_stream(resize_path)
+            .get_version_derived_stream(img_hash, derived_filename)
             .await?;
         return Ok(stream.boxed());
     }
 
-    log::debug!("resize to path {resize_path:?} from {image_path:?}");
+    log::debug!("create resized image {derived_filename} from hash {img_hash}");
     let image_format = detect_image_format_from_version(Arc::clone(&version_store), img_hash).await;
     let image_data = version_store.get_version(img_hash).await?;
 
@@ -1637,15 +1635,12 @@ pub async fn resize_cache_image_version_store(
     } else {
         img
     };
-    log::debug!("about to save {resize_path:?}");
 
-    log::debug!("saved {resize_path:?}");
-
-    let image_format = ImageFormat::from_path(resize_path)?;
+    let image_format = ImageFormat::from_path(derived_filename)?;
     let mut buf = Vec::new();
     resized_img.write_to(&mut Cursor::new(&mut buf), image_format)?;
     version_store
-        .store_version_derived(resized_img, buf.clone(), resize_path)
+        .store_version_derived(img_hash, derived_filename, &buf)
         .await?;
 
     let stream: Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>> =
@@ -1656,28 +1651,24 @@ pub async fn resize_cache_image_version_store(
 
 /// Generate a video thumbnail using thumbnails crate.
 /// This function extracts a frame from the video and saves it as an image thumbnail.
-/// Note: The thumbnails crate extracts from the beginning of the video.
-/// If a specific timestamp is required, it may need to be handled differently.
 #[cfg(feature = "ffmpeg")]
-fn generate_video_thumbnail_version_store(
+async fn generate_video_thumbnail_version_store(
     version_store: Arc<dyn VersionStore>,
     video_hash: &str,
-    _video_path: &Path,
-    thumbnail_path: &Path,
+    derived_filename: &str,
     thumbnail: VideoThumbnail,
 ) -> Result<(), OxenError> {
-    log::debug!("generate thumbnail to path {thumbnail_path:?} from video hash {video_hash}");
-    if thumbnail_path.exists() {
+    log::debug!(
+        "generate thumbnail derived_filename {derived_filename} from video hash {video_hash}"
+    );
+    if version_store
+        .derived_version_exists(video_hash, derived_filename)
+        .await?
+    {
         return Ok(());
     }
 
-    // Create parent directory if it doesn't exist
-    let thumbnail_parent = thumbnail_path.parent().unwrap_or(Path::new(""));
-    if !thumbnail_parent.exists() {
-        util::fs::create_dir_all(thumbnail_parent)?;
-    }
-
-    // Get the video file from version store
+    // Get the video file path from version store
     let version_path = version_store.get_version_path(video_hash)?;
 
     // Determine output dimensions
@@ -1694,75 +1685,44 @@ fn generate_video_thumbnail_version_store(
     // If timestamp support is needed, we may need to use ffmpeg directly or another approach.
     let _timestamp = thumbnail.timestamp.unwrap_or(1.0);
 
-    // Create thumbnailer with specified dimensions
-    let thumbnailer = Thumbnailer::new(output_width, output_height);
+    // Run blocking ffmpeg thumbnail generation on a separate thread
+    let buf = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, OxenError> {
+        // Create thumbnailer with specified dimensions
+        let thumbnailer = Thumbnailer::new(output_width, output_height);
 
-    // Generate thumbnail from video file
-    let thumb_image = thumbnailer.get(&version_path).map_err(|e| {
-        OxenError::basic_str(format!(
-            "Failed to generate thumbnail: {e}. Make sure ffmpeg is installed."
-        ))
-    })?;
+        // Generate thumbnail from video file
+        let thumb_image = thumbnailer
+            .get(&version_path)
+            .map_err(|e| OxenError::basic_str(format!("Failed to generate thumbnail: {e}.")))?;
+
+        let mut buf = Vec::new();
+        thumb_image
+            .write_to(&mut Cursor::new(&mut buf), image::ImageFormat::Jpeg)
+            .map_err(|e| OxenError::basic_str(format!("Failed to encode thumbnail: {e}")))?;
+        Ok(buf)
+    })
+    .await??;
 
     // Save the thumbnail image
-    thumb_image
-        .save(thumbnail_path)
-        .map_err(|e| OxenError::basic_str(format!("Failed to save thumbnail: {e}")))?;
+    version_store
+        .store_version_derived(video_hash, derived_filename, &buf)
+        .await?;
 
-    log::debug!("saved thumbnail {thumbnail_path:?}");
+    log::debug!("saved thumbnail {derived_filename}");
     Ok(())
 }
 
-/// Generate the cache path for a video thumbnail based on the video hash and thumbnail parameters.
-pub fn thumbnail_path_for_version_store_file(
-    version_store: Arc<dyn VersionStore>,
-    video_hash: &str,
-    _video_path: &Path,
-    width: Option<u32>,
-    height: Option<u32>,
-    timestamp: Option<f64>,
-) -> Result<PathBuf, OxenError> {
-    let video_version_path = version_store.get_version_path(video_hash)?;
-    let extension = "jpg"; // Always use jpg for thumbnails
-
-    // Build dimension strings for cache path - use "auto" when maintaining aspect ratio
-    let (width_str, height_str) = match (width, height) {
-        (Some(w), Some(h)) => (w.to_string(), h.to_string()),
-        (Some(w), None) => (w.to_string(), "auto".to_string()),
-        (None, Some(h)) => ("auto".to_string(), h.to_string()),
-        (None, None) => ("320".to_string(), "240".to_string()),
-    };
-
-    let timestamp_str = timestamp
-        .map(|t| format!("t{t:.1}"))
-        .unwrap_or_else(|| "t1.0".to_string());
-
-    let thumbnail_path = video_version_path.parent().unwrap().join(format!(
-        "thumbnail_{width_str}x{height_str}_{timestamp_str}.{extension}"
-    ));
-    Ok(thumbnail_path)
-}
-
-/// Handle video thumbnail generation: determine cache path and generate thumbnail if needed.
-/// Returns the path to the cached thumbnail.
+/// Handle video thumbnail generation: generate thumbnail if needed and return a stream.
 /// Only enabled if the 'ffmpeg' feature is enabled.
 #[allow(unused_variables)]
-pub fn handle_video_thumbnail(
+pub async fn handle_video_thumbnail(
     version_store: Arc<dyn VersionStore>,
     file_hash: String,
-    file_path: &Path,
-    version_path: &Path,
     video_thumbnail: VideoThumbnail,
-) -> Result<PathBuf, OxenError> {
+) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>, OxenError> {
     #[cfg(not(feature = "ffmpeg"))]
     {
-        let _ = (
-            version_store,
-            file_hash,
-            file_path,
-            version_path,
-            video_thumbnail,
-        );
+        let _ = (version_store, file_hash, video_thumbnail);
         Err(OxenError::thumbnailing_not_enabled(
             "Video thumbnail generation requires the 'ffmpeg' feature to be enabled. \
              Build with --features liboxen/ffmpeg to enable this functionality.",
@@ -1772,25 +1732,25 @@ pub fn handle_video_thumbnail(
     #[cfg(feature = "ffmpeg")]
     {
         log::debug!("video_thumbnail {video_thumbnail:?}");
-        let thumbnail_path = thumbnail_path_for_version_store_file(
-            Arc::clone(&version_store),
-            &file_hash,
-            file_path,
+        let derived_filename = video_thumbnail_filename(
             video_thumbnail.width,
             video_thumbnail.height,
             video_thumbnail.timestamp,
-        )?;
+        );
 
         generate_video_thumbnail_version_store(
-            version_store,
+            version_store.clone(),
             &file_hash,
-            version_path,
-            &thumbnail_path,
+            &derived_filename,
             video_thumbnail,
-        )?;
+        )
+        .await?;
 
-        log::debug!("In the thumbnail cache! {thumbnail_path:?}");
-        Ok(thumbnail_path)
+        log::debug!("In the thumbnail cache! {derived_filename}");
+        let stream = version_store
+            .get_version_derived_stream(&file_hash, &derived_filename)
+            .await?;
+        Ok(stream.boxed())
     }
 }
 

--- a/oxen-rust/crates/server/src/controllers/file.rs
+++ b/oxen-rust/crates/server/src/controllers/file.rs
@@ -23,9 +23,6 @@ use liboxen::view::{CommitResponse, StatusMessage};
 use serde::Deserialize;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
-use tokio::fs::File;
-use tokio::io::BufReader;
-use tokio_util::io::ReaderStream;
 use utoipa::ToSchema;
 
 #[derive(MultipartForm, ToSchema)]
@@ -183,8 +180,6 @@ pub async fn get(
     let hash_str = file_hash.to_string();
     let mime_type = entry.mime_type();
     let last_commit_id = entry.last_commit_id().to_string();
-    let version_path = version_store.get_version_path(&hash_str)?;
-
     let query_params = query.into_inner();
 
     // Handle image resize
@@ -198,10 +193,9 @@ pub async fn get(
         log::debug!("img_resize {img_resize:?}");
 
         let file_stream = util::fs::handle_image_resize(
-            Arc::clone(&version_store),
+            version_store.clone(),
             hash_str.clone(),
             &path,
-            &version_path,
             img_resize,
         )
         .await?;
@@ -222,19 +216,9 @@ pub async fn get(
         };
         log::debug!("video_thumbnail {video_thumbnail:?}");
 
-        let thumbnail_path = util::fs::handle_video_thumbnail(
-            Arc::clone(&version_store),
-            hash_str,
-            &path,
-            &version_path,
-            video_thumbnail,
-        )?;
-        log::debug!("In the thumbnail cache! {thumbnail_path:?}");
-
-        // Generate stream for the thumbnail (always JPEG)
-        let file = File::open(&thumbnail_path).await?;
-        let reader = BufReader::new(file);
-        let stream = ReaderStream::new(reader);
+        let stream =
+            util::fs::handle_video_thumbnail(Arc::clone(&version_store), hash_str, video_thumbnail)
+                .await?;
 
         return Ok(HttpResponse::Ok()
             .content_type("image/jpeg")

--- a/oxen-rust/crates/server/src/controllers/versions.rs
+++ b/oxen-rust/crates/server/src/controllers/versions.rs
@@ -131,8 +131,6 @@ pub async fn download(
     let hash_str = file_hash.to_string();
     let mime_type = entry.mime_type();
     let last_commit_id = entry.last_commit_id().to_string();
-    let version_path = version_store.get_version_path(&hash_str)?;
-
     // TODO: refactor out of here and check for type,
     // but seeing if it works to resize the image and cache it to disk if we have a resize query
     let img_resize = query.into_inner();
@@ -141,14 +139,9 @@ pub async fn download(
     {
         log::debug!("img_resize {img_resize:?}");
 
-        let file_stream = util::fs::handle_image_resize(
-            Arc::clone(&version_store),
-            hash_str,
-            &path,
-            &version_path,
-            img_resize,
-        )
-        .await?;
+        let file_stream =
+            util::fs::handle_image_resize(Arc::clone(&version_store), hash_str, &path, img_resize)
+                .await?;
 
         return Ok(HttpResponse::Ok()
             .content_type(mime_type)

--- a/oxen-rust/crates/server/src/controllers/workspaces/files.rs
+++ b/oxen-rust/crates/server/src/controllers/workspaces/files.rs
@@ -27,9 +27,6 @@ use serde::Deserialize;
 use std::io::Read as StdRead;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::fs::File;
-use tokio::io::BufReader;
-use tokio_util::io::ReaderStream;
 use utoipa;
 
 #[derive(utoipa::ToSchema)]
@@ -127,9 +124,6 @@ pub async fn get(
     let hash_str = file_hash.to_string();
     let mime_type = file_node.mime_type();
     let last_commit_id = file_node.last_commit_id().to_string();
-    let version_path = version_store.get_version_path(&hash_str)?;
-    log::debug!("got workspace file version path {:?}", &version_path);
-
     let query_params = query.into_inner();
 
     // Handle image resize
@@ -146,7 +140,6 @@ pub async fn get(
             Arc::clone(&version_store),
             hash_str.clone(),
             &PathBuf::from(&path),
-            &version_path,
             img_resize,
         )
         .await?;
@@ -167,19 +160,9 @@ pub async fn get(
         };
         log::debug!("video_thumbnail {video_thumbnail:?}");
 
-        let thumbnail_path = util::fs::handle_video_thumbnail(
-            Arc::clone(&version_store),
-            hash_str,
-            &PathBuf::from(&path),
-            &version_path,
-            video_thumbnail,
-        )?;
-        log::debug!("In the thumbnail cache! {thumbnail_path:?}");
-
-        // Generate stream for the thumbnail (always JPEG)
-        let file = File::open(&thumbnail_path).await?;
-        let reader = BufReader::new(file);
-        let stream = ReaderStream::new(reader);
+        let stream =
+            util::fs::handle_video_thumbnail(Arc::clone(&version_store), hash_str, video_thumbnail)
+                .await?;
 
         return Ok(HttpResponse::Ok()
             .content_type("image/jpeg")


### PR DESCRIPTION
I suggest reviewing in roughly this order:
- [oxen-rust/crates/lib/src/storage/version_store.rs](https://github.com/Oxen-AI/Oxen/compare/cleancut/centralize-version-fs-access?expand=1#diff-0be2229dafce1366149076c427fd3e918e6cf44938f36a8920f15f9c63c231e6)
  - `store_version_derived` - updated to accept parameters needed to derive a path/key to store the data, removed knowledge of what the derived data is.
  - `get_version_derived_stream` - ditto
  - `derived_version_exists` - (NEW) added a method to check if a derived file already exists, so callers don't reach into the implementation to check
- [‎oxen-rust/crates/lib/src/storage/local.rs‎](https://github.com/Oxen-AI/Oxen/pull/347/changes#diff-36ff6ff68faf98f8331522f4a05c18b3ef7f5a377c584c28f3827bd69a8336fb)
  - Updated (or added) implementations for `store_version_derived`, `get_version_derived_stream`, and `derived_version_exists`
  - Added some tests
- [‎oxen-rust/crates/lib/src/storage/s3.rs‎](https://github.com/Oxen-AI/Oxen/pull/347/changes#diff-d873b81aeecc4e0a669f0216e6ba02b3983cdbfa01acc7e83522c1897d7cdf6a)
  -  I wouldn't worry too much about the s3 implementation, since it's already broken (to fix it is the end goal of my project that this PR is a part of). There are some sensible-looking adjustments, but we don't actually test anything yet, and the entire implementation will probably need to be refactored holistically in a later PR.
- The rest of the files adjust to the changes above, and can be reviewed in any order:
  - [‎oxen-rust/crates/lib/src/util/fs.rs‎](https://github.com/Oxen-AI/Oxen/pull/347/changes#diff-047bb22b49bb7bef42ee810436831ef041a416d17ba692726c0498f52d9ea8a8)
  - [‎oxen-rust/crates/server/src/controllers/workspaces/files.rs‎](https://github.com/Oxen-AI/Oxen/pull/347/changes#diff-169c8d38e7dd01135d566c9e6ddf077bbdb4746eb492c392cf9042e2e76ec3d5)
  - [‎oxen-rust/crates/server/src/controllers/file.rs‎](https://github.com/Oxen-AI/Oxen/pull/347/changes#diff-36229057eafa6130edd100894f9eda56726d34ab7700ae97779613d9c3bf343a)
  - [‎oxen-rust/crates/server/src/controllers/versions.rs‎](https://github.com/Oxen-AI/Oxen/pull/347/changes#diff-1db724442c5b64bb334a3e0f68596544fb49ba14e93fc2c3b6b3a03fb532ea3e)