### PR TITLE
Exclude oxen-py from the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update \
 
 WORKDIR /usr/src/oxen-server
 COPY . .
-RUN cargo build --workspace --release --features liboxen/ffmpeg
+RUN cargo build --workspace --exclude oxen-py --release --features liboxen/ffmpeg
 
 # Minimal image to run the binary (without Rust toolchain)
 FROM debian:bookworm-slim AS runtime


### PR DESCRIPTION
Exclude oxen-py from the docker build, since that won't be used in there and we didn't install python and prereqs for it.