### PR TITLE
Remove unhelpful default server settings

### DIFF
--- a/oxen-rust/crates/server/src/main.rs
+++ b/oxen-rust/crates/server/src/main.rs
@@ -24,7 +24,6 @@ pub(crate) mod test;
 extern crate log;
 extern crate lru;
 
-use actix_web::http::KeepAlive;
 use actix_web::middleware::{Condition, DefaultHeaders, Logger};
 use actix_web::{App, HttpServer, web};
 use actix_web_httpauth::middleware::HttpAuthentication;
@@ -74,7 +73,6 @@ use clap::{Parser, Subcommand};
 
 use std::env;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 const VERSION: &str = liboxen::constants::OXEN_VERSION;
 
@@ -89,10 +87,6 @@ const SUPPORT: &str = "
 ";
 
 const START_SERVER_USAGE: &str = "Usage: `oxen-server start -i 0.0.0.0 -p 3000`";
-
-const DEFAULT_OXEN_KEEP_ALIVE_SECS: u64 = 600;
-
-const DEFAULT_OXEN_CLIENT_REQUEST_TIMEOUT_SECS: u64 = 600;
 
 // Exports for the utoipa docs
 // To add new endpoints to the docs, register their respective controller modules and schemas below
@@ -362,13 +356,6 @@ enum ServerError {
     Oxen(#[from] OxenError),
 }
 
-fn get_from_env_or_default<T: FromStr>(env_var_name: &str, default: T) -> T {
-    env::var(env_var_name)
-        .ok()
-        .and_then(|v| v.parse::<T>().ok())
-        .unwrap_or(default)
-}
-
 #[actix_web::main]
 async fn main() -> Result<(), ServerError> {
     dotenv().ok();
@@ -386,14 +373,6 @@ async fn main() -> Result<(), ServerError> {
         Err(_) => PathBuf::from("data"),
     };
 
-    let keep_alive_secs =
-        get_from_env_or_default("OXEN_KEEP_ALIVE_SECS", DEFAULT_OXEN_KEEP_ALIVE_SECS);
-
-    let client_request_timeout_secs = get_from_env_or_default(
-        "OXEN_CLIENT_REQUEST_TIMEOUT_SECS",
-        DEFAULT_OXEN_CLIENT_REQUEST_TIMEOUT_SECS,
-    );
-
     match ServerCli::parse().command {
         ServerCommand::Start { ip, port, auth } => {
             println!("🐂 v{VERSION}");
@@ -406,10 +385,6 @@ async fn main() -> Result<(), ServerError> {
                     // TODO: why is this not checking the value of the env var?
                     disable_merkle_cache: env::var("OXEN_DISABLE_MERKLE_CACHE").is_ok(),
                     enable_auth: auth,
-                    keep_alive: std::time::Duration::from_secs(keep_alive_secs),
-                    client_request_timeout: std::time::Duration::from_secs(
-                        client_request_timeout_secs,
-                    ),
                 },
                 &sync_dir,
             )
@@ -436,8 +411,6 @@ async fn main() -> Result<(), ServerError> {
 struct ServerConfig {
     disable_merkle_cache: bool,
     enable_auth: bool,
-    keep_alive: std::time::Duration,
-    client_request_timeout: std::time::Duration,
 }
 
 async fn start(
@@ -449,8 +422,6 @@ async fn start(
     let ServerConfig {
         disable_merkle_cache,
         enable_auth,
-        keep_alive,
-        client_request_timeout,
     } = *config;
 
     // Configure merkle tree node caching
@@ -509,8 +480,6 @@ async fn start(
             .wrap(Logger::default())
             .wrap(Logger::new("user agent is %a %{User-Agent}i"))
     })
-    .keep_alive(KeepAlive::Timeout(keep_alive))
-    .client_request_timeout(client_request_timeout)
     .bind((host.to_owned(), port))?
     .run()
     .await


### PR DESCRIPTION
### `keep_alive`

Actix's [keep_alive](https://github.com/Oxen-AI/Oxen/compare/cleancut/fix-server-settings?expand=1#diff-d37c11ba1bce3d86b20c038fb390a9b538c5df7aa92362f0e3c1a8e668cb09ccL512) setting sets the frequency that keep-alive packets are sent to keep a connection open if it doesn't have any traffic actively transiting it. We were decreasing the frequency from the default every 5 seconds to every 10 _minutes_. A setting this infrequent effectively disables server-side keep-alives, which can lead to unnecessarily dropped connections in transactions.

When I tested uploading 10 GB of files, I noticed that the upload took ~2 minutes, and then the server took ~1 minute to process the uploads and send a response.  I suspect there was no traffic happening in that last ~1 minute, which is where this setting could have caused problems if the client were also not sending keep-alives. Many corporate firewalls and other network infrastructure will terminate traffic-less connections. The most aggressive I've had to deal with in the past was set to 15 seconds, but 1-5 minutes is more common. `<cough>`_Hotels_`</cough>` 😂 

### `client_request_timeout`

Actix's [cient_request_timeout](https://github.com/Oxen-AI/Oxen/compare/cleancut/fix-server-settings?expand=1#diff-d37c11ba1bce3d86b20c038fb390a9b538c5df7aa92362f0e3c1a8e668cb09ccL513) setting configures the timeout for how long we will wait for a client to send their _headers_. This timeout is to prevent [DOS attacks](https://en.wikipedia.org/wiki/Denial-of-service_attack) from attackers who open a connection, start sending headers, but never finish sending headers, consuming a connection. The default is 5 seconds, which is a sufficiently small window to prevent most attackers from being able to exhaust resources before connections timeout. We set it to 10 _minutes_, which makes us trivially easy to DOS.