### PR TITLE
Merge commits into the specified base, not main

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -105,6 +105,7 @@ oxen push origin main               # Push to remote
 - When changing something that is documented in nearby code, or appears in any markdown files in the repository, update the affected documentation.
 - When prompted to always do something a certain way in general, add an entry to this section of the CLAUDE.md file.
 - When calling `get_staged_db_manager`, follow the doc comment on that function: drop the returned `StagedDBManager` as soon as possible (via a block scope or explicit `drop()`) to avoid holding the shared database handle longer than necessary.
+- After changing any Rust code, verify that tests pass with the `bin/test-rust` script (not `cargo`). The script is documented in a comment at the top of its file.
 
 # Testing Rules
 - Use the test helpers in `crates/lib/src/test.rs` (e.g., `run_empty_local_repo_test`) for unit tests in the lib code.

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -770,10 +770,8 @@ async fn create_merge_commit(
     merge_commits: &MergeCommits,
     shared_hashes: HashSet<MerkleHash>,
 ) -> Result<Commit, OxenError> {
-    // Stage changes
-
-    let head_commit = repositories::commits::head_commit(repo)?;
-    add::add_dir_except(repo, &Some(head_commit), repo.path.clone(), shared_hashes).await?;
+    let base_commit = merge_commits.base.clone();
+    add::add_dir_except(repo, &Some(base_commit), repo.path.clone(), shared_hashes).await?;
 
     let commit_msg = format!(
         "Merge commit {} into {}",
@@ -800,9 +798,8 @@ async fn create_merge_commit_on_branch(
     branch: &Branch,
     shared_hashes: HashSet<MerkleHash>,
 ) -> Result<Commit, OxenError> {
-    // Stage changes
-    let head_commit = repositories::commits::head_commit(repo)?;
-    add::add_dir_except(repo, &Some(head_commit), repo.path.clone(), shared_hashes).await?;
+    let base_commit = merge_commits.base.clone();
+    add::add_dir_except(repo, &Some(base_commit), repo.path.clone(), shared_hashes).await?;
 
     let commit_msg = format!(
         "Merge commit {} into {} on branch {}",

--- a/crates/lib/src/repositories/merge.rs
+++ b/crates/lib/src/repositories/merge.rs
@@ -971,14 +971,16 @@ mod tests {
 
             // 2. Create a new branch
             let new_branch_name = "new_branch";
-            let new_branch = repositories::branches::create_checkout(&repo, new_branch_name)?;
+            repositories::branches::create_checkout(&repo, new_branch_name)?;
 
             // 3. Commit something in new branch
             let labels_path = test::modify_txt_file(labels_path, "cat\ndog\nfish")?;
             repositories::add(&repo, &labels_path).await?;
             repositories::commit(&repo, "Adding fish to labels.txt file")?;
 
-            // 4. merge main onto new branch
+            // 4. merge main onto new branch (re-fetch branches to get current commit IDs)
+            let og_branch = repositories::branches::get_by_name(&repo, &og_branch.name)?.unwrap();
+            let new_branch = repositories::branches::get_by_name(&repo, new_branch_name)?.unwrap();
             let merge_result =
                 repositories::merge::merge_into_base(&repo, &og_branch, &new_branch).await;
 


### PR DESCRIPTION
Our code that created merge commits always used HEAD as the base commit for the merge. This is fine for the CLI, since we only support merging something else into the current HEAD. On the server, however, HEAD can be anything, and the base is specified in the request. So we were always merging into whatever the server had last set HEAD to, which could quite easily be something other than the base we want to merge into.

- Fixed the behavior
- Fixed the test, which was testing the wrong thing and broke when we fixed things. 😂 
- I also added an instruction for Claude to use `bin/test-rust` instead of `cargo test`