### PR TITLE
Remove clone cleanup on failure

### DIFF
--- a/crates/lib/src/repositories/clone.rs
+++ b/crates/lib/src/repositories/clone.rs
@@ -5,6 +5,7 @@
 
 use std::path::Path;
 
+use crate::api;
 use crate::constants::DEFAULT_REMOTE_NAME;
 use crate::core;
 use crate::core::versions::MinOxenVersion;
@@ -12,14 +13,9 @@ use crate::error::OxenError;
 use crate::model::{LocalRepository, Remote, RemoteRepository};
 use crate::opts::CloneOpts;
 use crate::opts::{FetchOpts, StorageOpts};
-use crate::{api, util};
 
 pub async fn clone(opts: &CloneOpts) -> Result<LocalRepository, OxenError> {
-    match clone_remote(opts).await {
-        Ok(Some(repo)) => Ok(repo),
-        Ok(None) => Err(OxenError::remote_repo_not_found(&opts.url)),
-        Err(err) => Err(err),
-    }
+    clone_remote(opts).await
 }
 
 pub async fn clone_url(
@@ -58,7 +54,7 @@ async fn _clone(
     clone(&opts).await
 }
 
-async fn clone_remote(opts: &CloneOpts) -> Result<Option<LocalRepository>, OxenError> {
+async fn clone_remote(opts: &CloneOpts) -> Result<LocalRepository, OxenError> {
     log::debug!(
         "clone_remote {} -> {:?} -> subtree? {:?} -> depth? {:?} -> all? {} -> storage backend? {:?} -> is vfs? {} -> is remote? {}",
         opts.url,
@@ -77,38 +73,10 @@ async fn clone_remote(opts: &CloneOpts) -> Result<Option<LocalRepository>, OxenE
     };
     let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
 
-    // Check if the destination directory exists before cloning so we know
-    // whether to clean it up or not in the case of an error.
-    let dst_exists_before_clone = opts.dst.exists();
-
     if opts.is_remote {
-        match clone_repo_remote_mode(remote_repo, opts).await {
-            Ok(repo) => Ok(Some(repo)),
-            Err(err) => {
-                if !dst_exists_before_clone && opts.dst.exists() {
-                    // Cleanup the destination directory if it wasn't there before cloning
-                    // Close DB instances before we delete it.
-                    core::staged::remove_from_cache_with_children(&opts.dst)?;
-                    core::refs::remove_from_cache(&opts.dst)?;
-                    util::fs::remove_dir_all(&opts.dst)?;
-                }
-                Err(err)
-            }
-        }
+        clone_repo_remote_mode(remote_repo, opts).await
     } else {
-        match clone_repo(remote_repo, opts).await {
-            Ok(repo) => Ok(Some(repo)),
-            Err(err) => {
-                if !dst_exists_before_clone && opts.dst.exists() {
-                    // Cleanup the destination directory if it wasn't there before cloning
-                    // Close DB instances before we delete it.
-                    core::staged::remove_from_cache_with_children(&opts.dst)?;
-                    core::refs::remove_from_cache(&opts.dst)?;
-                    util::fs::remove_dir_all(&opts.dst)?;
-                }
-                Err(err)
-            }
-        }
+        clone_repo(remote_repo, opts).await
     }
 }
 
@@ -164,7 +132,7 @@ mod tests {
                 let opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
 
                 log::debug!("about to clone the remote");
-                let local_repo = clone_remote(&opts).await?.unwrap();
+                let local_repo = clone_remote(&opts).await?;
                 log::debug!("succeeded");
                 let cfg_fname = ".oxen/config.toml".to_string();
                 let config_path = local_repo.path.join(&cfg_fname);
@@ -195,7 +163,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 let opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
-                let local_repo = clone_remote(&opts).await?.unwrap();
+                let local_repo = clone_remote(&opts).await?;
 
                 api::client::repositories::delete(&remote_repo).await?;
 
@@ -226,7 +194,7 @@ mod tests {
                 let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths = Some(vec![PathBuf::from(".")]);
                 opts.fetch_opts.depth = Some(1);
-                let local_repo = clone_remote(&opts).await?.unwrap();
+                let local_repo = clone_remote(&opts).await?;
 
                 // Make sure we set the depth and subtree paths
                 assert_eq!(local_repo.depth(), Some(1));
@@ -258,7 +226,7 @@ mod tests {
             test::run_empty_dir_test_async(|dir| async move {
                 let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths = Some(vec![PathBuf::from("annotations")]);
-                let local_repo = clone_remote(&opts).await?.unwrap();
+                let local_repo = clone_remote(&opts).await?;
 
                 // Make sure we set the depth and subtree paths
                 assert_eq!(
@@ -311,7 +279,7 @@ mod tests {
                 let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths =
                     Some(vec![PathBuf::from("annotations").join("test")]);
-                let local_repo = clone_remote(&opts).await?.unwrap();
+                let local_repo = clone_remote(&opts).await?;
 
                 assert!(local_repo.path.join("annotations").join("test").exists());
                 assert!(
@@ -343,7 +311,7 @@ mod tests {
                     PathBuf::from("annotations").join("test"),
                     PathBuf::from("nlp"),
                 ]);
-                let local_repo = clone_remote(&opts).await?.unwrap();
+                let local_repo = clone_remote(&opts).await?;
 
                 assert!(local_repo.path.join("annotations").join("test").exists());
                 assert!(local_repo.path.join("nlp").exists());

--- a/crates/lib/src/repositories/clone.rs
+++ b/crates/lib/src/repositories/clone.rs
@@ -630,45 +630,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_clone_error_cleanup() -> Result<(), OxenError> {
-        test::run_select_data_sync_remote("README.md", |_, remote_repo| async move {
-            // Clone a non-existent repo, destination directory should be cleaned up
-            let remote_url = remote_repo.remote.url.clone();
-            test::run_empty_dir_test_async(|new_repo_dir| async move {
-                let dst_dir = new_repo_dir.join("new_repo_1");
-                // cloning with a valid remote url but a non-existent branch
-                // will fail later in the clone process
-                let clone_opts = CloneOpts::from_branch(&remote_url, &dst_dir, "fake-branch");
-                let cloned_repo = repositories::clone(&clone_opts).await;
-                assert!(cloned_repo.is_err());
-                assert!(!dst_dir.exists());
-
-                Ok(())
-            })
-            .await?;
-
-            // Clone a non-existent repo, destination directory should *NOT* be
-            // cleaned up because it already existed before cloning
-            let remote_url = remote_repo.remote.url.clone();
-            test::run_empty_dir_test_async(|new_repo_dir| async move {
-                let dst_dir = new_repo_dir.join("new_repo_2");
-                // Create the destination directory before cloning
-                util::fs::create_dir_all(&dst_dir)?;
-                let clone_opts = CloneOpts::from_branch(&remote_url, &dst_dir, "fake-branch");
-                let cloned_repo = repositories::clone(&clone_opts).await;
-                assert!(cloned_repo.is_err());
-                assert!(dst_dir.exists());
-
-                Ok(())
-            })
-            .await?;
-
-            Ok(remote_repo)
-        })
-        .await
-    }
-
-    #[tokio::test]
     async fn test_clone_subtree_and_checkout_branch() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
             let remote_repo_copy = remote_repo.clone();


### PR DESCRIPTION
 was facing an issue where because of an issue with clone the cloned repository was being cleaned up, for a 350GB repo, which takes ~45 minutes to clone, this will be a frustrating experience.

while git does this delete on clone failure. it doesn't make sense for us, where the clone time can be long. we also have added a lot of repository healing commands lik, `fsck`, `--missing-files`, `--revalidate`. so it is better to have a broken repo and then fix it as opposed to having to start a new clone