### PR TITLE
Improve pre-commit CI output

### DIFF
--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Run Pre-Commit Hooks
         run: |
           cd ${{ github.workspace }}
-          pre-commit run --verbose --all-files
+          pre-commit run --color=always --verbose --all-files || git -c color.status=always status

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -46,4 +46,8 @@ jobs:
       - name: Run Pre-Commit Hooks
         run: |
           cd ${{ github.workspace }}
-          pre-commit run --color=always --verbose --all-files || git -c color.status=always status
+          if ! pre-commit run --color=always --verbose --all-files ; then
+            echo "Pre-commit failed. Showing git status:"
+            git -c color.status=always status
+            exit 1
+          fi


### PR DESCRIPTION
- Enable colors in pre-commit in CI
- Output `git status` in color if pre-commit fails in CI