### PR TITLE
Fix diff_text_file_nodes

### DIFF
--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -17,7 +17,7 @@ use crate::model::{
 };
 
 use crate::opts::PushOpts;
-use crate::util::{self, concurrency};
+use crate::util::concurrency;
 use crate::{api, repositories};
 
 pub async fn push(repo: &LocalRepository) -> Result<Branch, OxenError> {
@@ -570,19 +570,13 @@ async fn chunk_and_send_large_entries(
     }
 
     use tokio::time::sleep;
-    type PieceOfWork = (Entry, PathBuf, RemoteRepository);
+    type PieceOfWork = (Entry, RemoteRepository);
     type TaskQueue = deadqueue::limited::Queue<PieceOfWork>;
 
     log::debug!("Chunking and sending {} larger files", entries.len());
     let entries: Vec<PieceOfWork> = entries
         .iter()
-        .map(|e| {
-            (
-                e.to_owned(),
-                local_repo.path.clone(),
-                remote_repo.to_owned(),
-            )
-        })
+        .map(|e| (e.to_owned(), remote_repo.to_owned()))
         .collect();
 
     let queue = Arc::new(TaskQueue::new(entries.len()));
@@ -614,7 +608,7 @@ async fn chunk_and_send_large_entries(
                     break;
                 }
 
-                let Some((entry, repo_path, remote_repo)) = queue.try_pop() else {
+                let Some((entry, remote_repo)) = queue.try_pop() else {
                     // reached end of queue
                     break;
                 };
@@ -628,21 +622,10 @@ async fn chunk_and_send_large_entries(
                         break;
                     }
                 };
-                let relative_path = util::fs::path_relative_to_dir(version_path, &repo_path)
-                    .unwrap_or_else(|e| {
-                        log::error!("Failed to get relative path: {e}");
-                        entry.path()
-                    });
-                let path = if relative_path.exists() {
-                    relative_path
-                } else {
-                    // for test environment
-                    repo_path.join(relative_path)
-                };
 
                 match api::client::versions::parallel_large_file_upload(
                     &remote_repo,
-                    path,
+                    &*version_path,
                     None::<PathBuf>,
                     None,
                     Some(entry.clone()),

--- a/crates/lib/src/repositories/diffs.rs
+++ b/crates/lib/src/repositories/diffs.rs
@@ -793,41 +793,35 @@ pub async fn diff_text_file_nodes(
     let version_store = repo.version_store()?;
     match (file_1, file_2) {
         (Some(file_1), Some(file_2)) => {
-            let file_hash_1 = file_1.hash().to_string();
-            let file_content_1 = read_version_file_to_string(&version_store, &file_hash_1).await?;
-            let version_path_1 = version_store.get_version_path(&file_hash_1).await?;
-
-            let file_hash_2 = file_2.hash().to_string();
-            let file_content_2 = read_version_file_to_string(&version_store, &file_hash_2).await?;
-            let version_path_2 = version_store.get_version_path(&file_hash_2).await?;
-
+            let file_content_1 =
+                read_version_file_to_string(&version_store, &file_1.hash().to_string()).await?;
+            let file_content_2 =
+                read_version_file_to_string(&version_store, &file_2.hash().to_string()).await?;
             utf8_diff::diff(
                 Some(file_content_1),
-                Some(version_path_1.to_pathbuf()),
+                Some(PathBuf::from(file_1.name())),
                 Some(file_content_2),
-                Some(version_path_2.to_pathbuf()),
+                Some(PathBuf::from(file_2.name())),
             )
         }
         (Some(file_1), None) => {
-            let file_hash_1 = file_1.hash().to_string();
-            let file_content_1 = read_version_file_to_string(&version_store, &file_hash_1).await?;
-            let version_path_1 = version_store.get_version_path(&file_hash_1).await?;
+            let file_content_1 =
+                read_version_file_to_string(&version_store, &file_1.hash().to_string()).await?;
             utf8_diff::diff(
                 Some(file_content_1),
-                Some(version_path_1.to_pathbuf()),
+                Some(PathBuf::from(file_1.name())),
                 None,
                 None,
             )
         }
         (None, Some(file_2)) => {
-            let file_hash_2 = file_2.hash().to_string();
-            let file_content_2 = read_version_file_to_string(&version_store, &file_hash_2).await?;
-            let version_path_2 = version_store.get_version_path(&file_hash_2).await?;
+            let file_content_2 =
+                read_version_file_to_string(&version_store, &file_2.hash().to_string()).await?;
             utf8_diff::diff(
                 None,
                 None,
                 Some(file_content_2),
-                Some(version_path_2.to_pathbuf()),
+                Some(PathBuf::from(file_2.name())),
             )
         }
         (None, None) => Err(OxenError::basic_str(

--- a/crates/lib/src/repositories/fsck.rs
+++ b/crates/lib/src/repositories/fsck.rs
@@ -7,6 +7,7 @@
 mod tests {
     use crate::error::OxenError;
     use crate::repositories;
+    use crate::storage::version_store::LocalFilePath;
     use crate::test;
 
     #[tokio::test]
@@ -22,10 +23,15 @@ mod tests {
             let versions = version_store.list_versions().await?;
             assert!(!versions.is_empty());
 
-            // Corrupt a version file by overwriting its data
+            // Corrupt a version file by overwriting its data.
+            // This test relies on writing directly to the version store's
+            // on-disk path, which only works with LocalVersionStore.
             let hash = &versions[0];
             let version_path = version_store.get_version_path(hash).await?;
-            std::fs::write(&version_path, b"corrupted data")?;
+            let LocalFilePath::Stable(ref path) = version_path else {
+                panic!("Expected LocalVersionStore (Stable path), got a Temp path. This test only works with local storage.");
+            };
+            std::fs::write(path, b"corrupted data")?;
 
             // Dry run should detect corruption but not delete
             let result = version_store.clean_corrupted_versions(true).await?;
@@ -53,10 +59,15 @@ mod tests {
             let versions = version_store.list_versions().await?;
             assert!(!versions.is_empty());
 
-            // Corrupt a version file by overwriting its data
+            // Corrupt a version file by overwriting its data.
+            // This test relies on writing directly to the version store's
+            // on-disk path, which only works with LocalVersionStore.
             let hash = &versions[0];
             let version_path = version_store.get_version_path(hash).await?;
-            std::fs::write(&version_path, b"corrupted data")?;
+            let LocalFilePath::Stable(ref path) = version_path else {
+                panic!("Expected LocalVersionStore (Stable path), got a Temp path. This test only works with local storage.");
+            };
+            std::fs::write(path, b"corrupted data")?;
 
             // Clean should detect and remove the corrupted file
             let result = version_store.clean_corrupted_versions(false).await?;


### PR DESCRIPTION
- Stop double-downloading file content in the S3 implementation
- Display relative path in diff instead of opaque path