### PR TITLE
Update VersionStore::get_version_path to prep for S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
+name = "async-tempfile"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a57b75c36e16f4d015e60e6a177552976a99b6947724403c551bcfa7cb1207"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4435,6 +4444,7 @@ dependencies = [
  "async-compression",
  "async-std",
  "async-tar",
+ "async-tempfile",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ async-compression = { version = "0.4.2", features = ["tokio", "gzip", "futures-i
 async-recursion = "1.1.1"
 async-std = { version = "1.12.0", features = ["unstable"] }
 async-tar = "0.5.0"
+async-tempfile = "0.7.0"
 async-trait = "0.1.80"
 async_zip = { version = "0.0.18", features = ["full"] }
 aws-config = "1.8.11"
@@ -117,6 +118,7 @@ sql_query_builder = { version = "2.1.0", features = ["postgresql"] }
 sqlparser = "0.53.0"
 sysinfo = "0.33.0"
 tar = "0.4.44"
+# TODO: Replace all tempfile use with async-tempfile
 tempfile = "3.8.0"
 thiserror = "2.0.18"
 thumbnails = "0.2.1"

--- a/crates/cli/src/cmd/embeddings/index.rs
+++ b/crates/cli/src/cmd/embeddings/index.rs
@@ -64,7 +64,7 @@ impl RunCmd for EmbeddingsIndexCmd {
             let workspace_id = format!("{}-{}", path, commit.id);
             let workspace =
                 repositories::workspaces::create(&repository, &commit, workspace_id, false)?;
-            repositories::workspaces::data_frames::index(&repository, &workspace, path)?;
+            repositories::workspaces::data_frames::index(&repository, &workspace, path).await?;
             repositories::workspaces::data_frames::embeddings::index(
                 &workspace,
                 path,

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -36,6 +36,7 @@ astral-tokio-tar = { workspace = true }
 async-compression = { workspace = true }
 async-std = { workspace = true }
 async-tar = { workspace = true }
+async-tempfile = { workspace = true }
 async-trait = { workspace = true }
 aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }

--- a/crates/lib/src/core/df/sql.rs
+++ b/crates/lib/src/core/df/sql.rs
@@ -12,7 +12,7 @@ use crate::{
 use polars::frame::DataFrame;
 use uuid::Uuid;
 
-pub fn query_df_from_repo(
+pub async fn query_df_from_repo(
     sql: String,
     repo: &LocalRepository,
     path: &PathBuf,
@@ -25,7 +25,7 @@ pub fn query_df_from_repo(
         // If not, proceed to create a new workspace and index the data frame.
         let workspace_id = Uuid::new_v4().to_string();
         let workspace = repositories::workspaces::create(repo, &commit, workspace_id, false)?;
-        repositories::workspaces::data_frames::index(repo, &workspace, path)?;
+        repositories::workspaces::data_frames::index(repo, &workspace, path).await?;
     }
 
     let workspace =

--- a/crates/lib/src/core/df/tabular.rs
+++ b/crates/lib/src/core/df/tabular.rs
@@ -488,7 +488,8 @@ pub async fn transform_lazy(mut df: LazyFrame, opts: DFOpts) -> Result<LazyFrame
         && let Some(repo_dir) = opts.repo_dir.as_ref()
     {
         let repo = LocalRepository::from_dir(repo_dir)?;
-        df = sql::query_df_from_repo(sql, &repo, &opts.path.clone().unwrap_or_default(), &opts)?
+        df = sql::query_df_from_repo(sql, &repo, &opts.path.clone().unwrap_or_default(), &opts)
+            .await?
             .lazy();
     }
 

--- a/crates/lib/src/core/v_latest/data_frames.rs
+++ b/crates/lib/src/core/v_latest/data_frames.rs
@@ -95,7 +95,9 @@ pub async fn get_slice(
     }
     // Read the data frame from the version path
     let version_store = repo.version_store()?;
-    let version_path = version_store.get_version_path(&file_node.hash().to_string())?;
+    let version_path = version_store
+        .get_version_path(&file_node.hash().to_string())
+        .await?;
     let df = tabular::read_df_with_extension(version_path, file_node.extension(), opts).await?;
     log::debug!("get_slice df {:?}", df.height());
 

--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -619,7 +619,7 @@ async fn chunk_and_send_large_entries(
                     break;
                 };
 
-                let version_path = match version_store.get_version_path(&entry.hash()) {
+                let version_path = match version_store.get_version_path(&entry.hash()).await {
                     Ok(path) => path,
                     Err(e) => {
                         log::error!("Failed to get version path: {e}");

--- a/crates/lib/src/core/v_latest/revisions.rs
+++ b/crates/lib/src/core/v_latest/revisions.rs
@@ -1,13 +1,14 @@
 use crate::error::OxenError;
+use crate::storage::LocalFilePath;
 use crate::{model::LocalRepository, repositories};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// Get the version file path from a commit id
-pub fn get_version_file_from_commit_id(
+pub async fn get_version_file_from_commit_id(
     repo: &LocalRepository,
     commit_id: impl AsRef<str>,
     path: impl AsRef<Path>,
-) -> Result<PathBuf, OxenError> {
+) -> Result<LocalFilePath, OxenError> {
     let commit_id = commit_id.as_ref();
     let path = path.as_ref();
     let commit = repositories::commits::get_by_id(repo, commit_id)?
@@ -18,6 +19,6 @@ pub fn get_version_file_from_commit_id(
 
     let version_store = repo.version_store()?;
     let hash = file_node.hash().to_string();
-    let version_path = version_store.get_version_path(&hash)?;
+    let version_path = version_store.get_version_path(&hash).await?;
     Ok(version_path)
 }

--- a/crates/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -98,7 +98,7 @@ pub fn get_queryable_data_frame_workspace(
     get_queryable_data_frame_workspace_from_file_node(repo, &commit.id.parse()?, path)
 }
 
-pub fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
+pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
     // Is tabular just looks at the file extensions
     let file_node =
         repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
@@ -140,7 +140,9 @@ pub fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
     util::fs::create_dir_all(parent)?;
 
     let version_store = repo.version_store()?;
-    let version_path = version_store.get_version_path(&file_hash.to_string())?;
+    let version_path = version_store
+        .get_version_path(&file_hash.to_string())
+        .await?;
 
     log::debug!(
         "core::v_latest::index::workspaces::data_frames::index({path:?}) got version path: {version_path:?}"

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -275,7 +275,9 @@ pub async fn prepare_modified_or_removed_row(
 
     // let scan_rows = 10000 as usize;
     let version_store = repo.version_store()?;
-    let committed_df_path = version_store.get_version_path(&commit_merkle_tree.hash.to_string())?;
+    let committed_df_path = version_store
+        .get_version_path(&commit_merkle_tree.hash.to_string())
+        .await?;
 
     log::debug!("prepare_modified_or_removed_row() committed_df_path: {committed_df_path:?}");
 

--- a/crates/lib/src/core/v_latest/workspaces/files.rs
+++ b/crates/lib/src/core/v_latest/workspaces/files.rs
@@ -89,7 +89,7 @@ pub fn add_version_file(
     Ok(dst_path.to_path_buf())
 }
 
-pub fn add_version_files(
+pub async fn add_version_files(
     repo: &LocalRepository,
     workspace: &Workspace,
     files_with_hash: &[FileWithHash],
@@ -101,15 +101,20 @@ pub fn add_version_files(
     let workspace_repo = &workspace.workspace_repo;
     let seen_dirs = Arc::new(Mutex::new(HashSet::new()));
 
+    // Resolve all version paths before entering the sync closure
+    let mut version_paths = Vec::with_capacity(files_with_hash.len());
+    for item in files_with_hash.iter() {
+        version_paths.push(version_store.get_version_path(&item.hash).await?);
+    }
+
     let mut err_files: Vec<ErrorFileInfo> = vec![];
     with_staged_db_manager(workspace_repo, |staged_db_manager| {
-        for item in files_with_hash.iter() {
-            let version_path = version_store.get_version_path(&item.hash)?;
+        for (item, version_path) in files_with_hash.iter().zip(version_paths.iter()) {
             let target_path = PathBuf::from(directory).join(&item.path);
 
             match stage_file_with_hash(
                 workspace,
-                &version_path,
+                version_path,
                 &target_path,
                 &item.hash,
                 staged_db_manager,

--- a/crates/lib/src/model/diff/tabular_diff_summary.rs
+++ b/crates/lib/src/model/diff/tabular_diff_summary.rs
@@ -145,8 +145,9 @@ impl TabularDiffWrapper {
                 );
                 let version_path = version_store
                     .get_version_path(&node.hash().to_string())
+                    .await
                     .expect("invariant violation: version path not found in maybe_get_df_from_file_node");
-                tabular::read_df_with_extension(version_path, node.extension(), &DFOpts::empty())
+                tabular::read_df_with_extension(&*version_path, node.extension(), &DFOpts::empty())
                     .await
                     .ok()
             }
@@ -163,10 +164,10 @@ impl TabularDiffWrapper {
                 let version_store = repo
                     .version_store()
                     .expect("invariant violation: version store not found in maybe_get_df_from_commit_entry");
-                let version_path = version_store.get_version_path(&entry.hash).expect(
+                let version_path = version_store.get_version_path(&entry.hash).await.expect(
                     "invariant violation: version path not found in maybe_get_df_from_commit_entry",
                 );
-                tabular::read_df(version_path, DFOpts::empty()).await.ok()
+                tabular::read_df(&*version_path, DFOpts::empty()).await.ok()
             }
             None => None,
         }

--- a/crates/lib/src/repositories/checkout.rs
+++ b/crates/lib/src/repositories/checkout.rs
@@ -143,7 +143,9 @@ pub async fn checkout_combine<P: AsRef<Path>>(
     {
         if util::fs::is_tabular(&conflict.base_entry.path) {
             let version_store = repo.version_store()?;
-            let df_base_path = version_store.get_version_path(&conflict.base_entry.hash)?;
+            let df_base_path = version_store
+                .get_version_path(&conflict.base_entry.hash)
+                .await?;
             let df_base = tabular::maybe_read_df_with_extension(
                 repo,
                 &df_base_path,
@@ -152,7 +154,9 @@ pub async fn checkout_combine<P: AsRef<Path>>(
                 &DFOpts::empty(),
             )
             .await?;
-            let df_merge_path = version_store.get_version_path(&conflict.merge_entry.hash)?;
+            let df_merge_path = version_store
+                .get_version_path(&conflict.merge_entry.hash)
+                .await?;
             let df_merge = tabular::maybe_read_df_with_extension(
                 repo,
                 df_merge_path,

--- a/crates/lib/src/repositories/diffs.rs
+++ b/crates/lib/src/repositories/diffs.rs
@@ -662,7 +662,9 @@ pub async fn diff_tabular_file_and_file_node(
     let (df_1, df_2) = match file_node {
         Some(file_node) => {
             let version_store = repo.version_store()?;
-            let file_node_path = version_store.get_version_path(&file_node.hash().to_string())?;
+            let file_node_path = version_store
+                .get_version_path(&file_node.hash().to_string())
+                .await?;
             let df_1 = tabular::read_df_with_extension(
                 file_node_path,
                 file_node.extension(),
@@ -698,8 +700,12 @@ pub async fn diff_tabular_file_nodes(
     match (file_1, file_2) {
         (Some(file_1), Some(file_2)) => {
             let version_store = repo.version_store()?;
-            let version_path_1 = version_store.get_version_path(&file_1.hash().to_string())?;
-            let version_path_2 = version_store.get_version_path(&file_2.hash().to_string())?;
+            let version_path_1 = version_store
+                .get_version_path(&file_1.hash().to_string())
+                .await?;
+            let version_path_2 = version_store
+                .get_version_path(&file_2.hash().to_string())
+                .await?;
             let df_1 = tabular::read_df_with_extension(
                 version_path_1,
                 file_1.extension(),
@@ -719,7 +725,9 @@ pub async fn diff_tabular_file_nodes(
         }
         (Some(file_1), None) => {
             let version_store = repo.version_store()?;
-            let version_path_1 = version_store.get_version_path(&file_1.hash().to_string())?;
+            let version_path_1 = version_store
+                .get_version_path(&file_1.hash().to_string())
+                .await?;
             let df_1 = tabular::read_df_with_extension(
                 version_path_1,
                 file_1.extension(),
@@ -734,7 +742,9 @@ pub async fn diff_tabular_file_nodes(
         }
         (None, Some(file_2)) => {
             let version_store = repo.version_store()?;
-            let version_path_2 = version_store.get_version_path(&file_2.hash().to_string())?;
+            let version_path_2 = version_store
+                .get_version_path(&file_2.hash().to_string())
+                .await?;
             let df_1 = tabular::new_df();
             let df_2 = tabular::read_df_with_extension(
                 version_path_2,
@@ -761,9 +771,9 @@ pub async fn diff_text_file_and_node(
     let (file_node_content, version_path) = if let Some(node) = file_node {
         let file_hash = node.hash().to_string();
         let contents = read_version_file_to_string(&version_store, &file_hash).await?;
-        let path = version_store.get_version_path(&file_hash)?;
+        let path = version_store.get_version_path(&file_hash).await?;
 
-        (Some(contents), Some(path))
+        (Some(contents), Some(path.to_pathbuf()))
     } else {
         (None, None)
     };
@@ -788,30 +798,40 @@ pub async fn diff_text_file_nodes(
         (Some(file_1), Some(file_2)) => {
             let file_hash_1 = file_1.hash().to_string();
             let file_content_1 = read_version_file_to_string(&version_store, &file_hash_1).await?;
-            let version_path_1 = version_store.get_version_path(&file_hash_1)?;
+            let version_path_1 = version_store.get_version_path(&file_hash_1).await?;
 
             let file_hash_2 = file_2.hash().to_string();
             let file_content_2 = read_version_file_to_string(&version_store, &file_hash_2).await?;
-            let version_path_2 = version_store.get_version_path(&file_hash_2)?;
+            let version_path_2 = version_store.get_version_path(&file_hash_2).await?;
 
             utf8_diff::diff(
                 Some(file_content_1),
-                Some(version_path_1),
+                Some(version_path_1.to_pathbuf()),
                 Some(file_content_2),
-                Some(version_path_2),
+                Some(version_path_2.to_pathbuf()),
             )
         }
         (Some(file_1), None) => {
             let file_hash_1 = file_1.hash().to_string();
             let file_content_1 = read_version_file_to_string(&version_store, &file_hash_1).await?;
-            let version_path_1 = version_store.get_version_path(&file_hash_1)?;
-            utf8_diff::diff(Some(file_content_1), Some(version_path_1), None, None)
+            let version_path_1 = version_store.get_version_path(&file_hash_1).await?;
+            utf8_diff::diff(
+                Some(file_content_1),
+                Some(version_path_1.to_pathbuf()),
+                None,
+                None,
+            )
         }
         (None, Some(file_2)) => {
             let file_hash_2 = file_2.hash().to_string();
             let file_content_2 = read_version_file_to_string(&version_store, &file_hash_2).await?;
-            let version_path_2 = version_store.get_version_path(&file_hash_2)?;
-            utf8_diff::diff(None, None, Some(file_content_2), Some(version_path_2))
+            let version_path_2 = version_store.get_version_path(&file_hash_2).await?;
+            utf8_diff::diff(
+                None,
+                None,
+                Some(file_content_2),
+                Some(version_path_2.to_pathbuf()),
+            )
         }
         (None, None) => Err(OxenError::basic_str(
             "Could not find one or both of the files to compare",
@@ -1374,24 +1394,20 @@ pub async fn get_cached_diff(
     let right_entry = compare_entry_2.unwrap();
 
     // TODO this should be cached
-    let left_full_df = tabular::read_df(
-        repositories::revisions::get_version_file_from_commit_id(
-            repo,
-            left_entry.commit_id,
-            &left_entry.path,
-        )?,
-        DFOpts::empty(),
+    let left_version_path = repositories::revisions::get_version_file_from_commit_id(
+        repo,
+        left_entry.commit_id,
+        &left_entry.path,
     )
     .await?;
-    let right_full_df = tabular::read_df(
-        repositories::revisions::get_version_file_from_commit_id(
-            repo,
-            right_entry.commit_id,
-            &right_entry.path,
-        )?,
-        DFOpts::empty(),
+    let left_full_df = tabular::read_df(&*left_version_path, DFOpts::empty()).await?;
+    let right_version_path = repositories::revisions::get_version_file_from_commit_id(
+        repo,
+        right_entry.commit_id,
+        &right_entry.path,
     )
     .await?;
+    let right_full_df = tabular::read_df(&*right_version_path, DFOpts::empty()).await?;
 
     let schema_diff = TabularSchemaDiff::from_schemas(
         &Schema::from_polars(left_full_df.schema()),

--- a/crates/lib/src/repositories/entries.rs
+++ b/crates/lib/src/repositories/entries.rs
@@ -1109,7 +1109,7 @@ mod tests {
             // Now index df2
             let workspace_id = Uuid::new_v4().to_string();
             let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, false)?;
-            repositories::workspaces::data_frames::index(&repo, &workspace, &entry2.path)?;
+            repositories::workspaces::data_frames::index(&repo, &workspace, &entry2.path).await?;
 
             // Now get the metadata entries for the two dataframes
             let meta1 = repositories::entries::get_meta_entry(&repo, &commit, &path_1)?;

--- a/crates/lib/src/repositories/fsck.rs
+++ b/crates/lib/src/repositories/fsck.rs
@@ -24,7 +24,7 @@ mod tests {
 
             // Corrupt a version file by overwriting its data
             let hash = &versions[0];
-            let version_path = version_store.get_version_path(hash)?;
+            let version_path = version_store.get_version_path(hash).await?;
             std::fs::write(&version_path, b"corrupted data")?;
 
             // Dry run should detect corruption but not delete
@@ -55,7 +55,7 @@ mod tests {
 
             // Corrupt a version file by overwriting its data
             let hash = &versions[0];
-            let version_path = version_store.get_version_path(hash)?;
+            let version_path = version_store.get_version_path(hash).await?;
             std::fs::write(&version_path, b"corrupted data")?;
 
             // Clean should detect and remove the corrupted file

--- a/crates/lib/src/repositories/revisions.rs
+++ b/crates/lib/src/repositories/revisions.rs
@@ -1,12 +1,13 @@
 //! Revisions can either be commits by id or head commits on branches by name
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::core;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::{Commit, LocalRepository};
 use crate::repositories;
+use crate::storage::LocalFilePath;
 
 /// Get a commit object from a commit id or branch name
 /// Returns Ok(None) if the revision does not exist
@@ -31,13 +32,15 @@ pub fn get(repo: &LocalRepository, revision: impl AsRef<str>) -> Result<Option<C
 }
 
 /// Get the version file path from a commit id
-pub fn get_version_file_from_commit_id(
+pub async fn get_version_file_from_commit_id(
     repo: &LocalRepository,
     commit_id: impl AsRef<str>,
     path: impl AsRef<Path>,
-) -> Result<PathBuf, OxenError> {
+) -> Result<LocalFilePath, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::revisions::get_version_file_from_commit_id(repo, commit_id, path),
+        _ => {
+            core::v_latest::revisions::get_version_file_from_commit_id(repo, commit_id, path).await
+        }
     }
 }

--- a/crates/lib/src/repositories/workspaces/data_frames.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames.rs
@@ -82,14 +82,14 @@ pub fn get_queryable_data_frame_workspace(
     }
 }
 
-pub fn index(
+pub async fn index(
     repo: &LocalRepository,
     workspace: &Workspace,
     path: impl AsRef<Path>,
 ) -> Result<(), OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::workspaces::data_frames::index(workspace, path.as_ref()),
+        _ => core::v_latest::workspaces::data_frames::index(workspace, path.as_ref()).await,
     }
 }
 
@@ -118,7 +118,7 @@ pub fn unindex(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), Oxen
     })
 }
 
-pub fn restore(
+pub async fn restore(
     repo: &LocalRepository,
     workspace: &Workspace,
     path: impl AsRef<Path>,
@@ -127,7 +127,7 @@ pub fn restore(
     unindex(workspace, &path)?;
 
     // TODO: we could do this more granularly without a full reset
-    index(repo, workspace, path.as_ref())?;
+    index(repo, workspace, path.as_ref()).await?;
 
     Ok(())
 }
@@ -593,7 +593,7 @@ mod tests {
                 .join("bounding_box.csv");
 
             // Index dataset
-            workspaces::data_frames::index(&repo, &workspace, &file_path)?;
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
 
             // Append row
             let json_data = json!({
@@ -640,7 +640,7 @@ mod tests {
                 .join("bounding_box.csv");
 
             // Index dataset
-            workspaces::data_frames::index(&repo, &workspace, &file_path)?;
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
 
             // Append row
             let json_data = json!({
@@ -719,7 +719,7 @@ mod tests {
                 .join("bounding_box.csv");
 
             // Index the dataset
-            workspaces::data_frames::index(&repo, &workspace, &file_path)?;
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
 
             // Append the data to staging area
             let json_data = json!({
@@ -808,7 +808,7 @@ mod tests {
                 .join("bounding_box.csv");
 
             // Index the dataset
-            workspaces::data_frames::index(&repo, &workspace, &file_path)?;
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
 
             // Preview the dataset to grab some ids
             let mut page_opts = DFOpts::empty();
@@ -850,19 +850,21 @@ mod tests {
 
             let file_1 = repositories::revisions::get_version_file_from_commit_id(
                 &repo, &commit.id, &file_path,
-            )?;
+            )
+            .await?;
             // copy the file to the same path but with .csv as the extension
             let file_1_csv = file_1.with_extension("csv");
-            util::fs::copy(&file_1, &file_1_csv)?;
+            util::fs::copy(&*file_1, &file_1_csv)?;
             log::debug!("copied file 1 to {file_1_csv:?}");
 
             let file_2 = repositories::revisions::get_version_file_from_commit_id(
                 &repo,
                 commit_2.id,
                 &file_path,
-            )?;
+            )
+            .await?;
             let file_2_csv = file_2.with_extension("csv");
-            util::fs::copy(&file_2, &file_2_csv)?;
+            util::fs::copy(&*file_2, &file_2_csv)?;
             log::debug!("copied file 2 to {file_2_csv:?}");
             let diff_result =
                 repositories::diffs::diff_files(file_1_csv, file_2_csv, vec![], vec![], vec![])
@@ -899,7 +901,7 @@ mod tests {
 
             // Could use cache path here but they're being sketchy at time of writing
             // Index the dataset
-            workspaces::data_frames::index(&repo, &workspace, &file_path)?;
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
 
             // Add a row
             let json_data = json!({
@@ -975,7 +977,7 @@ mod tests {
 
             // Could use cache path here but they're being sketchy at time of writing
             // Index the dataset
-            workspaces::data_frames::index(&repo, &workspace, &file_path)?;
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
 
             // Add a row
             let json_data = json!({
@@ -1040,7 +1042,7 @@ mod tests {
 
             // Could use cache path here but they're being sketchy at time of writing
             // Index the dataset
-            workspaces::data_frames::index(&repo, &workspace, &file_path)?;
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
 
             // Preview the dataset to grab some ids
             let mut page_opts = DFOpts::empty();
@@ -1125,7 +1127,7 @@ mod tests {
                 .join("bounding_box.csv");
 
             // Index the dataset
-            workspaces::data_frames::index(&repo, &workspace, &file_path)?;
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
 
             // Preview the dataset to grab some ids
             let mut page_opts = DFOpts::empty();
@@ -1212,7 +1214,7 @@ mod tests {
                 .join("bounding_box.csv");
 
             // Index the dataset
-            workspaces::data_frames::index(&repo, &workspace, &file_path)?;
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
 
             // Preview the dataset to grab some ids
             let mut page_opts = DFOpts::empty();
@@ -1283,7 +1285,7 @@ mod tests {
 
             let workspace_id = UserConfig::identifier()?;
             let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
-            workspaces::data_frames::index(&repo, &workspace, &path)?;
+            workspaces::data_frames::index(&repo, &workspace, &path).await?;
             let json_data = json!({"NOT_REAL_COLUMN": "images/test.jpg"});
             let result = workspaces::data_frames::rows::add(&repo, &workspace, &path, &json_data);
             // Should be an error
@@ -1312,7 +1314,7 @@ mod tests {
             let workspace_id = UserConfig::identifier()?;
             let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
 
-            workspaces::data_frames::index(&repo, &workspace, &path)?;
+            workspaces::data_frames::index(&repo, &workspace, &path).await?;
             let json_data = json!({"file": "images/test.jpg", "label": "dog", "min_x": 2.0, "min_y": 3.0, "width": 100, "height": 120});
             workspaces::data_frames::rows::add(&repo, &workspace, &path, &json_data)?;
             let new_commit = NewCommitBody {
@@ -1326,7 +1328,7 @@ mod tests {
             // Make sure version file is updated
             let entry = repositories::entries::get_commit_entry(&repo, &commit, &path)?.unwrap();
             let version_store = repo.version_store()?;
-            let version_file = version_store.get_version_path(&entry.hash)?;
+            let version_file = version_store.get_version_path(&entry.hash).await?;
             let extension = entry.path.extension().unwrap().to_str().unwrap();
             let data_frame =
                 df::tabular::read_df_with_extension(version_file, extension, &DFOpts::empty()).await?;

--- a/crates/lib/src/storage.rs
+++ b/crates/lib/src/storage.rs
@@ -4,4 +4,4 @@ pub mod version_store;
 
 pub use local::LocalVersionStore;
 pub use s3::S3VersionStore;
-pub use version_store::*;
+pub use version_store::{LocalFilePath, StorageConfig, VersionStore, create_version_store};

--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::constants::{VERSION_CHUNK_FILE_NAME, VERSION_CHUNKS_DIR, VERSION_FILE_NAME};
 use crate::error::OxenError;
-use crate::storage::version_store::VersionStore;
+use crate::storage::version_store::{LocalFilePath, VersionStore};
 use crate::util::{self, concurrency, hasher};
 use crate::view::versions::CleanCorruptedVersionsResult;
 
@@ -190,8 +190,8 @@ impl VersionStore for LocalVersionStore {
         }
     }
 
-    fn get_version_path(&self, hash: &str) -> Result<PathBuf, OxenError> {
-        Ok(self.version_path(hash))
+    async fn get_version_path(&self, hash: &str) -> Result<LocalFilePath, OxenError> {
+        Ok(LocalFilePath::Stable(self.version_path(hash)))
     }
 
     // TODO: (CleanCut) Do we need to make sure the destination path is outside the version store?

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -1,4 +1,5 @@
 use crate::error::OxenError;
+use async_tempfile::TempFile;
 use async_trait::async_trait;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::error::SdkError;
@@ -10,10 +11,11 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use tokio::io::AsyncWriteExt;
 use tokio::sync::OnceCell;
 use tokio_stream::Stream;
 
-use super::version_store::VersionStore;
+use super::version_store::{LocalFilePath, VersionStore};
 use crate::constants::VERSION_FILE_NAME;
 use crate::view::versions::CleanCorruptedVersionsResult;
 
@@ -334,16 +336,30 @@ impl VersionStore for S3VersionStore {
         }
     }
 
-    fn get_version_path(&self, hash: &str) -> Result<PathBuf, OxenError> {
-        let key = self.generate_key(hash);
-        Ok(PathBuf::from(key))
+    async fn get_version_path(&self, hash: &str) -> Result<LocalFilePath, OxenError> {
+        // TODO: This needs to be updated to handle large files that won't fit in memory
+        let data = self.get_version(hash).await?;
+        let mut tmp = TempFile::new()
+            .await
+            .map_err(|e| OxenError::basic_str(format!("Failed to create temp file: {e}")))?;
+        tmp.write_all(&data)
+            .await
+            .map_err(|e| OxenError::basic_str(format!("Failed to write temp file: {e}")))?;
+        Ok(LocalFilePath::Temp(tmp))
     }
 
-    async fn copy_version_to_path(&self, _hash: &str, _dest_path: &Path) -> Result<(), OxenError> {
-        // TODO: Implement S3 version copying to path
-        Err(OxenError::basic_str(
-            "S3VersionStore copy_version_to_path not yet implemented",
-        ))
+    async fn copy_version_to_path(&self, hash: &str, dest_path: &Path) -> Result<(), OxenError> {
+        // TODO: This needs to be updated to handle large files that won't fit in memory
+        let data = self.get_version(hash).await?;
+        if let Some(parent) = dest_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| OxenError::basic_str(format!("Failed to create parent dirs: {e}")))?;
+        }
+        tokio::fs::write(dest_path, &data)
+            .await
+            .map_err(|e| OxenError::basic_str(format!("Failed to write file: {e}")))?;
+        Ok(())
     }
 
     async fn store_version_chunk(

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -15,6 +16,63 @@ use crate::opts::StorageOpts;
 use crate::storage::{LocalVersionStore, S3VersionStore};
 use crate::util;
 use crate::view::versions::CleanCorruptedVersionsResult;
+
+/// A local filesystem path to a version file.
+///
+/// The path is guaranteed to be readable on the local filesystem, but callers must NOT assume it is
+/// stable: non-local backends (e.g. S3) materialize the file into a temporary location that is
+/// cleaned up when this value is dropped.
+///
+/// - Implements `Deref<Target = Path>` so that `&LocalFilePath` can be passed directly to any
+///   function that accepts `&Path`.
+/// - Implements `AsRef<Path>` so that `LocalFilePath` can be passed directly to any function that
+///   accepts `impl AsRef<Path>`.
+///
+/// TODO: See how many of our own functions can be updated to accept LocalFilePath directly. Perhaps we can remove the need for `AsRef<Path>`.
+pub enum LocalFilePath {
+    /// A stable path (e.g. from `LocalVersionStore`) that outlives this value.
+    Stable(PathBuf),
+    /// A temporary file that is deleted when this value is dropped.
+    Temp(async_tempfile::TempFile),
+}
+
+impl Deref for LocalFilePath {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        match self {
+            LocalFilePath::Stable(p) => p.as_path(),
+            LocalFilePath::Temp(t) => t.file_path(),
+        }
+    }
+}
+
+impl AsRef<Path> for LocalFilePath {
+    fn as_ref(&self) -> &Path {
+        self.deref()
+    }
+}
+
+impl std::fmt::Debug for LocalFilePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LocalFilePath::Stable(p) => write!(f, "Stable({p:?})"),
+            LocalFilePath::Temp(t) => write!(f, "Temp({:?})", t.file_path()),
+        }
+    }
+}
+
+impl std::fmt::Display for LocalFilePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref().display())
+    }
+}
+
+impl LocalFilePath {
+    pub fn to_pathbuf(&self) -> PathBuf {
+        self.deref().to_path_buf()
+    }
+}
 
 /// Configuration for version storage backend
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -179,12 +237,19 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
         derived_filename: &str,
     ) -> Result<bool, OxenError>;
 
-    /// Get the path to a version file (sync operation)
+    /// Get a local filesystem path to a version file.
+    ///
+    /// The returned `LocalFilePath` is guaranteed to be readable on the local
+    /// filesystem. For local backends the path points into the version store
+    /// directly; for remote backends (e.g. S3) the file is downloaded to a
+    /// temporary location that is cleaned up when the `LocalFilePath` is dropped.
+    ///
+    /// **Callers must keep the returned value alive for as long as they use the
+    /// path.**
     ///
     /// # Arguments
-    /// * `hash` - The content hash of the version file to compute the path for
-    // TODO: See if we can make this infallible
-    fn get_version_path(&self, hash: &str) -> Result<PathBuf, OxenError>;
+    /// * `hash` - The content hash of the version file to retrieve
+    async fn get_version_path(&self, hash: &str) -> Result<LocalFilePath, OxenError>;
 
     /// Copy a versioned file from the version store to a destination path on the local filesystem
     ///

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -1669,7 +1669,7 @@ async fn generate_video_thumbnail_version_store(
     }
 
     // Get the video file path from version store
-    let version_path = version_store.get_version_path(video_hash)?;
+    let version_path = version_store.get_version_path(video_hash).await?;
 
     // Determine output dimensions
     // The thumbnails crate maintains aspect ratio, so we use max dimensions
@@ -2031,9 +2031,9 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn version_path() -> Result<(), OxenError> {
-        test::run_empty_local_repo_test(|repo| {
+    #[tokio::test]
+    async fn version_path() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
             let entry = CommitEntry {
                 commit_id: String::from("1234"),
                 path: PathBuf::from("hello_world.txt"),
@@ -2043,9 +2043,9 @@ mod tests {
                 last_modified_nanoseconds: 0,
             };
             let version_store = repo.version_store()?;
-            let path = version_store.get_version_path(&entry.hash)?;
+            let local_path = version_store.get_version_path(&entry.hash).await?;
             let versions_dir = util::fs::oxen_hidden_dir(&repo.path).join(constants::VERSIONS_DIR);
-            let relative_path = util::fs::path_relative_to_dir(path, versions_dir)?;
+            let relative_path = util::fs::path_relative_to_dir(&*local_path, versions_dir)?;
             assert_eq!(
                 relative_path,
                 Path::new(constants::FILES_DIR)
@@ -2056,6 +2056,7 @@ mod tests {
 
             Ok(())
         })
+        .await
     }
 
     #[test]

--- a/crates/server/src/controllers/data_frames.rs
+++ b/crates/server/src/controllers/data_frames.rs
@@ -169,7 +169,7 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
             Ok(workspace) => workspace,
             Err(_e) => repositories::workspaces::get_non_editable_by_commit_id(&repo, &commit.id)?,
         };
-        repositories::workspaces::data_frames::index(&repo, &workspace, &path)?;
+        repositories::workspaces::data_frames::index(&repo, &workspace, &path).await?;
     }
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_updated()))

--- a/crates/server/src/controllers/import.rs
+++ b/crates/server/src/controllers/import.rs
@@ -517,7 +517,9 @@ mod tests {
         let entry =
             repositories::entries::get_file(&repo, &resp.commit, "data/cats_vs_dogs.tsv")?.unwrap();
         let version_store = repo.version_store()?;
-        let version_path = version_store.get_version_path(&entry.hash().to_string())?;
+        let version_path = version_store
+            .get_version_path(&entry.hash().to_string())
+            .await?;
         assert!(version_path.exists());
 
         // cleanup
@@ -579,7 +581,9 @@ mod tests {
         )?
         .unwrap();
         let version_store = repo.version_store()?;
-        let version_path = version_store.get_version_path(&entry.hash().to_string())?;
+        let version_path = version_store
+            .get_version_path(&entry.hash().to_string())
+            .await?;
         assert!(version_path.exists());
 
         // cleanup

--- a/crates/server/src/controllers/workspaces/changes.rs
+++ b/crates/server/src/controllers/workspaces/changes.rs
@@ -121,7 +121,7 @@ pub async fn unstage(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
     };
 
-    unstage_from_workspace(&repo, &workspace, &path)
+    unstage_from_workspace(&repo, &workspace, &path).await
 }
 
 /// Unstage files
@@ -176,7 +176,7 @@ pub async fn unstage_many(
             continue;
         }
 
-        match unstage_from_workspace(&repo, &workspace, &path) {
+        match unstage_from_workspace(&repo, &workspace, &path).await {
             // Note: we can't delete the version file here because it may be
             // referenced elsewhere. In order to cleanup eagerly here we would
             // need the staged DB to track whether the version was newly added
@@ -199,14 +199,14 @@ pub async fn unstage_many(
     }
 }
 
-fn unstage_from_workspace(
+async fn unstage_from_workspace(
     repo: &LocalRepository,
     workspace: &Workspace,
     path: &PathBuf,
 ) -> Result<HttpResponse, OxenHttpError> {
     // This may not be in the commit if it's added, so have to parse tabular-ness from the path.
     if util::fs::is_tabular(path) {
-        repositories::workspaces::data_frames::restore(repo, workspace, path)?;
+        repositories::workspaces::data_frames::restore(repo, workspace, path).await?;
         Ok(HttpResponse::Ok().json(StatusMessage::resource_deleted()))
     } else if repositories::workspaces::files::exists(workspace, path)? {
         repositories::workspaces::files::unstage(workspace, path)?;

--- a/crates/server/src/controllers/workspaces/data_frames.rs
+++ b/crates/server/src/controllers/workspaces/data_frames.rs
@@ -232,7 +232,7 @@ pub async fn get_schema(req: HttpRequest) -> Result<HttpResponse, OxenHttpError>
     let is_indexed = repositories::workspaces::data_frames::is_indexed(&workspace, &file_path)?;
 
     if !is_indexed {
-        repositories::workspaces::data_frames::index(&repo, &workspace, &file_path)?;
+        repositories::workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
     }
 
     let db_path = repositories::workspaces::data_frames::duckdb_path(&workspace, &file_path);
@@ -605,7 +605,7 @@ pub async fn put(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHtt
     let is_indexed = repositories::workspaces::data_frames::is_indexed(&workspace, &file_path)?;
 
     if !is_indexed && to_index {
-        repositories::workspaces::data_frames::index(&repo, &workspace, &file_path)?;
+        repositories::workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
     } else if is_indexed && !to_index {
         repositories::workspaces::data_frames::unindex(&workspace, &file_path)?;
     }
@@ -626,7 +626,7 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
     };
 
-    repositories::workspaces::data_frames::restore(&repo, &workspace, file_path)?;
+    repositories::workspaces::data_frames::restore(&repo, &workspace, file_path).await?;
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_deleted()))
 }
@@ -695,7 +695,7 @@ mod tests {
         let workspace_id = uuid::Uuid::new_v4().to_string();
         let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, false)?;
         let file_path = std::path::Path::new("data/test.csv");
-        repositories::workspaces::data_frames::index(&repo, &workspace, file_path)?;
+        repositories::workspaces::data_frames::index(&repo, &workspace, file_path).await?;
 
         // Request download for the indexed file
         let uri = format!(

--- a/crates/server/src/controllers/workspaces/files.rs
+++ b/crates/server/src/controllers/workspaces/files.rs
@@ -230,7 +230,7 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
     for upload_file in upload_files {
         let file_name = upload_file.path.file_name().unwrap();
         let dst_path = PathBuf::from(&directory).join(file_name);
-        let version_path = version_store.get_version_path(&upload_file.hash)?;
+        let version_path = version_store.get_version_path(&upload_file.hash).await?;
 
         let ret_file = match core::v_latest::workspaces::files::add_version_file(
             &workspace,
@@ -308,7 +308,8 @@ pub async fn add_version_files(
         &workspace,
         &files_with_hash,
         &directory,
-    )?;
+    )
+    .await?;
 
     log::debug!("Staging complete with {:?} err files", err_files.len());
 

--- a/data/test/config/user_config.toml
+++ b/data/test/config/user_config.toml
@@ -1,2 +1,0 @@
-name = "ox"
-email = "ox@oxen.ai"

--- a/data/test/config/user_config.toml
+++ b/data/test/config/user_config.toml
@@ -1,2 +1,2 @@
-name = "Ox"
+name = "ox"
 email = "ox@oxen.ai"


### PR DESCRIPTION
Update `VersionStore::get_version_path` (and its usage) so that it won't break when we begin using that method on the S3 implementation

- Most of the changes in this PR are just reacting to `VersionStore::get_version_path` becoming `async` or from it returning a `LocalFilePath` instead of a `PathBuf`
- The important bits to review are:
  - [‎crates/lib/src/storage/version_store.rs‎](https://github.com/Oxen-AI/Oxen/pull/361/changes#diff-d9543740dd6fc2962deb38882527e8c531511eb2a21e8ede5cc5bb9a2de64592)
    - `LocalFilePath` is a new enum to represent a "path on disk" that also works with ephemeral files, as we plan to use with S3.
    - `VersionStore::get_version_path` becomes `async` and now returns a `LocalFilePath` in its result
  - [‎crates/lib/src/storage/local.rs‎](https://github.com/Oxen-AI/Oxen/pull/361/changes#diff-9ffb46f9c7f9a9b115123d6f8f0343efa45be21e0db25aed9d05367486aa10cd)
    -  Adjusts the `LocalVersionStore::get_version_path` to match the updated trait
  - [‎crates/lib/src/storage/s3.rs‎](https://github.com/Oxen-AI/Oxen/pull/361/changes#diff-42bf069a3479e7a1cc2124330a24a0a75a7cde91c33214cac4adce966b6de902)
    - ⚠️ Don't worry too much about the functionality here. The S3 implementation is already broken/unimplemented and this just begins to add something that _could_ work with small files for `get_version_path` and `copy_version_to_path`. This will be completely overhauled in another PR soon.

Resolves ENG-727
