### PR TITLE
Bump to Rust 1.94.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.94.1"


### PR DESCRIPTION
From the [blog post](https://blog.rust-lang.org/2026/03/26/1.94.1-release/)

## What's in 1.94.1

Rust 1.94.1 resolves three regressions that were introduced in the 1.94.0 release.

- [Fix std::thread::spawn on wasm32-wasip1-threads](https://github.com/rust-lang/rust/pull/153634)
- [Remove new methods added to std::os::windows::fs::OpenOptionsExt](https://github.com/rust-lang/rust/pull/153491) The new methods were unstable, but the trait itself is not sealed and so cannot be extended with non-default methods.
- [Clippy: fix ICE in match_same_arms](https://github.com/rust-lang/rust-clippy/pull/16685)
- [Cargo: downgrade curl-sys to 0.4.83](https://github.com/rust-lang/cargo/pull/16787) This fixes certificate validation error for some users on some versions of FreeBSD. See [this issue](https://github.com/rust-lang/cargo/issues/16357) for more details.

And a security fix:

- [Cargo: Update tar to 0.4.45](https://github.com/rust-lang/cargo/pull/16769) This resolves [CVE-2026-33055](https://www.cve.org/CVERecord?id=CVE-2026-33055) and [CVE-2026-33056](https://www.cve.org/CVERecord?id=CVE-2026-33056). Users of crates.io are not affected. See [blog](https://blog.rust-lang.org/2026/03/21/cve-2026-33056/) for more details.