### PR TITLE
Remove get_version_chunk_stream

### DIFF
--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -312,42 +312,6 @@ impl VersionStore for LocalVersionStore {
         Ok(buffer)
     }
 
-    async fn get_version_chunk_stream(
-        &self,
-        hash: &str,
-        offset: u64,
-        size: u64,
-    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
-    {
-        let version_file_path = self.version_path(hash);
-
-        let mut file = File::open(&version_file_path).await?;
-        let metadata = file.metadata().await?;
-        let file_len = metadata.len();
-
-        if offset >= file_len || offset + size > file_len {
-            return Err(OxenError::IO(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "beyond end of file",
-            )));
-        }
-
-        let read_len = std::cmp::min(size, file_len - offset);
-        if read_len > usize::MAX as u64 {
-            return Err(OxenError::basic_str("requested chunk too large"));
-        }
-
-        use tokio::io::{AsyncSeekExt, SeekFrom};
-        file.seek(SeekFrom::Start(offset)).await?;
-
-        // Create a limited reader that only reads the specified range
-        let limited_reader = file.take(read_len);
-        let reader = BufReader::new(limited_reader);
-        let stream = ReaderStream::new(reader);
-
-        Ok(Box::new(stream))
-    }
-
     async fn list_version_chunks(&self, hash: &str) -> Result<Vec<u64>, OxenError> {
         let chunk_dir = self.version_chunks_dir(hash);
         let mut chunks = Vec::new();

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -397,19 +397,6 @@ impl VersionStore for S3VersionStore {
         ))
     }
 
-    async fn get_version_chunk_stream(
-        &self,
-        _hash: &str,
-        _offset: u64,
-        _size: u64,
-    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
-    {
-        // TODO: Implement S3 version chunk stream retrieval
-        Err(OxenError::basic_str(
-            "S3VersionStore get_version_chunk_stream not yet implemented",
-        ))
-    }
-
     async fn list_version_chunks(&self, _hash: &str) -> Result<Vec<u64>, OxenError> {
         // TODO: Implement S3 version chunk listing
         Err(OxenError::basic_str(

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -166,19 +166,6 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
         size: u64,
     ) -> Result<Vec<u8>, OxenError>;
 
-    /// Get a chunk of a version file as a stream of bytes
-    ///
-    /// # Arguments
-    /// * `hash` - The content hash of the version to retrieve
-    /// * `offset` - The starting byte position of the chunk
-    /// * `size` - The chunk size
-    async fn get_version_chunk_stream(
-        &self,
-        hash: &str,
-        offset: u64,
-        size: u64,
-    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>;
-
     /// List all chunks for a version file
     ///
     /// # Arguments


### PR DESCRIPTION
This method is dead code, and in the designs I'm exploring I don't have any plans to use it.

Super easy to restore if we end up wanting it in the future.