### PR TITLE
Ensure oxen-server always gets cleaned up after tests

### DIFF
--- a/bin/test-rust
+++ b/bin/test-rust
@@ -31,7 +31,13 @@ cleanup() {
     if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
         echo "Stopping oxen-server (pid $SERVER_PID)..."
         kill "$SERVER_PID"
+        # Set a background process to force-kill after 20s if server still hasn't exited
+        (sleep 20 && kill -9 "$SERVER_PID" 2>/dev/null) &
+        WATCHDOG=$!
+        # Wait for server to exit
         wait "$SERVER_PID" 2>/dev/null || true
+        # Ensure the watchdog is killed, so it doesn't hang around when the server exits normally
+        kill "$WATCHDOG" 2>/dev/null || true
     fi
     if [ "$KEEP_DATA" = false ]; then
         echo "==> Removing test data..."


### PR DESCRIPTION
I ran into a situation where a normal kill didn't cause oxen-server to stop after tests finished, and it just hanged forever. It was super annoying since I had to look up the PID and `kill -9` it manually.

This sets a background process that will send a `kill -9` after 20 seconds. Normally the server gracefully shuts down in like a second, so this should only get executed if there's something really wrong.