### PR TITLE
Refactor with_staged_db_manager

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -103,7 +103,7 @@ oxen push origin main               # Push to remote
 # Making Changes
 
 - When changing something that is documented in nearby code, or appears in any markdown files in the repository, update the affected documentation.
-- When prompted always do something a certain way in general, add an entry to this section of the CLAUDE.md file.
+- When prompted to always do something a certain way in general, add an entry to this section of the CLAUDE.md file.
 - When calling `get_staged_db_manager`, follow the doc comment on that function: drop the returned `StagedDBManager` as soon as possible (via a block scope or explicit `drop()`) to avoid holding the shared database handle longer than necessary.
 
 # Testing Rules

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,6 +100,12 @@ oxen push origin main               # Push to remote
 - Functions should return `Result<T, OxenError>`
 - Implement proper error propagation through the `?` operator
 
+# Making Changes
+
+- When changing something that is documented in nearby code, or appears in any markdown files in the repository, update the affected documentation.
+- When prompted always do something a certain way in general, add an entry to this section of the CLAUDE.md file.
+- When calling `get_staged_db_manager`, follow the doc comment on that function: drop the returned `StagedDBManager` as soon as possible (via a block scope or explicit `drop()`) to avoid holding the shared database handle longer than necessary.
+
 # Testing Rules
 - Use the test helpers in `crates/lib/src/test.rs` (e.g., `run_empty_local_repo_test`) for unit tests in the lib code.
 - Try to use the minimal helper for the scenario you are testing. E.g., don't use `run_training_data_fully_sync_remote` when `run_one_commit_local_repo_test` is enough.

--- a/crates/lib/src/core/staged.rs
+++ b/crates/lib/src/core/staged.rs
@@ -1,5 +1,5 @@
 pub mod staged_db_manager;
 
+pub use staged_db_manager::get_staged_db_manager;
 pub use staged_db_manager::remove_from_cache;
 pub use staged_db_manager::remove_from_cache_with_children;
-pub use staged_db_manager::with_staged_db_manager;

--- a/crates/lib/src/core/staged/staged_db_manager.rs
+++ b/crates/lib/src/core/staged/staged_db_manager.rs
@@ -62,6 +62,32 @@ pub struct StagedDBManager {
     repository: LocalRepository,
 }
 
+/// Returns a [`StagedDBManager`] to access RocksDB for the given repository.
+///
+/// The manager holds a reference-counted handle to a shared RocksDB instance that is cached in a
+/// global LRU cache. You should **drop the manager as soon as you are done with it** to avoid
+/// holding the underlying database open longer than necessary. Holding it too long can cause
+/// contention with other operations that need write access to the staged DB, and can prevent the
+/// LRU cache from evicting idle database handles.
+///
+/// Easy ways to ensure the manager is dropped promptly:
+///
+/// **Call `drop()` explicitly** when you need the result in the same scope:
+/// ```ignore
+/// let mgr = get_staged_db_manager(repo)?;
+/// let result = mgr.read_from_staged_db(path)?;
+/// drop(mgr);
+/// // ... continue working with result ...
+/// ```
+///
+/// **Use a block scope** so the manager is dropped at the end of the block:
+/// ```ignore
+/// let result = {
+///     let mgr = get_staged_db_manager(repo)?;
+///     mgr.read_from_staged_db(path)?
+/// }; // mgr is dropped here
+/// // ... continue working with result ...
+/// ```
 pub fn get_staged_db_manager(repository: &LocalRepository) -> Result<StagedDBManager, OxenError> {
     let staged_db_dir = util::fs::oxen_hidden_dir(&repository.path).join(STAGED_DIR);
 

--- a/crates/lib/src/core/staged/staged_db_manager.rs
+++ b/crates/lib/src/core/staged/staged_db_manager.rs
@@ -70,6 +70,9 @@ pub struct StagedDBManager {
 /// contention with other operations that need write access to the staged DB, and can prevent the
 /// LRU cache from evicting idle database handles.
 ///
+/// **In async contexts**, ensure the manager is dropped before any `.await` points to avoid
+/// holding the database handle across suspension points.
+///
 /// Easy ways to ensure the manager is dropped promptly:
 ///
 /// **Call `drop()` explicitly** when you need the result in the same scope:

--- a/crates/lib/src/core/staged/staged_db_manager.rs
+++ b/crates/lib/src/core/staged/staged_db_manager.rs
@@ -66,18 +66,19 @@ pub fn get_staged_db_manager(repository: &LocalRepository) -> Result<StagedDBMan
     let staged_db_dir = util::fs::oxen_hidden_dir(&repository.path).join(STAGED_DIR);
 
     // Fast path: read lock
-    {
-        let cache_r = DB_INSTANCES.read();
-        if let Some(db_lock) = cache_r.peek(&staged_db_dir) {
-            return Ok(StagedDBManager {
-                staged_db: db_lock.clone(),
-                repository: repository.clone(),
-            });
-        }
+    let cache_r = DB_INSTANCES.read();
+    if let Some(db_lock) = cache_r.peek(&staged_db_dir) {
+        return Ok(StagedDBManager {
+            staged_db: db_lock.clone(),
+            repository: repository.clone(),
+        });
     }
+    drop(cache_r);
 
-    // Slow path: write lock, double-check
+    // Get a write lock on DB_INSTANCES so we can add the new DB to the cache
     let mut cache_w = DB_INSTANCES.write();
+    // It's possible another thread has already added the DB to the cache while we were waiting for
+    // the write lock, so we check again before creating the DB, just in case.
     if let Some(db_lock) = cache_w.get(&staged_db_dir) {
         return Ok(StagedDBManager {
             staged_db: db_lock.clone(),

--- a/crates/lib/src/core/staged/staged_db_manager.rs
+++ b/crates/lib/src/core/staged/staged_db_manager.rs
@@ -62,59 +62,48 @@ pub struct StagedDBManager {
     repository: LocalRepository,
 }
 
-pub fn with_staged_db_manager<F, T>(
-    repository: &LocalRepository,
-    operation: F,
-) -> Result<T, OxenError>
-where
-    F: FnOnce(&StagedDBManager) -> Result<T, OxenError>,
-{
-    let staged_db = {
-        let staged_db_dir = util::fs::oxen_hidden_dir(&repository.path).join(STAGED_DIR);
+pub fn get_staged_db_manager(repository: &LocalRepository) -> Result<StagedDBManager, OxenError> {
+    let staged_db_dir = util::fs::oxen_hidden_dir(&repository.path).join(STAGED_DIR);
 
-        // 1. If staged db exists in cache, return the existing connection
-        {
-            let cache_r = DB_INSTANCES.read();
-            if let Some(db_lock) = cache_r.peek(&staged_db_dir) {
-                // Read lock guard is dropped here, return the existing connection
-                return operation(&StagedDBManager {
-                    staged_db: db_lock.clone(),
-                    repository: repository.clone(),
-                });
-            }
+    // Fast path: read lock
+    {
+        let cache_r = DB_INSTANCES.read();
+        if let Some(db_lock) = cache_r.peek(&staged_db_dir) {
+            return Ok(StagedDBManager {
+                staged_db: db_lock.clone(),
+                repository: repository.clone(),
+            });
         }
+    }
 
-        // 2. If not exists, create the directory and open the db
-        let mut cache_w = DB_INSTANCES.write();
-        if let Some(db_lock) = cache_w.get(&staged_db_dir) {
-            db_lock.clone()
-        } else {
-            // Cache miss: create directory and open DB
-            if !staged_db_dir.exists() {
-                std::fs::create_dir_all(&staged_db_dir).map_err(|e| {
-                    log::error!("Failed to create staged db directory: {e}");
-                    OxenError::basic_str(format!("Failed to create staged db directory: {e}"))
-                })?;
-            }
-            let opts = db::key_val::opts::default();
-            let db = DB::open(&opts, dunce::simplified(&staged_db_dir)).map_err(|e| {
-                log::error!("Failed to open staged db: {e}");
-                OxenError::basic_str(format!("Failed to open staged db: {e}"))
-            })?;
-            // Wrap the DB in an RwLock and store it in the cache
-            let db_lock = Arc::new(RwLock::new(db));
-            cache_w.put(staged_db_dir.clone(), db_lock.clone());
-            db_lock
-        }
-    };
+    // Slow path: write lock, double-check
+    let mut cache_w = DB_INSTANCES.write();
+    if let Some(db_lock) = cache_w.get(&staged_db_dir) {
+        return Ok(StagedDBManager {
+            staged_db: db_lock.clone(),
+            repository: repository.clone(),
+        });
+    }
 
-    let manager = StagedDBManager {
-        staged_db,
+    // Cache miss: create directory and open DB
+    if !staged_db_dir.exists() {
+        std::fs::create_dir_all(&staged_db_dir).map_err(|e| {
+            log::error!("Failed to create staged db directory: {e}");
+            OxenError::basic_str(format!("Failed to create staged db directory: {e}"))
+        })?;
+    }
+    let opts = db::key_val::opts::default();
+    let db = DB::open(&opts, dunce::simplified(&staged_db_dir)).map_err(|e| {
+        log::error!("Failed to open staged db: {e}");
+        OxenError::basic_str(format!("Failed to open staged db: {e}"))
+    })?;
+    let db_lock = Arc::new(RwLock::new(db));
+    cache_w.put(staged_db_dir.clone(), db_lock.clone());
+
+    Ok(StagedDBManager {
+        staged_db: db_lock,
         repository: repository.clone(),
-    };
-
-    // Execute the operation with our StagedDBManager instance
-    operation(&manager)
+    })
 }
 
 /// Normalizes a path to use forward slashes for use as a DB key.

--- a/crates/lib/src/core/v_latest/add.rs
+++ b/crates/lib/src/core/v_latest/add.rs
@@ -19,7 +19,7 @@ use crate::constants::{OXEN_HIDDEN_DIR, STAGED_DIR};
 use crate::core;
 use crate::core::db;
 use crate::core::oxenignore;
-use crate::core::staged::staged_db_manager::{StagedDBManager, with_staged_db_manager};
+use crate::core::staged::staged_db_manager::{StagedDBManager, get_staged_db_manager};
 use crate::model::merkle_tree::node::file_node::FileNodeOpts;
 use crate::model::metadata::generic_metadata::GenericMetadata;
 use crate::model::workspace::Workspace;
@@ -946,16 +946,15 @@ pub fn add_file_node_to_staged_db(
     file_node: &FileNode,
     seen_dirs: &Arc<Mutex<HashSet<PathBuf>>>,
 ) -> Result<(), OxenError> {
-    with_staged_db_manager(repo, |staged_db_manager| {
-        add_file_node_and_parent_dir(
-            file_node,
-            status,
-            relative_path,
-            staged_db_manager,
-            seen_dirs,
-        )?;
-        Ok(())
-    })
+    let staged_db_manager = get_staged_db_manager(repo)?;
+    add_file_node_and_parent_dir(
+        file_node,
+        status,
+        relative_path,
+        &staged_db_manager,
+        seen_dirs,
+    )?;
+    Ok(())
 }
 
 pub fn stage_file_with_hash(

--- a/crates/lib/src/core/v_latest/data_frames.rs
+++ b/crates/lib/src/core/v_latest/data_frames.rs
@@ -1,7 +1,7 @@
 use crate::core::db::data_frames::df_db::with_df_db_manager;
 use crate::core::df::tabular::transform_new;
 use crate::core::df::{sql, tabular};
-use crate::core::staged::with_staged_db_manager;
+use crate::core::staged::get_staged_db_manager;
 use crate::error::OxenError;
 use crate::model::ParsedResource;
 use crate::model::data_frame::{DataFrameSchemaSize, DataFrameSlice, DataFrameSliceSchemas};
@@ -38,34 +38,32 @@ pub async fn get_slice(
     };
 
     let file_node = match workspace {
-        Some(ws) => with_staged_db_manager(staged_repo, |staged_db_manager| {
+        Some(ws) => {
+            let staged_db_manager = get_staged_db_manager(staged_repo)?;
             // Try staged DB first
             if let Some(staged_node) = staged_db_manager.read_from_staged_db(&path)? {
-                let file_node = match staged_node.node.node {
+                match staged_node.node.node {
                     EMerkleTreeNode::File(f) => Ok(f),
                     _ => Err(OxenError::basic_str(
                         "Only single file download is supported",
                     )),
-                }?;
-                return Ok(file_node);
+                }?
+            } else {
+                // Fall back to commit tree using workspace's commit
+                let commit = &ws.commit;
+                repositories::tree::get_file_by_path(base_repo, commit, &path)?
+                    .ok_or(OxenError::path_does_not_exist(path.as_ref()))?
             }
-
-            // Fall back to commit tree using workspace's commit
-            let commit = &ws.commit;
-            let file_node = repositories::tree::get_file_by_path(base_repo, commit, &path)?
-                .ok_or(OxenError::path_does_not_exist(path.as_ref()))?;
-            Ok(file_node)
-        }),
+        }
         None => {
             let commit = resource
                 .commit
                 .as_ref()
                 .ok_or(OxenError::basic_str("Commit not found"))?;
-            let file_node = repositories::tree::get_file_by_path(base_repo, commit, &path)?
-                .ok_or(OxenError::path_does_not_exist(path.as_ref()))?;
-            Ok(file_node)
+            repositories::tree::get_file_by_path(base_repo, commit, &path)?
+                .ok_or(OxenError::path_does_not_exist(path.as_ref()))?
         }
-    }?;
+    };
 
     log::debug!("get_slice file_node {file_node:?}");
 

--- a/crates/lib/src/core/v_latest/data_frames/schemas.rs
+++ b/crates/lib/src/core/v_latest/data_frames/schemas.rs
@@ -16,7 +16,7 @@ use std::str;
 use crate::constants;
 use crate::core::db;
 
-use crate::core::staged::staged_db_manager::with_staged_db_manager;
+use crate::core::staged::staged_db_manager::get_staged_db_manager;
 use crate::core::v_latest::index::CommitMerkleTree;
 use crate::error::OxenError;
 use crate::model::MerkleHash;
@@ -123,18 +123,17 @@ pub fn get_staged_schema_with_staged_db_manager(
     path: impl AsRef<Path>,
 ) -> Result<Option<Schema>, OxenError> {
     let path = util::fs::path_relative_to_dir(path, &repo.path)?;
-    with_staged_db_manager(repo, |staged_db_manager| {
-        match staged_db_manager.read_from_staged_db(&path) {
-            Ok(Some(value)) => {
-                let schema = db_val_to_schema(&value)?;
-                Ok(Some(schema))
-            }
-            _ => {
-                log::debug!("could not get staged schema");
-                Ok(None)
-            }
+    let staged_db_manager = get_staged_db_manager(repo)?;
+    match staged_db_manager.read_from_staged_db(&path) {
+        Ok(Some(value)) => {
+            let schema = db_val_to_schema(&value)?;
+            Ok(Some(schema))
         }
-    })
+        _ => {
+            log::debug!("could not get staged schema");
+            Ok(None)
+        }
+    }
 }
 
 /// Restores the staged schema in workspace df to its original state by comparing the original schema
@@ -148,48 +147,46 @@ pub fn restore_schema(
     after_column: &str,
 ) -> Result<(), OxenError> {
     let path = util::fs::path_relative_to_dir(&path, &repo.path)?;
-    with_staged_db_manager(repo, |staged_db_manager| {
-        let value = staged_db_manager.read_from_staged_db(&path)?;
-        let (mut staged_schema, val) = match value {
-            Some(value) => {
-                let schema = db_val_to_schema(&value)?;
-                (schema, value)
-            }
-            _ => {
-                log::debug!("could not get staged schema");
-                return Ok(());
-            }
-        };
+    let staged_db_manager = get_staged_db_manager(repo)?;
+    let value = staged_db_manager.read_from_staged_db(&path)?;
+    let (mut staged_schema, val) = match value {
+        Some(value) => {
+            let schema = db_val_to_schema(&value)?;
+            (schema, value)
+        }
+        _ => {
+            log::debug!("could not get staged schema");
+            return Ok(());
+        }
+    };
 
-        for field in &mut staged_schema.fields {
-            if field.name == after_column {
-                field.name = before_column.to_string();
+    for field in &mut staged_schema.fields {
+        if field.name == after_column {
+            field.name = before_column.to_string();
 
-                for og_field in &og_schema.fields {
-                    if og_field.name == before_column {
-                        field.metadata = og_field.metadata.clone();
-                    }
+            for og_field in &og_schema.fields {
+                if og_field.name == before_column {
+                    field.metadata = og_field.metadata.clone();
                 }
-                break;
             }
+            break;
         }
+    }
 
-        let mut file_node = val.node.file()?;
-        if let Some(GenericMetadata::MetadataTabular(tabular_metadata)) = &file_node.metadata() {
-            file_node.set_metadata(Some(GenericMetadata::MetadataTabular(
-                MetadataTabular::new(
-                    tabular_metadata.tabular.width,
-                    tabular_metadata.tabular.height,
-                    staged_schema,
-                ),
-            )));
-        } else {
-            return Err(OxenError::basic_str("Expected tabular metadata"));
-        }
+    let mut file_node = val.node.file()?;
+    if let Some(GenericMetadata::MetadataTabular(tabular_metadata)) = &file_node.metadata() {
+        file_node.set_metadata(Some(GenericMetadata::MetadataTabular(
+            MetadataTabular::new(
+                tabular_metadata.tabular.width,
+                tabular_metadata.tabular.height,
+                staged_schema,
+            ),
+        )));
+    } else {
+        return Err(OxenError::basic_str("Expected tabular metadata"));
+    }
 
-        staged_db_manager.upsert_file_node(&path, StagedEntryStatus::Modified, &file_node)?;
-        Ok(())
-    })?;
+    staged_db_manager.upsert_file_node(&path, StagedEntryStatus::Modified, &file_node)?;
     Ok(())
 }
 

--- a/crates/lib/src/core/v_latest/rm.rs
+++ b/crates/lib/src/core/v_latest/rm.rs
@@ -15,7 +15,7 @@ use indicatif::ProgressStyle;
 use rocksdb::IteratorMode;
 use tokio::time::Duration;
 
-use crate::core::staged::with_staged_db_manager;
+use crate::core::staged::get_staged_db_manager;
 use crate::core::v_latest::add::CumulativeStats;
 use crate::core::v_latest::add::add_file_node_and_parent_dir;
 use crate::model::merkle_tree::node::EMerkleTreeNode;
@@ -293,20 +293,19 @@ pub fn remove_file_with_db_manager(
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let mut err_files: Vec<ErrorFileInfo> = vec![];
 
-    let _ = with_staged_db_manager(repo, |staged_db_manager| {
+    if let Ok(staged_db_manager) = get_staged_db_manager(repo) {
         let status = StagedEntryStatus::Removed;
-        match add_file_node_and_parent_dir(file_node, status, path, staged_db_manager, seen_dirs) {
-            Ok(_) => Ok(()),
+        match add_file_node_and_parent_dir(file_node, status, path, &staged_db_manager, seen_dirs) {
+            Ok(_) => {}
             Err(e) => {
                 err_files.push(ErrorFileInfo {
                     hash: file_node.hash().to_string(),
                     path: Some(path.to_path_buf()),
                     error: format!("Failed to add file to staged db: {e}"),
                 });
-                Err(e)
             }
         }
-    });
+    }
 
     Ok(err_files)
 }
@@ -322,80 +321,80 @@ pub fn remove_dir_with_db_manager(
     let mut staged_nodes: HashMap<PathBuf, StagedMerkleTreeNode> = HashMap::new();
     // let err_files: Vec<ErrorFileInfo> = vec![];
 
-    with_staged_db_manager(repo, |staged_db_manager| {
-        // Walk the tree, collecting every node under the dir
-        let nodes = root_dir.list_files_and_dirs()?;
-        let parent_path = root_path.parent().unwrap_or(&empty_path);
+    let staged_db_manager = get_staged_db_manager(repo)?;
 
-        for (path, node) in nodes {
-            let path = parent_path.join(path);
-            let corrected_node = match &node.node {
-                EMerkleTreeNode::File(file_node) => {
-                    let mut file_node = file_node.clone();
-                    file_node.set_name(&path.to_string_lossy());
-                    MerkleTreeNode {
-                        hash: node.hash,
-                        node: EMerkleTreeNode::File(file_node.clone()),
-                        parent_id: node.parent_id,
-                        children: node.children.clone(),
-                    }
-                }
+    // Walk the tree, collecting every node under the dir
+    let nodes = root_dir.list_files_and_dirs()?;
+    let parent_path = root_path.parent().unwrap_or(&empty_path);
 
-                EMerkleTreeNode::Directory(dir_node) => {
-                    let mut dir_node = dir_node.clone();
-                    dir_node.set_name(path.to_string_lossy());
-                    MerkleTreeNode {
-                        hash: node.hash,
-                        node: EMerkleTreeNode::Directory(dir_node.clone()),
-                        parent_id: node.parent_id,
-                        children: node.children.clone(),
-                    }
-                }
-                _ => {
-                    return Err(OxenError::basic_str("Error: Unexpected node type"));
-                }
-            };
-
-            let staged_node = StagedMerkleTreeNode {
-                status: StagedEntryStatus::Removed,
-                node: corrected_node,
-            };
-
-            staged_nodes.insert(path, staged_node);
-        }
-
-        log::debug!("staged_nodes: {}", staged_nodes.len());
-
-        // Stage the root dir's parents
-        let mut parent_path = root_path.to_path_buf();
-        while let Some(parent) = parent_path.parent() {
-            parent_path = parent.to_path_buf();
-
-            match staged_db_manager.add_directory(&parent_path, seen_dirs) {
-                Ok(_) => {}
-                Err(e) => {
-                    log::debug!("Error adding parent dirs: {e:?}");
-                    return Err(e);
+    for (path, node) in nodes {
+        let path = parent_path.join(path);
+        let corrected_node = match &node.node {
+            EMerkleTreeNode::File(file_node) => {
+                let mut file_node = file_node.clone();
+                file_node.set_name(&path.to_string_lossy());
+                MerkleTreeNode {
+                    hash: node.hash,
+                    node: EMerkleTreeNode::File(file_node.clone()),
+                    parent_id: node.parent_id,
+                    children: node.children.clone(),
                 }
             }
 
-            if parent_path == Path::new("") {
-                break;
+            EMerkleTreeNode::Directory(dir_node) => {
+                let mut dir_node = dir_node.clone();
+                dir_node.set_name(path.to_string_lossy());
+                MerkleTreeNode {
+                    hash: node.hash,
+                    node: EMerkleTreeNode::Directory(dir_node.clone()),
+                    parent_id: node.parent_id,
+                    children: node.children.clone(),
+                }
             }
-        }
+            _ => {
+                return Err(OxenError::basic_str("Error: Unexpected node type"));
+            }
+        };
 
-        // Write all files to staged db
-        match staged_db_manager.upsert_staged_nodes(&staged_nodes) {
-            Ok(_) => {
-                log::debug!("Successfully upserted staged nodes");
-                Ok(())
-            }
+        let staged_node = StagedMerkleTreeNode {
+            status: StagedEntryStatus::Removed,
+            node: corrected_node,
+        };
+
+        staged_nodes.insert(path, staged_node);
+    }
+
+    log::debug!("staged_nodes: {}", staged_nodes.len());
+
+    // Stage the root dir's parents
+    let mut parent_path = root_path.to_path_buf();
+    while let Some(parent) = parent_path.parent() {
+        parent_path = parent.to_path_buf();
+
+        match staged_db_manager.add_directory(&parent_path, seen_dirs) {
+            Ok(_) => {}
             Err(e) => {
-                log::error!("Failed to upsert staged nodes due to error: {e:?}");
-                Err(e)
+                log::debug!("Error adding parent dirs: {e:?}");
+                return Err(e);
             }
         }
-    })
+
+        if parent_path == Path::new("") {
+            break;
+        }
+    }
+
+    // Write all files to staged db
+    match staged_db_manager.upsert_staged_nodes(&staged_nodes) {
+        Ok(_) => {
+            log::debug!("Successfully upserted staged nodes");
+            Ok(())
+        }
+        Err(e) => {
+            log::error!("Failed to upsert staged nodes due to error: {e:?}");
+            Err(e)
+        }
+    }
 }
 
 // Stages the file_node as removed, and all its parents in the repo as modified

--- a/crates/lib/src/core/v_latest/status.rs
+++ b/crates/lib/src/core/v_latest/status.rs
@@ -1,7 +1,7 @@
 use crate::constants::STAGED_DIR;
 use crate::core::db;
 use crate::core::oxenignore;
-use crate::core::staged::staged_db_manager::with_staged_db_manager;
+use crate::core::staged::staged_db_manager::get_staged_db_manager;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::FileNode;
 use crate::model::merkle_tree::node::StagedMerkleTreeNode;
@@ -367,9 +367,8 @@ pub fn read_staged_entries_below_path_with_staged_db_manager(
     start_path: impl AsRef<Path>,
     read_progress: &ProgressBar,
 ) -> Result<(HashMap<PathBuf, Vec<StagedMerkleTreeNode>>, usize), OxenError> {
-    with_staged_db_manager(repo, |staged_db_manager| {
-        staged_db_manager.read_staged_entries_below_path(start_path, read_progress)
-    })
+    let staged_db_manager = get_staged_db_manager(repo)?;
+    staged_db_manager.read_staged_entries_below_path(start_path, read_progress)
 }
 
 pub fn read_staged_entries_below_path(

--- a/crates/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -3,7 +3,7 @@ use duckdb::Connection;
 use crate::constants::{DIFF_HASH_COL, DIFF_STATUS_COL, EXCLUDE_OXEN_COLS, TABLE_NAME};
 use crate::core::db::data_frames::df_db;
 use crate::core::db::data_frames::df_db::with_df_db_manager;
-use crate::core::staged::with_staged_db_manager;
+use crate::core::staged::get_staged_db_manager;
 use crate::core::v_latest::workspaces::files::{add, track_modified_data_frame};
 use parking_lot::Mutex;
 use sql_query_builder::Delete;
@@ -203,10 +203,8 @@ pub async fn rename(
     util::fs::remove_dir_all(og_db_path_parent)?;
 
     // Use staged_db_manager
-    let mut staged_entry = with_staged_db_manager(workspace_repo, |staged_db_manager| {
-        // Try to read existing staged entry
-        staged_db_manager.read_from_staged_db(path)
-    })?;
+    let staged_db_manager = get_staged_db_manager(workspace_repo)?;
+    let mut staged_entry = staged_db_manager.read_from_staged_db(path)?;
 
     if staged_entry.is_none() {
         let workspace_file_path = workspace.workspace_repo.path.join(new_path);
@@ -240,9 +238,7 @@ pub async fn rename(
         }
 
         // Read the staged entry again after adding
-        staged_entry = with_staged_db_manager(workspace_repo, |staged_db_manager| {
-            staged_db_manager.read_from_staged_db(new_path)
-        })?;
+        staged_entry = get_staged_db_manager(workspace_repo)?.read_from_staged_db(new_path)?;
         log::debug!("rename: staged_entry after add: {staged_entry:?}");
     }
 
@@ -261,26 +257,23 @@ pub async fn rename(
     // Get the file node from the staged entry
     let file_node = new_staged_entry.node.file()?;
 
-    with_staged_db_manager(workspace_repo, |staged_db_manager| {
-        // Add the file node at the new path using staged_db_manager
-        staged_db_manager.upsert_file_node(new_path, new_staged_entry.status, &file_node)?;
+    let staged_db_manager = get_staged_db_manager(workspace_repo)?;
+    // Add the file node at the new path using staged_db_manager
+    staged_db_manager.upsert_file_node(new_path, new_staged_entry.status, &file_node)?;
 
-        // Delete the old path entry
-        staged_db_manager.delete_entry(path)?;
+    // Delete the old path entry
+    staged_db_manager.delete_entry(path)?;
 
-        // Add parent directories for the new path
-        if let Some(parents) = new_path.parent() {
-            let seen_dirs = Arc::new(Mutex::new(HashSet::new()));
-            for dir in parents.ancestors() {
-                staged_db_manager.add_directory(dir, &seen_dirs)?;
-                if dir == Path::new("") {
-                    break;
-                }
+    // Add parent directories for the new path
+    if let Some(parents) = new_path.parent() {
+        let seen_dirs = Arc::new(Mutex::new(HashSet::new()));
+        for dir in parents.ancestors() {
+            staged_db_manager.add_directory(dir, &seen_dirs)?;
+            if dir == Path::new("") {
+                break;
             }
         }
-
-        Ok(())
-    })?;
+    }
 
     let relative_path = util::fs::path_relative_to_dir(new_path, &workspace_repo.path)?;
     Ok(relative_path)

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/columns.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/columns.rs
@@ -5,7 +5,7 @@ use crate::constants::TABLE_NAME;
 use crate::core::db;
 use crate::core::db::data_frames::workspace_df_db::schema_without_oxen_cols;
 use crate::core::db::data_frames::{column_changes_db, columns, df_db::with_df_db_manager};
-use crate::core::staged::staged_db_manager::with_staged_db_manager;
+use crate::core::staged::staged_db_manager::get_staged_db_manager;
 use crate::core::v_latest::workspaces;
 use crate::error::OxenError;
 use crate::model::data_frame::schema::Field;
@@ -346,7 +346,8 @@ pub fn add_column_metadata(
     column: impl AsRef<str>,
     metadata: &serde_json::Value,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
-    with_staged_db_manager(&workspace.workspace_repo, |staged_db_manager| {
+    let staged_db_manager = get_staged_db_manager(&workspace.workspace_repo)?;
+    {
         let path = file_path.as_ref();
         let path = util::fs::path_relative_to_dir(path, &workspace.workspace_repo.path)?;
         let column = column.as_ref();
@@ -451,7 +452,7 @@ pub fn add_column_metadata(
         staged_db_manager.upsert_staged_node(&path, &staged_entry, None)?;
 
         Ok(results)
-    })
+    }
 }
 
 pub fn update_column_names_in_metadata(

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -14,7 +14,7 @@ use crate::opts::DFOpts;
 use crate::core::db::data_frames::df_db::with_df_db_manager;
 use crate::core::db::data_frames::rows;
 use crate::core::df::tabular;
-use crate::core::staged::staged_db_manager::with_staged_db_manager;
+use crate::core::staged::staged_db_manager::get_staged_db_manager;
 use crate::core::v_latest::workspaces;
 use crate::error::OxenError;
 use crate::model::data_frame::update_result::UpdateResult;
@@ -75,23 +75,21 @@ pub async fn restore(
         log::debug!("no changes, deleting file from staged db");
         // Restored to original state == delete file from staged db
         // TODO: Implement this
-        with_staged_db_manager(&workspace.workspace_repo, |manager| {
+        let manager = get_staged_db_manager(&workspace.workspace_repo)?;
+        manager.remove_staged_recursively(
+            &workspace.workspace_repo,
+            &HashSet::from([path.as_ref().to_path_buf()]),
+        )?;
+
+        // loop over parents and delete from staged db
+        let mut current_path = path.as_ref().to_path_buf();
+        while let Some(parent) = current_path.parent() {
             manager.remove_staged_recursively(
                 &workspace.workspace_repo,
-                &HashSet::from([path.as_ref().to_path_buf()]),
+                &HashSet::from([parent.to_path_buf()]),
             )?;
-
-            // loop over parents and delete from staged db
-            let mut current_path = path.as_ref().to_path_buf();
-            while let Some(parent) = current_path.parent() {
-                manager.remove_staged_recursively(
-                    &workspace.workspace_repo,
-                    &HashSet::from([parent.to_path_buf()]),
-                )?;
-                current_path = parent.to_path_buf();
-            }
-            Ok(())
-        })?;
+            current_path = parent.to_path_buf();
+        }
     }
 
     Ok(restored_row)
@@ -130,13 +128,10 @@ pub fn delete(
         if !diff.has_changes() {
             log::debug!("no changes, deleting file from staged db {path:?}");
             // Restored to original state == delete file from staged db
-            with_staged_db_manager(&workspace.workspace_repo, |manager| {
-                manager.remove_staged_recursively(
-                    &workspace.workspace_repo,
-                    &HashSet::from([path.to_path_buf()]),
-                )?;
-                Ok(())
-            })?;
+            get_staged_db_manager(&workspace.workspace_repo)?.remove_staged_recursively(
+                &workspace.workspace_repo,
+                &HashSet::from([path.to_path_buf()]),
+            )?;
         } else {
             log::debug!("there are still changes, not deleting file from staged db");
             log::debug!("diff: {diff:?}");
@@ -184,13 +179,10 @@ pub fn update(
     log::debug!("update() diff: {diff:?}");
     if let DiffResult::Tabular(diff) = diff {
         if !diff.has_changes() {
-            with_staged_db_manager(&workspace.workspace_repo, |manager| {
-                manager.remove_staged_recursively(
-                    &workspace.workspace_repo,
-                    &HashSet::from([path.to_path_buf()]),
-                )?;
-                Ok(())
-            })?;
+            get_staged_db_manager(&workspace.workspace_repo)?.remove_staged_recursively(
+                &workspace.workspace_repo,
+                &HashSet::from([path.to_path_buf()]),
+            )?;
         } else {
             workspaces::files::track_modified_data_frame(workspace, path)?;
         }

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/schemas.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/schemas.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::core::staged::with_staged_db_manager;
+use crate::core::staged::get_staged_db_manager;
 use crate::error::OxenError;
 use crate::model::Schema;
 use crate::model::StagedEntryStatus;
@@ -43,37 +43,35 @@ pub fn update_schema(
         }
     }
 
-    with_staged_db_manager(&workspace.workspace_repo, |staged_db_manager| {
-        let data = staged_db_manager.read_from_staged_db(&path)?;
+    let staged_db_manager = get_staged_db_manager(&workspace.workspace_repo)?;
+    let data = staged_db_manager.read_from_staged_db(&path)?;
 
-        let mut file_node: FileNode;
+    let mut file_node: FileNode;
 
-        if let Some(data) = data {
-            file_node = data.node.file()?;
-        } else {
-            file_node = repositories::tree::get_file_by_path(
-                &workspace.base_repo,
-                &workspace.commit,
-                path.as_ref(),
-            )?
-            .ok_or(OxenError::basic_str("File not found"))?;
-        }
+    if let Some(data) = data {
+        file_node = data.node.file()?;
+    } else {
+        file_node = repositories::tree::get_file_by_path(
+            &workspace.base_repo,
+            &workspace.commit,
+            path.as_ref(),
+        )?
+        .ok_or(OxenError::basic_str("File not found"))?;
+    }
 
-        if let Some(GenericMetadata::MetadataTabular(tabular_metadata)) = &file_node.metadata() {
-            file_node.set_metadata(Some(GenericMetadata::MetadataTabular(
-                MetadataTabular::new(
-                    tabular_metadata.tabular.width,
-                    tabular_metadata.tabular.height,
-                    schema,
-                ),
-            )));
-        } else {
-            return Err(OxenError::basic_str("Expected tabular metadata"));
-        }
+    if let Some(GenericMetadata::MetadataTabular(tabular_metadata)) = &file_node.metadata() {
+        file_node.set_metadata(Some(GenericMetadata::MetadataTabular(
+            MetadataTabular::new(
+                tabular_metadata.tabular.width,
+                tabular_metadata.tabular.height,
+                schema,
+            ),
+        )));
+    } else {
+        return Err(OxenError::basic_str("Expected tabular metadata"));
+    }
 
-        staged_db_manager.upsert_file_node(path, StagedEntryStatus::Modified, &file_node)?;
-        Ok(())
-    })?;
+    staged_db_manager.upsert_file_node(path, StagedEntryStatus::Modified, &file_node)?;
 
     Ok(())
 }

--- a/crates/lib/src/core/v_latest/workspaces/files.rs
+++ b/crates/lib/src/core/v_latest/workspaces/files.rs
@@ -14,7 +14,7 @@ use url::Url;
 use zip::ZipArchive;
 
 use crate::core;
-use crate::core::staged::staged_db_manager::with_staged_db_manager;
+use crate::core::staged::staged_db_manager::get_staged_db_manager;
 use crate::core::v_latest::add::{
     add_file_node_to_staged_db, get_file_node, process_add_file_with_staged_db_manager,
     stage_file_with_hash,
@@ -78,16 +78,15 @@ pub fn add_version_file(
     // let workspace_repo = &workspace.workspace_repo;
     // let seen_dirs = Arc::new(Mutex::new(HashSet::new()));
 
-    with_staged_db_manager(&workspace.workspace_repo, |staged_db_manager| {
-        stage_file_with_hash(
-            workspace,
-            version_path.as_ref(),
-            dst_path,
-            file_hash,
-            staged_db_manager,
-            &Arc::new(Mutex::new(HashSet::new())),
-        )
-    })?;
+    let staged_db_manager = get_staged_db_manager(&workspace.workspace_repo)?;
+    stage_file_with_hash(
+        workspace,
+        version_path.as_ref(),
+        dst_path,
+        file_hash,
+        &staged_db_manager,
+        &Arc::new(Mutex::new(HashSet::new())),
+    )?;
 
     Ok(dst_path.to_path_buf())
 }
@@ -111,39 +110,38 @@ pub async fn add_version_files(
     }
 
     let mut err_files: Vec<ErrorFileInfo> = vec![];
-    with_staged_db_manager(workspace_repo, |staged_db_manager| {
-        for (item, version_path) in files_with_hash.iter().zip(version_paths.iter()) {
-            let target_path = PathBuf::from(directory).join(&item.path);
+    let staged_db_manager = get_staged_db_manager(workspace_repo)?;
+    for (item, version_path) in files_with_hash.iter().zip(version_paths.iter()) {
+        let target_path = PathBuf::from(directory).join(&item.path);
 
-            match stage_file_with_hash(
-                workspace,
-                version_path,
-                &target_path,
-                &item.hash,
-                staged_db_manager,
-                &seen_dirs,
-            ) {
-                Ok(_) => {
-                    // Add parents to staged db
-                    // let parent_dirs = item.parents;
-                }
-                Err(e) => {
-                    log::error!("error with adding file: {e:?}");
-                    err_files.push(ErrorFileInfo {
-                        hash: item.hash.clone(),
-                        path: Some(item.path.clone()),
-                        error: format!("Failed to add file to staged db: {e}"),
-                    });
-                    continue;
-                }
+        match stage_file_with_hash(
+            workspace,
+            version_path,
+            &target_path,
+            &item.hash,
+            &staged_db_manager,
+            &seen_dirs,
+        ) {
+            Ok(_) => {
+                // Add parents to staged db
+                // let parent_dirs = item.parents;
+            }
+            Err(e) => {
+                log::error!("error with adding file: {e:?}");
+                err_files.push(ErrorFileInfo {
+                    hash: item.hash.clone(),
+                    path: Some(item.path.clone()),
+                    error: format!("Failed to add file to staged db: {e}"),
+                });
+                continue;
             }
         }
-        log::debug!(
-            "add_version_files complete with {:?} err_files",
-            err_files.len()
-        );
-        Ok(err_files)
-    })
+    }
+    log::debug!(
+        "add_version_files complete with {:?} err_files",
+        err_files.len()
+    );
+    Ok(err_files)
 }
 
 pub fn track_modified_data_frame(
@@ -185,17 +183,13 @@ pub async fn remove_files_from_staged_db(
 pub fn unstage(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), OxenError> {
     let workspace_repo = &workspace.workspace_repo;
     let path = util::fs::path_relative_to_dir(path.as_ref(), &workspace_repo.path)?;
-    with_staged_db_manager(workspace_repo, |staged_db_manager| {
-        staged_db_manager.delete_entry(&path)
-    })
+    get_staged_db_manager(workspace_repo)?.delete_entry(&path)
 }
 
 pub fn exists(workspace: &Workspace, path: impl AsRef<Path>) -> Result<bool, OxenError> {
     let workspace_repo = &workspace.workspace_repo;
     let path = util::fs::path_relative_to_dir(path.as_ref(), &workspace_repo.path)?;
-    with_staged_db_manager(workspace_repo, |staged_db_manager| {
-        staged_db_manager.exists(&path)
-    })
+    get_staged_db_manager(workspace_repo)?.exists(&path)
 }
 
 /// SSRF protection: checks whether an IP is non-globally-routable. Covers private,
@@ -971,9 +965,7 @@ pub fn mv(
     let workspace_repo = &workspace.workspace_repo;
 
     // First, try to read existing staged entry for the source path
-    let staged_entry = with_staged_db_manager(workspace_repo, |staged_db_manager| {
-        staged_db_manager.read_from_staged_db(path)
-    })?;
+    let staged_entry = get_staged_db_manager(workspace_repo)?.read_from_staged_db(path)?;
 
     // Get the file node - either from staged_db or from the base repo
     let file_node = if let Some(entry) = staged_entry {
@@ -1004,64 +996,58 @@ pub fn mv(
 
     let seen_dirs = Arc::new(Mutex::new(HashSet::new()));
 
-    with_staged_db_manager(workspace_repo, |staged_db_manager| {
-        if staged_db_manager.read_from_staged_db(new_path)?.is_some() {
-            return Err(OxenError::basic_str(format!(
-                "Destination already staged: {new_path:?}"
-            )));
-        }
-        // Add the file node at the new path
-        staged_db_manager.upsert_file_node(new_path, new_status, &new_file_node)?;
+    let staged_db_manager = get_staged_db_manager(workspace_repo)?;
+    if staged_db_manager.read_from_staged_db(new_path)?.is_some() {
+        return Err(OxenError::basic_str(format!(
+            "Destination already staged: {new_path:?}"
+        )));
+    }
+    // Add the file node at the new path
+    staged_db_manager.upsert_file_node(new_path, new_status, &new_file_node)?;
 
-        // Only handle removal if source and destination are different
-        if !is_same_path {
-            // Check if the source file exists in the base repo (needs to be staged for removal)
-            let source_exists_in_base = repositories::tree::get_file_by_path(
-                &workspace.base_repo,
-                &workspace.commit,
+    // Only handle removal if source and destination are different
+    if !is_same_path {
+        // Check if the source file exists in the base repo (needs to be staged for removal)
+        let source_exists_in_base =
+            repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
+                .is_some();
+
+        if source_exists_in_base {
+            // Create a file node for the removed entry with the full original path as name
+            let mut removed_file_node = file_node.clone();
+            removed_file_node.set_name(path.to_str().unwrap());
+
+            // Stage the original path as removed
+            staged_db_manager.upsert_file_node(
                 path,
-            )?
-            .is_some();
+                StagedEntryStatus::Removed,
+                &removed_file_node,
+            )?;
 
-            if source_exists_in_base {
-                // Create a file node for the removed entry with the full original path as name
-                let mut removed_file_node = file_node.clone();
-                removed_file_node.set_name(path.to_str().unwrap());
-
-                // Stage the original path as removed
-                staged_db_manager.upsert_file_node(
-                    path,
-                    StagedEntryStatus::Removed,
-                    &removed_file_node,
-                )?;
-
-                // Add parent directories for the removed path
-                if let Some(parents) = path.parent() {
-                    for dir in parents.ancestors() {
-                        staged_db_manager.add_directory(dir, &seen_dirs)?;
-                        if dir == Path::new("") {
-                            break;
-                        }
+            // Add parent directories for the removed path
+            if let Some(parents) = path.parent() {
+                for dir in parents.ancestors() {
+                    staged_db_manager.add_directory(dir, &seen_dirs)?;
+                    if dir == Path::new("") {
+                        break;
                     }
                 }
-            } else {
-                // Just delete the staged entry if file wasn't in base repo
-                staged_db_manager.delete_entry(path)?;
+            }
+        } else {
+            // Just delete the staged entry if file wasn't in base repo
+            staged_db_manager.delete_entry(path)?;
+        }
+    }
+
+    // Add parent directories for the new path
+    if let Some(parents) = new_path.parent() {
+        for dir in parents.ancestors() {
+            staged_db_manager.add_directory(dir, &seen_dirs)?;
+            if dir == Path::new("") {
+                break;
             }
         }
-
-        // Add parent directories for the new path
-        if let Some(parents) = new_path.parent() {
-            for dir in parents.ancestors() {
-                staged_db_manager.add_directory(dir, &seen_dirs)?;
-                if dir == Path::new("") {
-                    break;
-                }
-            }
-        }
-
-        Ok(())
-    })?;
+    }
 
     let relative_path = util::fs::path_relative_to_dir(new_path, &workspace_repo.path)?;
     Ok(relative_path)

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -1,7 +1,7 @@
 use crate::config::RepositoryConfig;
 use crate::constants::{OXEN_HIDDEN_DIR, REPO_CONFIG_FILENAME};
 use crate::core;
-use crate::core::staged::staged_db_manager::with_staged_db_manager;
+use crate::core::staged::staged_db_manager::get_staged_db_manager;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::entry::metadata_entry::{WorkspaceChanges, WorkspaceMetadataEntry};
@@ -424,10 +424,8 @@ pub fn populate_entries_with_workspace_data(
     }
     for (file_path, status) in additions_map.iter() {
         if *status == StagedEntryStatus::Added {
-            let staged_node =
-                with_staged_db_manager(&workspace.workspace_repo, |staged_db_manager| {
-                    staged_db_manager.read_from_staged_db(file_path)
-                })?
+            let staged_node = get_staged_db_manager(&workspace.workspace_repo)?
+                .read_from_staged_db(file_path)?
                 .expect("Staged node found in status not present in staged db");
 
             let metadata = match staged_node.node.node {
@@ -489,10 +487,9 @@ pub fn get_added_entry(
             ));
         }
 
-        let staged_node = with_staged_db_manager(&workspace.workspace_repo, |staged_db_manager| {
-            staged_db_manager.read_from_staged_db(file_path)
-        })?
-        .expect("Staged node found in status not present in staged db");
+        let staged_node = get_staged_db_manager(&workspace.workspace_repo)?
+            .read_from_staged_db(file_path)?
+            .expect("Staged node found in status not present in staged db");
 
         let metadata = match staged_node.node.node {
             EMerkleTreeNode::File(file_node) => {

--- a/crates/server/src/controllers/file.rs
+++ b/crates/server/src/controllers/file.rs
@@ -8,7 +8,7 @@ use actix_multipart::{Field, MultipartError};
 use actix_web::{HttpRequest, HttpResponse, web};
 use futures_util::TryStreamExt as _;
 use futures_util::future::LocalBoxFuture;
-use liboxen::core::staged::with_staged_db_manager;
+use liboxen::core::staged::get_staged_db_manager;
 use liboxen::error::OxenError;
 use liboxen::model::Commit;
 use liboxen::model::commit::NewCommitBody;
@@ -150,31 +150,29 @@ pub async fn get(
     };
 
     let entry = match workspace {
-        Some(ws) => with_staged_db_manager(staged_repo, |staged_db_manager| {
+        Some(ws) => {
+            let staged_db_manager = get_staged_db_manager(staged_repo)?;
             // Try staged DB first
             if let Some(staged_node) = staged_db_manager.read_from_staged_db(&path)? {
-                let file_node = match staged_node.node.node {
+                match staged_node.node.node {
                     EMerkleTreeNode::File(f) => Ok(f),
                     _ => Err(OxenError::basic_str(
                         "Only single file download is supported",
                     )),
-                }?;
-                return Ok(file_node);
+                }?
+            } else {
+                // Fall back to commit tree using workspace's commit
+                let commit = &ws.commit;
+                repositories::tree::get_file_by_path(base_repo, commit, &path)?
+                    .ok_or(OxenError::path_does_not_exist(path.clone()))?
             }
-
-            // Fall back to commit tree using workspace's commit
-            let commit = &ws.commit;
-            let file_node = repositories::tree::get_file_by_path(base_repo, commit, &path)?
-                .ok_or(OxenError::path_does_not_exist(path.clone()))?;
-            Ok(file_node)
-        }),
+        }
         None => {
             let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
-            let file_node = repositories::tree::get_file_by_path(base_repo, &commit, &path)?
-                .ok_or(OxenError::path_does_not_exist(path.clone()))?;
-            Ok(file_node)
+            repositories::tree::get_file_by_path(base_repo, &commit, &path)?
+                .ok_or(OxenError::path_does_not_exist(path.clone()))?
         }
-    }?;
+    };
 
     let file_hash = entry.hash();
     let hash_str = file_hash.to_string();

--- a/crates/server/src/controllers/workspaces/changes.rs
+++ b/crates/server/src/controllers/workspaces/changes.rs
@@ -3,7 +3,7 @@ use crate::helpers::get_repo;
 use crate::params::{PageNumQuery, app_data, path_param};
 
 use liboxen::constants;
-use liboxen::core::staged::with_staged_db_manager;
+use liboxen::core::staged::get_staged_db_manager;
 use liboxen::model::LocalRepository;
 use liboxen::model::Workspace;
 use liboxen::repositories;
@@ -167,10 +167,9 @@ pub async fn unstage_many(
     let mut err_paths = vec![];
 
     for path in paths_to_remove {
-        let is_staged = with_staged_db_manager(&workspace.workspace_repo, |staged_db_manager| {
-            staged_db_manager.read_from_staged_db(&path)
-        })?
-        .is_some();
+        let is_staged = get_staged_db_manager(&workspace.workspace_repo)?
+            .read_from_staged_db(&path)?
+            .is_some();
 
         if !is_staged {
             continue;

--- a/crates/server/src/controllers/workspaces/files.rs
+++ b/crates/server/src/controllers/workspaces/files.rs
@@ -3,7 +3,7 @@ use crate::helpers::get_repo;
 use crate::params::{app_data, path_param};
 
 use liboxen::core;
-use liboxen::core::staged::with_staged_db_manager;
+use liboxen::core::staged::get_staged_db_manager;
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::model::merkle_tree::node::EMerkleTreeNode;
@@ -91,34 +91,29 @@ pub async fn get(
     log::debug!("got workspace file path {:?}", &path);
 
     // First, look for the file in the workspace staged_db
-    let file_node = with_staged_db_manager(&workspace.workspace_repo, |staged_db_manager| {
-        let staged_node = staged_db_manager.read_from_staged_db(&path)?;
-
-        match staged_node {
-            Some(staged_node) => {
-                let file_node = match staged_node.node.node {
-                    EMerkleTreeNode::File(f) => Ok(f),
-                    _ => Err(OxenError::basic_str(
-                        "Only single file download is supported",
-                    )),
-                }?;
-
-                Ok(file_node)
-            }
-            None => {
-                // If the file isn't in the workspace staged_db, look for it in the base repo
-                if let Some(file_node) = repositories::tree::get_file_by_path(
-                    &workspace.base_repo,
-                    &workspace.commit,
-                    &path,
-                )? {
-                    Ok(file_node)
-                } else {
-                    Err(OxenError::resource_not_found(&path))
-                }
+    let staged_db_manager = get_staged_db_manager(&workspace.workspace_repo)?;
+    let file_node = match staged_db_manager.read_from_staged_db(&path)? {
+        Some(staged_node) => match staged_node.node.node {
+            EMerkleTreeNode::File(f) => Ok(f),
+            _ => Err(OxenError::basic_str(
+                "Only single file download is supported",
+            )),
+        }?,
+        None => {
+            // If the file isn't in the workspace staged_db, look for it in the base repo
+            if let Some(file_node) = repositories::tree::get_file_by_path(
+                &workspace.base_repo,
+                &workspace.commit,
+                &path,
+            )? {
+                file_node
+            } else {
+                return Err(OxenHttpError::InternalOxenError(
+                    OxenError::resource_not_found(&path),
+                ));
             }
         }
-    })?;
+    };
 
     let file_hash = file_node.hash();
     let hash_str = file_hash.to_string();


### PR DESCRIPTION
Refactor `with_staged_db_manager` so it doesn't enforce using sync closures in the middle of async code.

Instead of accepting a (sync) closure, and then getting the staged db manager and injecting it into the closure, we just return the staged db manager to the caller and let them use it. There's not any reason for us to guard it behind a closure in the first place.

I'm doing this because this function was blocking my next S3 project step of cleaning up some usage of get_version_path, which is now async.

### Review guidance

- [‎crates/lib/src/core/staged/staged_db_manager.rs‎](https://github.com/Oxen-AI/Oxen/pull/366/changes#diff-f84b133d80118cf2756d3c789de5ceb10ef5e890100e05db5cc8d5b3aea7b177)
  - This is the actual change (and happens to be at the top of the diff list). 
- The remainder of the files are just assigning the db manager to a variable and moving the code out of the closure to use it directly.

### This unblocks:

- #375
- #376 
- #377 
- #378 
- #379



### Along the way...

...some other issues came to light. Since I felt that adding those fixes to this PR would make it too overwhelming to review, I stacked the fixes separately:

- #369
- #370 
- #371
- #372
- #373
- #374