### PR TITLE
switch order of parse resource to prefer branches over workspaces

### DIFF
--- a/crates/lib/src/core/v_latest/resource.rs
+++ b/crates/lib/src/core/v_latest/resource.rs
@@ -20,7 +20,7 @@ pub fn parse_resource_from_path(
     let components = path.components().collect::<Vec<_>>();
 
     let first_str = match components.first() {
-        Some(c) => component_str(c),
+        Some(c) => c.as_os_str().to_str().expect("non-UTF-8 resource path"),
         None => return Ok(None),
     };
 
@@ -105,18 +105,6 @@ fn parsed_from_workspace(
     }
 }
 
-/// All resource paths originate from HTTP routes, so non-UTF-8 is unreachable.
-/// These two helpers make that assumption explicit in one place.
-fn component_str<'a>(c: &'a Component<'a>) -> &'a str {
-    let p: &Path = c.as_ref();
-    path_str(p)
-}
-
-fn path_str(p: &Path) -> &str {
-    p.to_str()
-        .expect("resource path component is not valid UTF-8")
-}
-
 fn remaining_path(components: &[Component], skip: usize) -> PathBuf {
     components.iter().skip(skip).fold(PathBuf::new(), |acc, c| {
         let p: &Path = c.as_ref();
@@ -158,7 +146,9 @@ fn try_parse_as_branch(
             (&components[..split], &components[split..])
         };
 
-        let branch_name = util::fs::linux_path_str(path_str(&join_components(branch_components)));
+        let joined = join_components(branch_components);
+        let branch_name =
+            util::fs::linux_path_str(joined.to_str().expect("non-UTF-8 resource path"));
 
         let maybe_branch =
             with_ref_manager(repo, |manager| manager.get_branch_by_name(&branch_name))?;

--- a/crates/lib/src/core/v_latest/resource.rs
+++ b/crates/lib/src/core/v_latest/resource.rs
@@ -1,138 +1,180 @@
 use crate::core::refs::with_ref_manager;
 
 use crate::error::OxenError;
-use crate::model::{LocalRepository, ParsedResource};
+use crate::model::{Branch, Commit, LocalRepository, ParsedResource, Workspace};
 use crate::repositories;
 
 use crate::util;
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
+/// Parse a resource identifier from a URL-style path.
+///
+/// Resolution order: commits, then branches, then workspaces.
+/// Reason: At the moment, workspaces are slow to lookup.
+///         We will speed up the lookup, but they are lowest priority.
 pub fn parse_resource_from_path(
     repo: &LocalRepository,
     path: &Path,
 ) -> Result<Option<ParsedResource>, OxenError> {
-    let mut components = path.components().collect::<Vec<_>>();
-    // Try to use the first component as a commit id or a workspace id.
-    if let Some(first_component) = components.first() {
-        let base_path: &Path = first_component.as_ref();
-        let first_str = base_path.to_str().unwrap();
+    let components = path.components().collect::<Vec<_>>();
 
-        // First try to interpret the first component as a commit id.
-        if let Some(commit) = repositories::commits::get_by_id(repo, first_str)? {
-            let mut file_path = PathBuf::new();
-            for (i, component) in components.iter().enumerate() {
-                if i != 0 {
-                    let component_path: &Path = component.as_ref();
-                    file_path = file_path.join(component_path);
-                }
-            }
+    let first_str = match components.first() {
+        Some(c) => component_str(c),
+        None => return Ok(None),
+    };
+
+    // 1) Commit — first component is a commit id
+    if let Some(commit) = repositories::commits::get_by_id(repo, first_str)? {
+        let file_path = remaining_path(&components, 1);
+        log::debug!(
+            "parse_resource_from_path got commit.id [{}] and filepath [{:?}]",
+            commit.id,
+            file_path
+        );
+        return Ok(Some(parsed_from_commit(path, commit, file_path)));
+    }
+
+    // 2) Branch — progressively match components as a branch name
+    if let Some(resource) = try_parse_as_branch(repo, path, &components)? {
+        return Ok(Some(resource));
+    }
+
+    // 3) Workspace — first component is a workspace id or name
+    //    (`repositories::workspaces::get` accepts either form)
+    match repositories::workspaces::get(repo, first_str) {
+        Ok(Some(workspace)) => {
+            let file_path = remaining_path(&components, 1);
             log::debug!(
-                "parse_resource_from_path got commit.id [{}] and filepath [{:?}]",
-                commit.id,
+                "parse_resource_from_path got workspace.id [{}] and filepath [{:?}]",
+                workspace.id,
                 file_path
             );
-            return Ok(Some(ParsedResource {
-                commit: Some(commit.clone()),
-                branch: None,
-                workspace: None,
-                path: file_path,
-                version: PathBuf::from(commit.id.to_string()),
-                resource: path.to_owned(),
-            }));
+            return Ok(Some(parsed_from_workspace(path, workspace, file_path)));
         }
-
-        // If not a commit, try to interpret the first component as a workspace id.
-        match repositories::workspaces::get(repo, first_str) {
-            Ok(Some(workspace)) => {
-                let mut file_path = PathBuf::new();
-                for (i, component) in components.iter().enumerate() {
-                    if i != 0 {
-                        let component_path: &Path = component.as_ref();
-                        file_path = file_path.join(component_path);
-                    }
-                }
-                log::debug!(
-                    "parse_resource_from_path got workspace.id [{}] and filepath [{:?}]",
-                    workspace.id,
-                    file_path
-                );
-                return Ok(Some(ParsedResource {
-                    commit: None,
-                    branch: None,
-                    workspace: Some(workspace.clone()),
-                    path: file_path,
-                    version: PathBuf::from(workspace.id),
-                    resource: path.to_owned(),
-                }));
-            }
-            Ok(None) => {
-                log::debug!("Workspace not found: {first_str}");
-                // Continue to branch resolution below if no workspace is found
-            }
-            Err(e) => {
-                log::debug!("Workspace lookup failed for '{first_str}' with error: {e:?}");
-                // Continue to branch resolution below if no workspace is found
-            }
+        Ok(None) => {
+            log::debug!("Workspace not found: {first_str}");
+        }
+        Err(e) => {
+            log::debug!("Workspace lookup failed for '{first_str}' with error: {e:?}");
         }
     }
 
-    // Fallback to branch resolution logic if neither commit nor workspace was found.
-    // Create a ref reader to look up branch information.
-    let mut file_path = PathBuf::new();
-    while let Some(component) = components.pop() {
-        let component_path: &Path = component.as_ref();
-        if file_path == PathBuf::new() {
-            file_path = component_path.to_path_buf();
-        } else {
-            file_path = component_path.join(file_path);
-        }
-        // If we have no more components to process, consider this as the branch name.
-        if components.is_empty() {
-            let branch_name = util::fs::linux_path_str(file_path.to_str().unwrap());
-            let maybe_branch =
-                with_ref_manager(repo, |manager| manager.get_branch_by_name(&branch_name))?;
-            if let Some(branch) = maybe_branch {
-                log::debug!(
-                    "parse_resource_from_path got branch [{branch_name}] with no file path"
-                );
-                let commit = repositories::commits::get_by_id(repo, &branch.commit_id)?;
-                file_path = PathBuf::from("");
-                return Ok(Some(ParsedResource {
-                    commit,
-                    branch: Some(branch.clone()),
-                    workspace: None,
-                    path: file_path,
-                    version: PathBuf::from(branch.name),
-                    resource: path.to_owned(),
-                }));
-            } else {
-                return Ok(None);
-            }
-        }
+    Ok(None)
+}
 
-        // Otherwise, try constructing a branch name from the remaining components.
-        let mut branch_path = PathBuf::new();
-        for component in components.iter() {
-            let component_path: &Path = component.as_ref();
-            branch_path = branch_path.join(component_path);
-        }
-        let branch_name = util::fs::linux_path_str(branch_path.to_str().unwrap());
+fn parsed_from_commit(resource_path: &Path, commit: Commit, file_path: PathBuf) -> ParsedResource {
+    ParsedResource {
+        version: PathBuf::from(commit.id.to_string()),
+        commit: Some(commit),
+        branch: None,
+        workspace: None,
+        path: file_path,
+        resource: resource_path.to_owned(),
+    }
+}
+
+fn parsed_from_branch(
+    resource_path: &Path,
+    branch: Branch,
+    commit: Option<Commit>,
+    file_path: PathBuf,
+) -> ParsedResource {
+    ParsedResource {
+        version: PathBuf::from(&branch.name),
+        commit,
+        branch: Some(branch),
+        workspace: None,
+        path: file_path,
+        resource: resource_path.to_owned(),
+    }
+}
+
+fn parsed_from_workspace(
+    resource_path: &Path,
+    workspace: Workspace,
+    file_path: PathBuf,
+) -> ParsedResource {
+    ParsedResource {
+        version: PathBuf::from(&workspace.id),
+        commit: None,
+        branch: None,
+        workspace: Some(workspace),
+        path: file_path,
+        resource: resource_path.to_owned(),
+    }
+}
+
+/// All resource paths originate from HTTP routes, so non-UTF-8 is unreachable.
+/// These two helpers make that assumption explicit in one place.
+fn component_str<'a>(c: &'a Component<'a>) -> &'a str {
+    let p: &Path = c.as_ref();
+    path_str(p)
+}
+
+fn path_str(p: &Path) -> &str {
+    p.to_str()
+        .expect("resource path component is not valid UTF-8")
+}
+
+fn remaining_path(components: &[Component], skip: usize) -> PathBuf {
+    components.iter().skip(skip).fold(PathBuf::new(), |acc, c| {
+        let p: &Path = c.as_ref();
+        acc.join(p)
+    })
+}
+
+fn join_components(components: &[Component]) -> PathBuf {
+    components
+        .iter()
+        .fold(PathBuf::new(), |acc, c| acc.join::<&Path>(c.as_ref()))
+}
+
+/// Try progressively shorter prefixes of the path as a branch name.
+///
+/// For a path like `a/b/c/d`, tries:
+///   1. `a/b/c` as branch, file = `d`
+///   2. `a/b`   as branch, file = `c/d`
+///   3. `a`     as branch, file = `b/c/d`
+///   4. `a/b/c/d` as branch, file = (empty)
+fn try_parse_as_branch(
+    repo: &LocalRepository,
+    path: &Path,
+    components: &[Component],
+) -> Result<Option<ParsedResource>, OxenError> {
+    let len = components.len();
+    if len == 0 {
+        return Ok(None);
+    }
+
+    // Try every split point: branch = components[..split], file = components[split..]
+    // Start with the longest possible branch prefix (all but last component),
+    // then shrink, ending with the full path as the branch name (split == 0).
+    for split in (0..len).rev() {
+        let (branch_components, file_components) = if split == 0 {
+            // Entire path is the candidate branch name, no file portion.
+            (components, &components[0..0])
+        } else {
+            (&components[..split], &components[split..])
+        };
+
+        let branch_name = util::fs::linux_path_str(path_str(&join_components(branch_components)));
+
         let maybe_branch =
             with_ref_manager(repo, |manager| manager.get_branch_by_name(&branch_name))?;
+
         if let Some(branch) = maybe_branch {
+            let file_path = if file_components.is_empty() {
+                PathBuf::new()
+            } else {
+                join_components(file_components)
+            };
+
             log::debug!(
                 "parse_resource_from_path got branch [{branch_name}] and filepath [{file_path:?}]"
             );
             let commit = repositories::commits::get_by_id(repo, &branch.commit_id)?;
-            return Ok(Some(ParsedResource {
-                commit,
-                branch: Some(branch.clone()),
-                workspace: None,
-                path: file_path,
-                version: PathBuf::from(branch.name),
-                resource: path.to_owned(),
-            }));
+            return Ok(Some(parsed_from_branch(path, branch, commit, file_path)));
         }
     }
 

--- a/crates/lib/src/core/v_latest/resource.rs
+++ b/crates/lib/src/core/v_latest/resource.rs
@@ -56,7 +56,7 @@ pub fn parse_resource_from_path(
             log::debug!("Workspace not found: {first_str}");
         }
         Err(e) => {
-            log::debug!("Workspace lookup failed for '{first_str}' with error: {e:?}");
+            return Err(e);
         }
     }
 

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -6,39 +6,33 @@
 //!
 //! Instantiating a new repo:
 //!
-//! ```
-//! use liboxen::command;
+//! ```ignore
+//! use liboxen::repositories;
 //!
 //! // Instantiate a new repo
 //! let repo = repositories::init("test_repo")?;
 //! // Add a file to the repo
-//! repositories::add(&repo, "file.txt")?;
+//! repositories::add(&repo, "file.txt").await?;
 //! // Commit the file
 //! repositories::commit(&repo, "Added file.txt")?;
-//!
 //! ```
 //!
 //! Push data from local repo to remote repo:
 //!
-//! ```
+//! ```ignore
 //! use liboxen::command;
 //! use liboxen::model::LocalRepository;
+//! use liboxen::repositories;
+//! use liboxen::api;
 //!
 //! // Create LocalRepository from existing repo
 //! let repo = LocalRepository::from_dir("test_repo")?;
 //! // Add a file to the repo
-//! repositories::add(&repo, "file.txt")?;
+//! repositories::add(&repo, "file.txt").await?;
 //! // Commit the file
 //! repositories::commit(&repo, "Added file.txt")?;
 //! // Set remote
-//! let namespace = "ox";
-//! let repo_name = "test_repo";
-//! let host = "0.0.0.0:3000";
-//! let remote_repo = api::client::repositories::create(
-//!     repo, namespace, repo_name, host
-//! ).await?;
-//! let remote_url = remote_repo.url();
-//! // Set remote
+//! let remote_url = "http://0.0.0.0:3000/ox/test_repo";
 //! let remote_name = "origin";
 //! command::config::set_remote(&mut repo, remote_name, &remote_url)?;
 //! // Push to remote
@@ -46,9 +40,9 @@
 //! ```
 //!
 //! Clone data from remote url
-//! ```
-//! use liboxen::command;
-//! use liboxen::model::LocalRepository;
+//! ```ignore
+//! use liboxen::opts::CloneOpts;
+//! use liboxen::repositories;
 //!
 //! let url = "http://0.0.0.0:3000/ox/test_repo";
 //! let repo_dir = "test_repo";

--- a/crates/lib/src/repositories/add.rs
+++ b/crates/lib/src/repositories/add.rs
@@ -11,15 +11,9 @@ use std::path::Path;
 
 /// # Stage files into repository
 ///
-/// ```
-/// use liboxen::command;
+/// ```ignore
+/// use liboxen::repositories;
 /// use liboxen::util;
-/// # use liboxen::error::OxenError;
-/// # use std::path::Path;
-/// #
-///
-/// # fn main() -> Result<(), OxenError> {
-/// # liboxen::test::init_test_env();
 ///
 /// // Initialize the repository
 /// let base_dir = Path::new("repo_dir_add");
@@ -30,11 +24,9 @@ use std::path::Path;
 /// util::fs::write_to_path(&hello_file, "Hello World");
 ///
 /// // Stage the file
-/// repositories::add(&repo, &hello_file)?;
+/// repositories::add(&repo, &hello_file).await?;
 ///
 /// # util::fs::remove_dir_all(base_dir)?;
-/// # Ok(())
-/// # }
 /// ```
 pub async fn add(repo: &LocalRepository, path: impl AsRef<Path>) -> Result<(), OxenError> {
     add_all_with_version(repo, vec![path], repo.min_version()).await

--- a/crates/lib/src/repositories/commits.rs
+++ b/crates/lib/src/repositories/commits.rs
@@ -19,14 +19,9 @@ pub mod commit_writer;
 
 /// # Commit the staged files in the repo
 ///
-/// ```
-/// use liboxen::command;
+/// ```ignore
+/// use liboxen::repositories;
 /// use liboxen::util;
-/// #
-/// # use liboxen::error::OxenError;
-/// # use std::path::Path;
-/// # fn main() -> Result<(), OxenError> {
-/// # liboxen::test::init_test_env();
 ///
 /// // Initialize the repository
 /// let base_dir = Path::new("repo_dir_commit");
@@ -37,14 +32,10 @@ pub mod commit_writer;
 /// util::fs::write_to_path(&hello_file, "Hello World");
 ///
 /// // Stage the file
-/// repositories::add(&repo, &hello_file)?;
+/// repositories::add(&repo, &hello_file).await?;
 ///
 /// // Commit staged
 /// repositories::commit(&repo, "My commit message")?;
-///
-/// # util::fs::remove_dir_all(base_dir)?;
-/// # Ok(())
-/// # }
 /// ```
 pub fn commit(repo: &LocalRepository, message: &str) -> Result<Commit, OxenError> {
     match repo.min_version() {

--- a/crates/lib/src/repositories/init.rs
+++ b/crates/lib/src/repositories/init.rs
@@ -13,19 +13,13 @@ use crate::model::LocalRepository;
 use crate::opts::StorageOpts;
 
 /// # Initialize an Empty Oxen Repository
-/// ```
-/// # use liboxen::command;
-/// # use liboxen::error::OxenError;
-/// # use std::path::Path;
-/// #
-/// # fn main() -> Result<(), OxenError> {
-/// # liboxen::test::init_test_env();
+/// ```ignore
+/// use liboxen::repositories;
+/// use std::path::Path;
+///
 /// let base_dir = Path::new("repo_dir_init");
-/// command::repositori(base_dir)?;
+/// let repo = repositories::init(base_dir)?;
 /// assert!(base_dir.join(".oxen").exists());
-/// # util::fs::remove_dir_all(base_dir)?;
-/// # Ok(())
-/// # }
 /// ```
 pub fn init(path: impl AsRef<Path>) -> Result<LocalRepository, OxenError> {
     init_with_version(path, MIN_OXEN_VERSION)

--- a/crates/lib/src/repositories/push.rs
+++ b/crates/lib/src/repositories/push.rs
@@ -9,18 +9,13 @@ use crate::error::OxenError;
 use crate::model::{Branch, LocalRepository};
 use crate::opts::PushOpts;
 
-/// # Get a log of all the commits
+/// # Push committed data to a remote
 ///
-/// ```
-/// # use liboxen::api;
-/// #
+/// ```ignore
 /// use liboxen::command;
+/// use liboxen::repositories;
 /// use liboxen::util;
-/// # use liboxen::error::OxenError;
-/// # use std::path::Path;
-/// # #[tokio::main]
-/// # async fn main() -> Result<(), OxenError> {
-/// # liboxen::test::init_test_env();
+///
 /// // Initialize the repository
 /// let base_dir = Path::new("repo_dir_push");
 /// let mut repo = repositories::init(base_dir)?;
@@ -30,7 +25,7 @@ use crate::opts::PushOpts;
 /// util::fs::write_to_path(&hello_file, "Hello World");
 ///
 /// // Stage the file
-/// repositories::add(&repo, &hello_file)?;
+/// repositories::add(&repo, &hello_file).await?;
 ///
 /// // Commit staged
 /// repositories::commit(&repo, "My commit message")?;
@@ -38,15 +33,8 @@ use crate::opts::PushOpts;
 /// // Set the remote server
 /// command::config::set_remote(&mut repo, "origin", "http://localhost:3000/repositories/hello");
 ///
-/// let remote_repo = api::client::repositories::create(&repo, "repositories", "hello", "localhost:3000").await?;
-///
 /// // Push the file
-/// repositories::push(&repo).await;
-///
-/// # util::fs::remove_dir_all(base_dir)?;
-/// # api::client::repositories::delete(&remote_repo).await?;
-/// # Ok(())
-/// # }
+/// repositories::push(&repo).await?;
 /// ```
 pub async fn push(repo: &LocalRepository) -> Result<Branch, OxenError> {
     match repo.min_version() {

--- a/crates/lib/src/repositories/restore.rs
+++ b/crates/lib/src/repositories/restore.rs
@@ -11,15 +11,10 @@ use crate::opts::RestoreOpts;
 
 /// # Restore a removed file that was committed
 ///
-/// ```
-/// use liboxen::command;
+/// ```ignore
+/// use liboxen::repositories;
+/// use liboxen::opts::RestoreOpts;
 /// use liboxen::util;
-/// #
-/// # use liboxen::error::OxenError;
-/// # use liboxen::opts::RestoreOpts;
-/// # use std::path::Path;
-/// # fn main() -> Result<(), OxenError> {
-/// # liboxen::test::init_test_env();
 ///
 /// // Initialize the repository
 /// let base_dir = Path::new("repo_dir_commit");
@@ -34,17 +29,13 @@ use crate::opts::RestoreOpts;
 /// repositories::add(&repo, &hello_path).await?;
 ///
 /// // Commit staged
-/// let commit = repositories::commit(&repo, "My commit message")?.unwrap();
+/// let commit = repositories::commit(&repo, "My commit message")?;
 ///
 /// // Remove the file from disk
 /// util::fs::remove_file(hello_path)?;
 ///
 /// // Restore the file
-/// repositories::restore::restore(&repo, RestoreOpts::from_path_ref(hello_name, commit.id))?;
-///
-/// # util::fs::remove_dir_all(base_dir)?;
-/// # Ok(())
-/// # }
+/// repositories::restore::restore(&repo, RestoreOpts::from_path_ref(hello_name, commit.id)).await?;
 /// ```
 pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), OxenError> {
     match repo.min_version() {

--- a/crates/lib/src/repositories/status.rs
+++ b/crates/lib/src/repositories/status.rs
@@ -19,14 +19,8 @@ use crate::model::{LocalRepository, StagedData};
 ///
 /// Empty Repository:
 ///
-/// ```
-/// use liboxen::command;
-/// # use liboxen::error::OxenError;
-/// # use std::path::Path;
-/// #
-///
-/// # fn main() -> Result<(), OxenError> {
-/// # liboxen::test::init_test_env();
+/// ```ignore
+/// use liboxen::repositories;
 ///
 /// let base_dir = Path::new("repo_dir_status_1");
 /// // Initialize empty repo
@@ -34,22 +28,12 @@ use crate::model::{LocalRepository, StagedData};
 /// // Get status on repo
 /// let status = repositories::status(&repo)?;
 /// assert!(status.is_clean());
-///
-/// # util::fs::remove_dir_all(base_dir)?;
-/// # Ok(())
-/// # }
 /// ```
 ///
 /// Repository with files
-/// ```
-/// use liboxen::command;
+/// ```ignore
+/// use liboxen::repositories;
 /// use liboxen::util;
-/// # use liboxen::error::OxenError;
-/// # use std::path::Path;
-/// #
-///
-/// # fn main() -> Result<(), OxenError> {
-/// # liboxen::test::init_test_env();
 ///
 /// let base_dir = Path::new("repo_dir_status_2");
 /// // Initialize empty repo
@@ -62,10 +46,6 @@ use crate::model::{LocalRepository, StagedData};
 /// // Get status on repo
 /// let status = repositories::status(&repo)?;
 /// assert_eq!(status.untracked_files.len(), 1);
-///
-/// # util::fs::remove_dir_all(base_dir)?;
-/// # Ok(())
-/// # }
 /// ```
 pub fn status(repo: &LocalRepository) -> Result<StagedData, OxenError> {
     match repo.min_version() {

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -103,13 +103,8 @@ pub fn get_by_name(
     workspace_name: impl AsRef<str>,
 ) -> Result<Option<Workspace>, OxenError> {
     let workspace_name = workspace_name.as_ref();
-    let workspaces = list(repo)?;
-    for workspace in workspaces {
-        if workspace.name == Some(workspace_name.to_string()) {
-            return Ok(Some(workspace));
-        }
-    }
-    Ok(None)
+    let workspace = iter_workspaces(repo)?.find(|ws| ws.name.as_deref() == Some(workspace_name));
+    Ok(workspace)
 }
 
 /// Creates a new workspace and saves it to the filesystem
@@ -251,36 +246,46 @@ fn check_existing_workspace_name(
     Ok(())
 }
 
-pub fn list(repo: &LocalRepository) -> Result<Vec<Workspace>, OxenError> {
+/// Returns a lazy iterator over all workspaces in the repository.
+/// Each workspace is loaded from the filesystem on demand.
+fn iter_workspaces(
+    repo: &LocalRepository,
+) -> Result<impl Iterator<Item = Workspace> + '_, OxenError> {
     let workspaces_dir = Workspace::workspaces_dir(repo);
-    log::debug!("workspace::list got workspaces_dir: {workspaces_dir:?}");
-    if !workspaces_dir.exists() {
-        // Return early if the workspaces directory does not exist
-        return Ok(vec![]);
-    }
+    log::debug!("workspace::iter_workspaces got workspaces_dir: {workspaces_dir:?}");
 
-    let workspaces_hashes = util::fs::list_dirs_in_dir(&workspaces_dir)
-        .map_err(|e| OxenError::basic_str(format!("Error listing workspace directories: {e}")))?;
+    let workspace_hashes = if workspaces_dir.exists() {
+        util::fs::list_dirs_in_dir(&workspaces_dir).map_err(|e| {
+            OxenError::basic_str(format!("Error listing workspace directories: {e}"))
+        })?
+    } else {
+        Vec::new()
+    };
 
-    log::debug!("workspace::list got {} workspaces", workspaces_hashes.len());
+    log::debug!(
+        "workspace::iter_workspaces got {} workspaces",
+        workspace_hashes.len()
+    );
 
-    let mut workspaces = Vec::new();
-    for workspace_hash in workspaces_hashes {
-        // Construct the Workspace and add it to the list
-        match get_by_dir(repo, &workspace_hash) {
-            Ok(Some(workspace)) => workspaces.push(workspace),
-            Ok(None) => {
-                log::debug!("Workspace not found: {workspace_hash:?}");
-                continue;
-            }
-            Err(e) => {
-                log::error!("Failed to list workspace: {e}");
-                continue;
-            }
-        }
-    }
+    Ok(workspace_hashes
+        .into_iter()
+        .filter_map(
+            move |workspace_hash| match get_by_dir(repo, &workspace_hash) {
+                Ok(Some(workspace)) => Some(workspace),
+                Ok(None) => {
+                    log::debug!("Workspace not found: {workspace_hash:?}");
+                    None
+                }
+                Err(e) => {
+                    log::error!("Failed to list workspace: {e}");
+                    None
+                }
+            },
+        ))
+}
 
-    Ok(workspaces)
+pub fn list(repo: &LocalRepository) -> Result<Vec<Workspace>, OxenError> {
+    iter_workspaces(repo).map(|iter| iter.collect())
 }
 
 pub fn get_non_editable_by_commit_id(

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -103,8 +103,14 @@ pub fn get_by_name(
     workspace_name: impl AsRef<str>,
 ) -> Result<Option<Workspace>, OxenError> {
     let workspace_name = workspace_name.as_ref();
-    let workspace = iter_workspaces(repo)?.find(|ws| ws.name.as_deref() == Some(workspace_name));
-    Ok(workspace)
+    for workspace in iter_workspaces(repo)? {
+        if let Some(workspace) = workspace?
+            && workspace.name.as_deref() == Some(workspace_name)
+        {
+            return Ok(Some(workspace));
+        }
+    }
+    Ok(None)
 }
 
 /// Creates a new workspace and saves it to the filesystem
@@ -250,7 +256,7 @@ fn check_existing_workspace_name(
 /// Each workspace is loaded from the filesystem on demand.
 fn iter_workspaces(
     repo: &LocalRepository,
-) -> Result<impl Iterator<Item = Workspace> + '_, OxenError> {
+) -> Result<impl Iterator<Item = Result<Option<Workspace>, OxenError>> + '_, OxenError> {
     let workspaces_dir = Workspace::workspaces_dir(repo);
     log::debug!("workspace::iter_workspaces got workspaces_dir: {workspaces_dir:?}");
 
@@ -269,23 +275,17 @@ fn iter_workspaces(
 
     Ok(workspace_hashes
         .into_iter()
-        .filter_map(
-            move |workspace_hash| match get_by_dir(repo, &workspace_hash) {
-                Ok(Some(workspace)) => Some(workspace),
-                Ok(None) => {
-                    log::debug!("Workspace not found: {workspace_hash:?}");
-                    None
-                }
-                Err(e) => {
-                    log::error!("Failed to list workspace: {e}");
-                    None
-                }
-            },
-        ))
+        .map(move |workspace_hash| get_by_dir(repo, &workspace_hash)))
 }
 
 pub fn list(repo: &LocalRepository) -> Result<Vec<Workspace>, OxenError> {
-    iter_workspaces(repo).map(|iter| iter.collect())
+    let mut workspaces = Vec::new();
+    for workspace in iter_workspaces(repo)? {
+        if let Some(workspace) = workspace? {
+            workspaces.push(workspace);
+        }
+    }
+    Ok(workspaces)
 }
 
 pub fn get_non_editable_by_commit_id(

--- a/crates/lib/src/resource.rs
+++ b/crates/lib/src/resource.rs
@@ -265,4 +265,116 @@ mod tests {
         })
         .await
     }
+
+    // -----------------------------------------------------------------------
+    // Precedence tests — lock in the commit > branch > workspace ordering
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_parse_resource_commit_wins_over_branch() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let commit = repositories::commits::head_commit(&repo)?;
+
+            // Create a branch whose name is exactly the commit id.
+            repositories::branches::create_from_head(&repo, &commit.id)?;
+
+            let path_str = format!("{}/some/file.txt", commit.id);
+            let path = Path::new(&path_str);
+            let resource =
+                resource::parse_resource_from_path(&repo, path)?.expect("should resolve");
+
+            // Must resolve as a commit, not the branch.
+            assert!(resource.commit.is_some(), "expected commit");
+            assert!(resource.branch.is_none(), "should not resolve as branch");
+            assert_eq!(resource.commit.unwrap().id, commit.id);
+            assert_eq!(resource.path, Path::new("some/file.txt"));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_parse_resource_branch_wins_over_workspace() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let commit = repositories::commits::head_commit(&repo)?;
+
+            // Create a branch and a workspace with the same name.
+            let shared_name = "shared-name";
+            let branch = repositories::branches::create_from_head(&repo, shared_name)?;
+            let _workspace = repositories::workspaces::create(&repo, &commit, shared_name, false)?;
+
+            let path_str = format!("{shared_name}/data.csv");
+            let path = Path::new(&path_str);
+            let resource =
+                resource::parse_resource_from_path(&repo, path)?.expect("should resolve");
+
+            // Must resolve as a branch, not the workspace.
+            assert!(resource.branch.is_some(), "expected branch");
+            assert!(
+                resource.workspace.is_none(),
+                "should not resolve as workspace"
+            );
+            assert_eq!(resource.branch.unwrap().name, branch.name);
+            assert_eq!(resource.path, Path::new("data.csv"));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_parse_resource_workspace_resolves_when_no_branch() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let commit = repositories::commits::head_commit(&repo)?;
+
+            let workspace = repositories::workspaces::create(&repo, &commit, "my-workspace", true)?;
+
+            let path_str = format!("{}/data.csv", workspace.id);
+            let path = Path::new(&path_str);
+            let resource =
+                resource::parse_resource_from_path(&repo, path)?.expect("should resolve");
+
+            assert!(resource.workspace.is_some(), "expected workspace");
+            assert!(resource.branch.is_none());
+            assert!(resource.commit.is_none());
+            assert_eq!(resource.workspace.unwrap().id, workspace.id);
+            assert_eq!(resource.path, Path::new("data.csv"));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_parse_resource_full_branch_path_match() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            // Branch name spans the entire path — no file portion.
+            let branch_name = "feature/v2/experiment";
+            let branch = repositories::branches::create_from_head(&repo, branch_name)?;
+
+            let path = Path::new(branch_name);
+            let resource =
+                resource::parse_resource_from_path(&repo, path)?.expect("should resolve");
+
+            assert!(resource.branch.is_some());
+            assert_eq!(resource.branch.unwrap().name, branch.name);
+            assert_eq!(resource.path, Path::new(""));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_parse_resource_returns_none_for_unknown() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let path = Path::new("nonexistent-thing/file.txt");
+            let result = resource::parse_resource_from_path(&repo, path)?;
+            assert!(result.is_none(), "unknown identifier should return None");
+
+            Ok(())
+        })
+        .await
+    }
 }

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -199,7 +199,7 @@ pub async fn add_n_files_m_dirs(
 /// This function will create a directory with a uniq name
 /// and take care of cleaning it up afterwards
 ///
-/// ```
+/// ```ignore
 /// test::run_empty_dir_test(|repo_dir| {
 ///   // do your fancy testing here
 ///   assert!(true);


### PR DESCRIPTION
To give a little more color and example of what I was seeing, I recorded a loom: https://www.loom.com/share/b4427df179714ccca91e598d864368ea

@malcolmgreaves I know you had a PR improving the speed of looking up workspaces, which I think is the real fix to this problem, but this at least will help us in the short term prefer branches over workspaces.

The main problem is when you hit a URL like

`/api/repos/{namespace}/{repo_name}/dir/{revision}/{path}` 

or for example 

`/api/repos/691c9e51-2f5b-4560-b5a9-390baad2ee8c/381e0d28-9a3e-4f5c-9989-ae1db9c7cdfb/dir/main/uploads/`

The order of lookup to figure out the `revision` was:

1) Commit?
2) Workspace?
3) Branch?

And since the workspace lookup is inefficient, when you have a repo with a lot of workspaces, any time we request a resource on a branch, it would make the list workspace call, check if there is a workspace, and slow everything down.

So for now I switched it to look up this order:

1) Commit?
2) Branch?
3) Workspace?

Which will save us on the branch case, but still be slow for actual workspace lookups, which we can cleanup in a follow up PR.
