### PR TITLE
Fix diff for S3, diff output fixes

### DIFF
--- a/crates/cli/src/cmd/diff.rs
+++ b/crates/cli/src/cmd/diff.rs
@@ -19,8 +19,15 @@ pub const NAME: &str = "diff";
 pub const DIFFSEP: &str = "..";
 pub struct DiffCmd;
 
-fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
+fn writeln_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
     match writeln!(output, "{text}") {
+        Ok(_) => Ok(()),
+        Err(_) => Err(OxenError::basic_str("Could not write to pager")),
+    }
+}
+
+fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
+    match write!(output, "{text}") {
         Ok(_) => Ok(()),
         Err(_) => Err(OxenError::basic_str("Could not write to pager")),
     }
@@ -221,23 +228,22 @@ impl DiffCmd {
             match result {
                 DiffResult::Tabular(diff) => {
                     // println!("{:?}", ct.summary);
-                    write_to_pager(
+                    writeln_to_pager(
                         &mut p,
                         &format!(
-                            "--- from file: {}\n+++ to file: {}\n",
+                            "--- from file: {}\n+++ to file: {}",
                             diff.filename1.as_ref().unwrap_or(&"".to_string()),
                             diff.filename2.as_ref().unwrap_or(&"".to_string())
                         ),
                     )?;
                     DiffCmd::print_column_changes(&mut p, &diff.summary.modifications)?;
                     DiffCmd::print_row_changes(&mut p, &diff.summary.modifications)?;
-                    write_to_pager(&mut p, pretty_print::df_to_str(&diff.contents).as_str())?;
+                    writeln_to_pager(&mut p, pretty_print::df_to_str(&diff.contents).as_str())?;
                 }
                 DiffResult::Text(diff) => {
                     DiffCmd::print_text_diff(&mut p, diff)?;
                 }
             }
-            write_to_pager(&mut p, "\n\n".to_string().as_str())?;
         }
 
         match minus::page_all(p) {
@@ -272,10 +278,10 @@ impl DiffCmd {
         }
 
         for output in outputs {
-            write_to_pager(p, &output)?;
+            writeln_to_pager(p, &output)?;
         }
 
-        write_to_pager(p, "\n".to_string().as_str())?;
+        writeln_to_pager(p, "\n".to_string().as_str())?;
 
         Ok(())
     }
@@ -297,7 +303,7 @@ impl DiffCmd {
         }
 
         for output in outputs {
-            write_to_pager(p, &format!("{output}"))?;
+            writeln_to_pager(p, &format!("{output}"))?;
         }
 
         Ok(())
@@ -311,7 +317,7 @@ impl DiffCmd {
         write_to_pager(
             p,
             &format!(
-                "--- from file: {}\n+++ to file: {}\n",
+                "--- from file: {}\n+++ to file: {}",
                 filename1.unwrap_or(String::from("")),
                 filename2.unwrap_or(String::from("")),
             ),
@@ -319,10 +325,10 @@ impl DiffCmd {
 
         for line in &diff.lines {
             match line.modification {
-                ChangeType::Unchanged => write_to_pager(p, line.text.to_string().as_str())?,
-                ChangeType::Added => write_to_pager(p, &format!("+ {}", line.text.green()))?,
-                ChangeType::Removed => write_to_pager(p, &format!("- {}", line.text.red()))?,
-                ChangeType::Modified => write_to_pager(p, line.text.to_string().as_str())?,
+                ChangeType::Unchanged => write_to_pager(p, &format!("\n{}", line.text))?,
+                ChangeType::Added => write_to_pager(p, &format!("\n+ {}", line.text.green()))?,
+                ChangeType::Removed => write_to_pager(p, &format!("\n- {}", line.text.red()))?,
+                ChangeType::Modified => write_to_pager(p, &format!("\n{}", line.text))?,
             }
         }
         Ok(())

--- a/crates/lib/src/repositories/diffs.rs
+++ b/crates/lib/src/repositories/diffs.rs
@@ -768,20 +768,17 @@ pub async fn diff_text_file_and_node(
     file_path: impl AsRef<Path>,
 ) -> Result<DiffResult, OxenError> {
     let version_store = repo.version_store()?;
-    let (file_node_content, version_path) = if let Some(node) = file_node {
+    let file_node_content = if let Some(node) = file_node {
         let file_hash = node.hash().to_string();
-        let contents = read_version_file_to_string(&version_store, &file_hash).await?;
-        let path = version_store.get_version_path(&file_hash).await?;
-
-        (Some(contents), Some(path.to_pathbuf()))
+        Some(read_version_file_to_string(&version_store, &file_hash).await?)
     } else {
-        (None, None)
+        None
     };
 
     let file_path_content = util::fs::read_file(Some(&file_path))?;
     let result = utf8_diff::diff(
         file_node_content,
-        version_path,
+        Some(file_path.as_ref().to_path_buf()), // The display path for the file node is the same as the locally-changed file
         Some(file_path_content),
         Some(file_path.as_ref().to_path_buf()),
     )?;


### PR DESCRIPTION
#361 changed the behavior of `get_version_path` to potentially download a file from S3. The diff was calling `get_version_path` to use as the display name of the source file...which was not the correct behavior in the first place, if we're mimicking Git. Updated to use the same path as the file that was altered, fixing both problems.

### Before

- Incorrect "from file" filename
- Extra blank line after the header
- Four extra blank lines after the diff
```
tmp $ oxen diff
--- from file: /Users/nathan/ox/tmp/.oxen/versions/files/4f/625f61bba7ce96722d40b9fd102418/data
+++ to file: file1

a file
+ second line




tmp $ 
```

### After

```
tmp $ oxen diff
--- from file: file1
+++ to file: file1
a file
+ second line
tmp $
```

(and the S3 implementation no longer double-downloads)

Resolves ENG-788