### PR TITLE
Don't attempt to build oxen-py during release until we're ready

### DIFF
--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Build oxen binaries
         run: |
-          cargo build --workspace --release
+          cargo build --workspace --exclude oxen-py --release
 
       - name: Build Python wheels
         run: |

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -38,8 +38,8 @@ jobs:
           rustup target add aarch64-apple-darwin
           rustup target add x86_64-apple-darwin
 
-          cargo build --workspace --release --target aarch64-apple-darwin
-          cargo build --workspace --release --target x86_64-apple-darwin
+          cargo build --workspace --exclude oxen-py --release --target aarch64-apple-darwin
+          cargo build --workspace --exclude oxen-py --release --target x86_64-apple-darwin
 
       - name: Build Python wheels
         run: |

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Build oxen binaries
         run: |
           refreshenv
-          cargo build --workspace --release
+          cargo build --workspace --exclude oxen-py --release
 
       - name: Build Python wheels
         run: |


### PR DESCRIPTION
In #359 we moved the python bindings Rust project into the same workspace as the rest of the Rust project. This is fine in the regular tests, since we install the oldest supported version of Python before building everything.

In the release workflow, we need to build the non-python Rust crates first, and then in a matrix that iterates through different Python versions build the python Rust bindings project.