### PR TITLE
Check file location stability in tests

### DIFF
--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -17,7 +17,7 @@ use crate::model::{
 };
 
 use crate::opts::PushOpts;
-use crate::util::{self, concurrency};
+use crate::util::concurrency;
 use crate::{api, repositories};
 
 pub async fn push(repo: &LocalRepository) -> Result<Branch, OxenError> {
@@ -570,19 +570,13 @@ async fn chunk_and_send_large_entries(
     }
 
     use tokio::time::sleep;
-    type PieceOfWork = (Entry, PathBuf, RemoteRepository);
+    type PieceOfWork = (Entry, RemoteRepository);
     type TaskQueue = deadqueue::limited::Queue<PieceOfWork>;
 
     log::debug!("Chunking and sending {} larger files", entries.len());
     let entries: Vec<PieceOfWork> = entries
         .iter()
-        .map(|e| {
-            (
-                e.to_owned(),
-                local_repo.path.clone(),
-                remote_repo.to_owned(),
-            )
-        })
+        .map(|e| (e.to_owned(), remote_repo.to_owned()))
         .collect();
 
     let queue = Arc::new(TaskQueue::new(entries.len()));
@@ -614,7 +608,7 @@ async fn chunk_and_send_large_entries(
                     break;
                 }
 
-                let Some((entry, repo_path, remote_repo)) = queue.try_pop() else {
+                let Some((entry, remote_repo)) = queue.try_pop() else {
                     // reached end of queue
                     break;
                 };
@@ -628,21 +622,10 @@ async fn chunk_and_send_large_entries(
                         break;
                     }
                 };
-                let relative_path = util::fs::path_relative_to_dir(version_path, &repo_path)
-                    .unwrap_or_else(|e| {
-                        log::error!("Failed to get relative path: {e}");
-                        entry.path()
-                    });
-                let path = if relative_path.exists() {
-                    relative_path
-                } else {
-                    // for test environment
-                    repo_path.join(relative_path)
-                };
 
                 match api::client::versions::parallel_large_file_upload(
                     &remote_repo,
-                    path,
+                    &*version_path,
                     None::<PathBuf>,
                     None,
                     Some(entry.clone()),

--- a/crates/lib/src/repositories/fsck.rs
+++ b/crates/lib/src/repositories/fsck.rs
@@ -7,6 +7,7 @@
 mod tests {
     use crate::error::OxenError;
     use crate::repositories;
+    use crate::storage::version_store::LocalFilePath;
     use crate::test;
 
     #[tokio::test]
@@ -22,10 +23,15 @@ mod tests {
             let versions = version_store.list_versions().await?;
             assert!(!versions.is_empty());
 
-            // Corrupt a version file by overwriting its data
+            // Corrupt a version file by overwriting its data.
+            // This test relies on writing directly to the version store's
+            // on-disk path, which only works with LocalVersionStore.
             let hash = &versions[0];
             let version_path = version_store.get_version_path(hash).await?;
-            std::fs::write(&version_path, b"corrupted data")?;
+            let LocalFilePath::Stable(ref path) = version_path else {
+                panic!("Expected LocalVersionStore (Stable path), got a Temp path. This test only works with local storage.");
+            };
+            std::fs::write(path, b"corrupted data")?;
 
             // Dry run should detect corruption but not delete
             let result = version_store.clean_corrupted_versions(true).await?;
@@ -53,10 +59,15 @@ mod tests {
             let versions = version_store.list_versions().await?;
             assert!(!versions.is_empty());
 
-            // Corrupt a version file by overwriting its data
+            // Corrupt a version file by overwriting its data.
+            // This test relies on writing directly to the version store's
+            // on-disk path, which only works with LocalVersionStore.
             let hash = &versions[0];
             let version_path = version_store.get_version_path(hash).await?;
-            std::fs::write(&version_path, b"corrupted data")?;
+            let LocalFilePath::Stable(ref path) = version_path else {
+                panic!("Expected LocalVersionStore (Stable path), got a Temp path. This test only works with local storage.");
+            };
+            std::fs::write(path, b"corrupted data")?;
 
             // Clean should detect and remove the corrupted file
             let result = version_store.clean_corrupted_versions(false).await?;


### PR DESCRIPTION
In tests that rely on the local disk file location being stable, check for that stability.

This will become an issue in the future when we actually use other implementations of `VersionStore` such as `S3VersionStore`