### PR TITLE
Doc & simplify OxenError; using .ok_or_else(|| OxenError); not-found + conflict HTTP

### DIFF
--- a/crates/cli/src/cmd/branch.rs
+++ b/crates/cli/src/cmd/branch.rs
@@ -201,7 +201,7 @@ impl BranchCmd {
 
         let remote = repo
             .get_remote(remote_name)
-            .ok_or(OxenError::remote_not_set(remote_name))?;
+            .ok_or_else(|| OxenError::RemoteNotSet(remote_name.to_string()))?;
         let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
 
         let branches = api::client::branches::list(&remote_repo).await?;

--- a/crates/cli/src/cmd/branch/unlock.rs
+++ b/crates/cli/src/cmd/branch/unlock.rs
@@ -47,7 +47,7 @@ impl RunCmd for BranchUnlockCmd {
         // Get the remote repo
         let remote = repository
             .get_remote(remote_name)
-            .ok_or(OxenError::remote_not_set(remote_name))?;
+            .ok_or_else(|| OxenError::RemoteNotSet(remote_name.clone()))?;
         let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
 
         // Unlock the branch

--- a/crates/cli/src/cmd/migrate.rs
+++ b/crates/cli/src/cmd/migrate.rs
@@ -64,9 +64,7 @@ impl RunCmd for MigrateCmd {
         {
             let migration = migrations
                 .get(migration)
-                .ok_or(OxenError::basic_str(format!(
-                    "Unknown migration: {migration}"
-                )))?;
+                .ok_or_else(|| OxenError::basic_str(format!("Unknown migration: {migration}")))?;
             let path_str = sub_matches.get_one::<String>("PATH").expect("required");
             let path = Path::new(path_str);
 

--- a/crates/cli/src/cmd/prune.rs
+++ b/crates/cli/src/cmd/prune.rs
@@ -55,7 +55,7 @@ impl RunCmd for PruneCmd {
             // Remote prune
             let remote = repository
                 .get_remote(remote_name)
-                .ok_or_else(|| OxenError::remote_not_set(remote_name))?;
+                .ok_or_else(|| OxenError::RemoteNotSet(remote_name.to_string()))?;
             let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
 
             if dry_run {

--- a/crates/cli/src/cmd/workspace/clear.rs
+++ b/crates/cli/src/cmd/workspace/clear.rs
@@ -32,7 +32,7 @@ impl RunCmd for WorkspaceClearCmd {
             Some(name) => {
                 let remote = repository
                     .get_remote(name)
-                    .ok_or(OxenError::remote_not_set(name))?;
+                    .ok_or_else(|| OxenError::RemoteNotSet(name.clone()))?;
                 api::client::repositories::get_by_remote(&remote).await?
             }
             None => api::client::repositories::get_default_remote(&repository).await?,

--- a/crates/cli/src/cmd/workspace/list.rs
+++ b/crates/cli/src/cmd/workspace/list.rs
@@ -31,7 +31,7 @@ impl RunCmd for WorkspaceListCmd {
             Some(name) => {
                 let remote = repository
                     .get_remote(name)
-                    .ok_or(OxenError::remote_not_set(name))?;
+                    .ok_or_else(|| OxenError::RemoteNotSet(name.clone()))?;
                 api::client::repositories::get_by_remote(&remote).await?
             }
             None => api::client::repositories::get_default_remote(&repository).await?,

--- a/crates/lib/src/api/client/branches.rs
+++ b/crates/lib/src/api/client/branches.rs
@@ -164,7 +164,7 @@ pub async fn delete_remote(
 ) -> Result<Branch, OxenError> {
     let remote = repo
         .get_remote(&remote)
-        .ok_or_else(|| OxenError::remote_not_set(remote))?;
+        .ok_or_else(|| OxenError::RemoteNotSet(remote.as_ref().to_string()))?;
     let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
     let branch = api::client::branches::get_by_name(&remote_repo, &branch_name)
         .await?

--- a/crates/lib/src/api/client/repositories.rs
+++ b/crates/lib/src/api/client/repositories.rs
@@ -40,7 +40,7 @@ impl fmt::Display for ActionEventState {
 pub async fn get_default_remote(repo: &LocalRepository) -> Result<RemoteRepository, OxenError> {
     let remote = repo
         .get_remote(DEFAULT_REMOTE_NAME)
-        .ok_or(OxenError::remote_not_set(DEFAULT_REMOTE_NAME))?;
+        .ok_or_else(|| OxenError::RemoteNotSet(DEFAULT_REMOTE_NAME.to_string()))?;
     api::client::repositories::get_by_remote(&remote).await
 }
 
@@ -113,7 +113,7 @@ pub async fn get_by_remote(remote: &Remote) -> Result<RemoteRepository, OxenErro
     let res = client.get(&url).send().await?;
     log::debug!("get_by_remote status: {}", res.status());
     if 404 == res.status() {
-        return Err(OxenError::remote_repo_not_found(&remote.url));
+        return Err(OxenError::RemoteRepoNotFound(remote.url.as_str().into()));
     }
 
     let body = client::parse_json_body(&url, res).await?;

--- a/crates/lib/src/command/df.rs
+++ b/crates/lib/src/command/df.rs
@@ -34,9 +34,8 @@ pub async fn df_revision(
     revision: impl AsRef<str>,
     opts: DFOpts,
 ) -> Result<(), OxenError> {
-    let commit = repositories::revisions::get(repo, &revision)?.ok_or(OxenError::basic_str(
-        format!("Revision {} not found", revision.as_ref()),
-    ))?;
+    let commit = repositories::revisions::get(repo, &revision)?
+        .ok_or_else(|| OxenError::basic_str(format!("Revision {} not found", revision.as_ref())))?;
     let path = input.as_ref();
     let Some(root) = repositories::tree::get_node_by_path_with_children(repo, &commit, path)?
     else {

--- a/crates/lib/src/core/df/tabular.rs
+++ b/crates/lib/src/core/df/tabular.rs
@@ -72,7 +72,7 @@ fn read_df_jsonl(path: impl AsRef<Path>) -> Result<LazyFrame, OxenError> {
     let path = path
         .as_ref()
         .to_str()
-        .ok_or(OxenError::basic_str("Could not convert path to string"))?;
+        .ok_or_else(|| OxenError::basic_str("Could not convert path to string"))?;
     LazyJsonLineReader::new(path)
         .with_infer_schema_length(Some(NonZeroUsize::new(10000).unwrap()))
         .finish()
@@ -149,7 +149,7 @@ pub fn scan_df_jsonl(path: impl AsRef<Path>, total_rows: usize) -> Result<LazyFr
     let path = path
         .as_ref()
         .to_str()
-        .ok_or(OxenError::basic_str("Could not convert path to string"))?;
+        .ok_or_else(|| OxenError::basic_str("Could not convert path to string"))?;
     LazyJsonLineReader::new(path)
         .with_infer_schema_length(Some(NonZeroUsize::new(10000).unwrap()))
         .with_n_rows(Some(total_rows))

--- a/crates/lib/src/core/index/schema_reader/objects_schema_reader.rs
+++ b/crates/lib/src/core/index/schema_reader/objects_schema_reader.rs
@@ -105,19 +105,19 @@ impl ObjectsSchemaReader {
         let commit =
             commit_reader
                 .get_commit_by_id(&self.commit_id)?
-                .ok_or(OxenError::basic_str(format!(
+                .ok_or_else(|| OxenError::basic_str(format!(
                     "Could not find commit {}",
                     self.commit_id
                 )))?;
 
         let root_hash = commit
             .root_hash
-            .ok_or(format!("Root hash not found for commit {}", self.commit_id))?;
+            .ok_or_else(|| format!("Root hash not found for commit {}", self.commit_id))?;
 
         let root_node: TreeObject =
             self.object_reader
                 .get_dir(&root_hash)?
-                .ok_or(OxenError::basic_str(
+                .ok_or_else(|| OxenError::basic_str(
                     "Could not find root node in object db",
                 ))?;
 

--- a/crates/lib/src/core/v_latest/branches.rs
+++ b/crates/lib/src/core/v_latest/branches.rs
@@ -145,10 +145,10 @@ pub async fn checkout(
 ) -> Result<(), OxenError> {
     log::debug!("checkout {branch_name}");
     let branch = repositories::branches::get_by_name(repo, branch_name)?
-        .ok_or(OxenError::local_branch_not_found(branch_name))?;
+        .ok_or_else(|| OxenError::local_branch_not_found(branch_name))?;
 
     let commit = repositories::commits::get_by_id(repo, &branch.commit_id)?
-        .ok_or(OxenError::commit_id_does_not_exist(&branch.commit_id))?;
+        .ok_or_else(|| OxenError::commit_id_does_not_exist(&branch.commit_id))?;
 
     checkout_commit(repo, &commit, from_commit).await?;
 

--- a/crates/lib/src/core/v_latest/commits.rs
+++ b/crates/lib/src/core/v_latest/commits.rs
@@ -147,14 +147,14 @@ pub fn latest_commit(repo: &LocalRepository) -> Result<Commit, OxenError> {
             latest_commit = Some(commit);
         }
     }
-    latest_commit.ok_or(OxenError::no_commits_found())
+    latest_commit.ok_or(OxenError::NoCommitsFound)
 }
 
 fn head_commit_id(repo: &LocalRepository) -> Result<MerkleHash, OxenError> {
     let commit_id = with_ref_manager(repo, |manager| manager.head_commit_id())?;
     match commit_id {
         Some(commit_id) => Ok(commit_id.parse()?),
-        None => Err(OxenError::head_not_found()),
+        None => Err(OxenError::HeadNotFound),
     }
 }
 
@@ -173,10 +173,11 @@ pub fn head_commit(repo: &LocalRepository) -> Result<Commit, OxenError> {
     let head_commit_id = head_commit_id(repo)?;
     log::debug!("head_commit: head_commit_id: {head_commit_id:?}");
 
-    let node =
-        repositories::tree::get_node_by_id(repo, &head_commit_id)?.ok_or(OxenError::basic_str(
-            format!("Merkle tree node not found for head commit: '{head_commit_id}'"),
-        ))?;
+    let node = repositories::tree::get_node_by_id(repo, &head_commit_id)?.ok_or_else(|| {
+        OxenError::basic_str(format!(
+            "Merkle tree node not found for head commit: '{head_commit_id}'"
+        ))
+    })?;
     let commit = node.commit()?;
     Ok(commit.to_commit())
 }
@@ -257,15 +258,17 @@ pub fn create_empty_commit(
 ) -> Result<Commit, OxenError> {
     let branch_name = branch_name.as_ref();
     let Some(existing_commit) = repositories::revisions::get(repo, branch_name)? else {
-        return Err(OxenError::revision_not_found(branch_name.into()));
+        return Err(OxenError::RevisionNotFound(branch_name.into()));
     };
     let existing_commit_id = existing_commit.id.parse()?;
     let existing_node =
-        repositories::tree::get_node_by_id_with_children(repo, &existing_commit_id)?.ok_or(
-            OxenError::basic_str(format!(
-                "Merkle tree node not found for commit: '{}'",
-                existing_commit.id
-            )),
+        repositories::tree::get_node_by_id_with_children(repo, &existing_commit_id)?.ok_or_else(
+            || {
+                OxenError::basic_str(format!(
+                    "Merkle tree node not found for commit: '{}'",
+                    existing_commit.id
+                ))
+            },
         )?;
     let timestamp = OffsetDateTime::now_utc();
     let commit_node = CommitNode::new(
@@ -677,9 +680,9 @@ pub fn list_from_paginated_impl(
         let base = split[0];
         let head = split[1];
         let base_commit = repositories::commits::get_by_id(repo, base)?
-            .ok_or(OxenError::revision_not_found(base.into()))?;
+            .ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
         let head_commit = repositories::commits::get_by_id(repo, head)?
-            .ok_or(OxenError::revision_not_found(head.into()))?;
+            .ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
 
         let (commits, total_count) =
             list_recursive_paginated(repo, head_commit, skip, limit, Some(&base_commit), None)?;
@@ -791,7 +794,7 @@ pub fn count_from(
     let revision = revision.as_ref();
 
     let commit = repositories::revisions::get(repo, revision)?
-        .ok_or_else(|| OxenError::revision_not_found(revision.into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(revision.into()))?;
 
     let db = open_commit_count_db(repo)?;
 
@@ -839,7 +842,7 @@ pub fn search_entries(
 
     let mut results = HashSet::new();
     let tree = repositories::tree::get_root_with_children(repo, commit)?
-        .ok_or(OxenError::basic_str("Root not found"))?;
+        .ok_or_else(|| OxenError::basic_str("Root not found"))?;
     let (files, _) = repositories::tree::list_files_and_dirs(&tree)?;
     for file in files {
         let path = file.dir.join(file.file_node.name());
@@ -947,9 +950,9 @@ pub fn list_by_path_from_paginated(
 
     // Check if the path is a directory or file
     let _perf_node = crate::perf_guard!("core::commits::get_node_by_path");
-    let node = repositories::tree::get_node_by_path(repo, commit, path)?.ok_or(
-        OxenError::basic_str(format!("Merkle tree node not found for path: {path:?}")),
-    )?;
+    let node = repositories::tree::get_node_by_path(repo, commit, path)?.ok_or_else(|| {
+        OxenError::basic_str(format!("Merkle tree node not found for path: {path:?}"))
+    })?;
     let last_commit_id = match &node.node {
         EMerkleTreeNode::File(file_node) => file_node.last_commit_id(),
         EMerkleTreeNode::Directory(dir_node) => dir_node.last_commit_id(),

--- a/crates/lib/src/core/v_latest/data_frames.rs
+++ b/crates/lib/src/core/v_latest/data_frames.rs
@@ -29,7 +29,7 @@ pub async fn get_slice(
         None => resource
             .commit
             .clone()
-            .ok_or(OxenError::basic_str("Commit not found"))?,
+            .ok_or_else(|| OxenError::basic_str("Commit not found"))?,
     };
 
     let (staged_repo, base_repo) = match workspace {
@@ -52,16 +52,16 @@ pub async fn get_slice(
                 // Fall back to commit tree using workspace's commit
                 let commit = &ws.commit;
                 repositories::tree::get_file_by_path(base_repo, commit, &path)?
-                    .ok_or(OxenError::path_does_not_exist(path.as_ref()))?
+                    .ok_or_else(|| OxenError::path_does_not_exist(path.as_ref()))?
             }
         }
         None => {
             let commit = resource
                 .commit
                 .as_ref()
-                .ok_or(OxenError::basic_str("Commit not found"))?;
+                .ok_or_else(|| OxenError::basic_str("Commit not found"))?;
             repositories::tree::get_file_by_path(base_repo, commit, &path)?
-                .ok_or(OxenError::path_does_not_exist(path.as_ref()))?
+                .ok_or_else(|| OxenError::path_does_not_exist(path.as_ref()))?
         }
     };
 

--- a/crates/lib/src/core/v_latest/entries.rs
+++ b/crates/lib/src/core/v_latest/entries.rs
@@ -72,19 +72,19 @@ pub fn list_directory_with_depth(
     let commit = parsed_resource
         .commit
         .clone()
-        .ok_or(OxenError::revision_not_found(revision.into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(revision.into()))?;
 
     log::debug!("list_directory commit {commit}");
 
     let _perf_get_dir = crate::perf_guard!("core::entries::get_dir_with_children");
     let dir = repositories::tree::get_dir_with_children(repo, &commit, directory, None)?
-        .ok_or(OxenError::resource_not_found(directory.to_str().unwrap()))?;
+        .ok_or_else(|| OxenError::resource_not_found(directory.to_string_lossy()))?;
     drop(_perf_get_dir);
 
     log::debug!("list_directory dir {dir}");
 
     let EMerkleTreeNode::Directory(dir_node) = &dir.node else {
-        return Err(OxenError::resource_not_found(directory.to_str().unwrap()));
+        return Err(OxenError::resource_not_found(directory.to_string_lossy()));
     };
 
     log::debug!("list_directory dir_node {dir_node}");
@@ -155,9 +155,7 @@ pub fn get_meta_entry(
     let commit = parsed_resource
         .commit
         .clone()
-        .ok_or(OxenError::parsed_resource_not_found(
-            parsed_resource.clone(),
-        ))?;
+        .ok_or_else(|| OxenError::parsed_resource_not_found(parsed_resource.clone()))?;
     log::debug!("get_meta_entry path: {path:?} commit: {commit}");
     let node = repositories::tree::get_dir_without_children(repo, &commit, path, None)?;
     log::debug!("get_meta_entry node: {node:?}");
@@ -301,9 +299,10 @@ fn dir_node_to_metadata_entry(
         found_commits.entry(*dir_node.last_commit_id())
     {
         let _perf_commit = crate::perf_guard!("core::entries::get_commit_by_hash");
-        let commit = repositories::commits::get_by_hash(repo, dir_node.last_commit_id())?.ok_or(
-            OxenError::commit_id_does_not_exist(dir_node.last_commit_id().to_string()),
-        )?;
+        let commit = repositories::commits::get_by_hash(repo, dir_node.last_commit_id())?
+            .ok_or_else(|| {
+                OxenError::commit_id_does_not_exist(dir_node.last_commit_id().to_string())
+            })?;
         e.insert(commit);
     }
 
@@ -344,9 +343,10 @@ fn file_node_to_metadata_entry(
         found_commits.entry(*file_node.last_commit_id())
     {
         let _perf_commit = crate::perf_guard!("core::entries::get_commit_by_hash");
-        let commit = repositories::commits::get_by_hash(repo, file_node.last_commit_id())?.ok_or(
-            OxenError::commit_id_does_not_exist(file_node.last_commit_id().to_string()),
-        )?;
+        let commit = repositories::commits::get_by_hash(repo, file_node.last_commit_id())?
+            .ok_or_else(|| {
+                OxenError::commit_id_does_not_exist(file_node.last_commit_id().to_string())
+            })?;
         e.insert(commit);
     }
 
@@ -537,7 +537,7 @@ pub fn list_for_commit(
 
 pub fn update_metadata(repo: &LocalRepository, revision: impl AsRef<str>) -> Result<(), OxenError> {
     let commit = repositories::revisions::get(repo, revision.as_ref())?
-        .ok_or_else(|| OxenError::revision_not_found(revision.as_ref().to_string().into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(revision.as_ref().to_string().into()))?;
     let tree: CommitMerkleTree = CommitMerkleTree::from_commit(repo, &commit)?;
     let mut node = tree.root;
 

--- a/crates/lib/src/core/v_latest/fetch.rs
+++ b/crates/lib/src/core/v_latest/fetch.rs
@@ -116,7 +116,7 @@ pub async fn fetch_remote_branch(
     } else {
         let hash = remote_branch.commit_id.parse()?;
         let commit_node = repositories::tree::get_node_by_id(repo, &hash)?
-            .ok_or(OxenError::basic_str("Commit node not found"))?;
+            .ok_or_else(|| OxenError::basic_str("Commit node not found"))?;
 
         if !fetch_opts.missing_files && core::commit_sync_status::commit_is_synced(repo, &hash) {
             HashSet::new()

--- a/crates/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/crates/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -66,10 +66,12 @@ impl CommitMerkleTree {
         // This debug log is to help make sure we don't load the tree too many times
         // if you see it in the logs being called too much, it could be why the code is slow.
         log::debug!("Load tree from commit: {} in repo: {:?}", commit, repo.path);
-        let root =
-            CommitMerkleTree::root_with_children(repo, commit)?.ok_or(OxenError::basic_str(
-                format!("Merkle tree hash not found for commit: '{}'", commit.id),
-            ))?;
+        let root = CommitMerkleTree::root_with_children(repo, commit)?.ok_or_else(|| {
+            OxenError::basic_str(format!(
+                "Merkle tree hash not found for commit: '{}'",
+                commit.id
+            ))
+        })?;
 
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
         Ok(Self { root, dir_hashes })
@@ -84,12 +86,13 @@ impl CommitMerkleTree {
         // This debug log is to help make sure we don't load the tree too many times
         // if you see it in the logs being called too much, it could be why the code is slow.
         log::debug!("Load tree from commit: {} in repo: {:?}", commit, repo.path);
-        let node = CommitMerkleTree::read_from_path(repo, commit, path, load_recursive)?.ok_or(
-            OxenError::basic_str(format!(
-                "Merkle tree hash not found for commit: '{}'",
-                commit.id
-            )),
-        )?;
+        let node = CommitMerkleTree::read_from_path(repo, commit, path, load_recursive)?
+            .ok_or_else(|| {
+                OxenError::basic_str(format!(
+                    "Merkle tree hash not found for commit: '{}'",
+                    commit.id
+                ))
+            })?;
 
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
 
@@ -446,13 +449,13 @@ impl CommitMerkleTree {
         } else {
             // We are skipping to a file in the tree using the dir_hashes db
             log::debug!("Look up file 📄 {node_path:?}");
-            CommitMerkleTree::read_file(repo, &dir_hashes, &node_path)?.ok_or(
+            CommitMerkleTree::read_file(repo, &dir_hashes, &node_path)?.ok_or_else(|| {
                 OxenError::basic_str(format!(
                     "Merkle tree hash not found for file: '{}' in commit: '{}'",
                     node_path.to_str().unwrap(),
                     commit.id
-                )),
-            )?
+                ))
+            })?
         };
 
         Ok(Some(root))
@@ -495,13 +498,13 @@ impl CommitMerkleTree {
         } else {
             // We are skipping to a file in the tree using the dir_hashes db
             log::debug!("Look up file 📄 {node_path:?}");
-            CommitMerkleTree::read_file(repo, &dir_hashes, &node_path)?.ok_or(
+            CommitMerkleTree::read_file(repo, &dir_hashes, &node_path)?.ok_or_else(|| {
                 OxenError::basic_str(format!(
                     "Merkle tree hash not found for file: '{}' in commit: '{}'",
                     node_path.to_str().unwrap(),
                     commit.id
-                )),
-            )?
+                ))
+            })?
         };
 
         Ok(Some(root))
@@ -544,13 +547,13 @@ impl CommitMerkleTree {
         } else {
             // We are skipping to a file in the tree using the dir_hashes db
             log::debug!("Look up file 📄 {node_path:?}");
-            CommitMerkleTree::read_file(repo, &dir_hashes, &node_path)?.ok_or(
+            CommitMerkleTree::read_file(repo, &dir_hashes, &node_path)?.ok_or_else(|| {
                 OxenError::basic_str(format!(
                     "Merkle tree hash not found for file: '{}' in commit: '{}'",
                     node_path.to_str().unwrap(),
                     commit.id
-                )),
-            )?
+                ))
+            })?
         };
 
         Ok(Some(root))
@@ -697,12 +700,9 @@ impl CommitMerkleTree {
         path: impl AsRef<Path>,
     ) -> Result<HashSet<MerkleTreeNode>, OxenError> {
         let path = path.as_ref();
-        let node = self
-            .root
-            .get_by_path(path)?
-            .ok_or(OxenError::basic_str(format!(
-                "Merkle tree hash not found for parent: {path:?}"
-            )))?;
+        let node = self.root.get_by_path(path)?.ok_or_else(|| {
+            OxenError::basic_str(format!("Merkle tree hash not found for parent: {path:?}"))
+        })?;
         let mut children = HashSet::new();
         for child in &node.children {
             children.extend(child.children.iter().cloned());

--- a/crates/lib/src/core/v_latest/index/file_chunker.rs
+++ b/crates/lib/src/core/v_latest/index/file_chunker.rs
@@ -334,7 +334,7 @@ impl ChunkShardManager {
         let shard_idx = self
             .db
             .get(hash)?
-            .ok_or(OxenError::basic_str("Chunk not found"))?;
+            .ok_or_else(|| OxenError::basic_str("Chunk not found"))?;
         log::debug!("Reading chunk from shard: [{shard_idx}] for hash: {hash}");
         // Cache the current shard file for faster reads of the same shard
         if shard_idx as i32 != self.current_idx {

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -217,7 +217,7 @@ pub async fn merge(
     let branch_name = branch_name.as_ref();
 
     let merge_branch = repositories::branches::get_by_name(repo, branch_name)?
-        .ok_or(OxenError::local_branch_not_found(branch_name))?;
+        .ok_or_else(|| OxenError::local_branch_not_found(branch_name))?;
 
     let base_commit = repositories::commits::head_commit(repo)?;
     let merge_commit = get_commit_or_head(repo, Some(merge_branch.commit_id.clone()))?;
@@ -297,7 +297,7 @@ pub fn find_merge_commits<S: AsRef<str>>(
     let branch_name = branch_name.as_ref();
 
     let current_branch = repositories::branches::current_branch(repo)?
-        .ok_or(OxenError::basic_str("No current branch"))?;
+        .ok_or_else(|| OxenError::basic_str("No current branch"))?;
 
     let head_commit =
         repositories::commits::get_commit_or_head(repo, Some(current_branch.name.clone()))?;
@@ -396,7 +396,7 @@ pub fn lowest_common_ancestor(
 ) -> Result<Option<Commit>, OxenError> {
     let branch_name = branch_name.as_ref();
     let current_branch = repositories::branches::current_branch(repo)?
-        .ok_or(OxenError::basic_str("No current branch"))?;
+        .ok_or_else(|| OxenError::basic_str("No current branch"))?;
 
     let base_commit =
         repositories::commits::get_commit_or_head(repo, Some(current_branch.name.clone()))?;

--- a/crates/lib/src/core/v_latest/metadata.rs
+++ b/crates/lib/src/core/v_latest/metadata.rs
@@ -22,7 +22,7 @@ pub fn get_cli(
     let entry_path = entry_path.as_ref();
     let base_name = entry_path
         .file_name()
-        .ok_or(OxenError::file_has_no_name(path))?;
+        .ok_or_else(|| OxenError::file_has_no_name(path))?;
     let size = repositories::metadata::get_file_size(path)?;
     let hash = util::hasher::hash_file_contents(path)?;
     let mime_type = util::fs::file_mime_type(path);

--- a/crates/lib/src/core/v_latest/pull.rs
+++ b/crates/lib/src/core/v_latest/pull.rs
@@ -35,7 +35,7 @@ pub async fn pull_remote_branch(
 
     let remote = repo
         .get_remote(remote)
-        .ok_or(OxenError::remote_not_set(remote))?;
+        .ok_or_else(|| OxenError::RemoteNotSet(remote.clone()))?;
 
     let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
 
@@ -47,9 +47,8 @@ pub async fn pull_remote_branch(
     fetch_opts.should_update_branch_head = false;
     let remote_branch = fetch::fetch_remote_branch(repo, &remote_repo, &fetch_opts).await?;
 
-    let new_head_commit = repositories::revisions::get(repo, &remote_branch.commit_id)?.ok_or(
-        OxenError::revision_not_found(remote_branch.commit_id.to_owned().into()),
-    )?;
+    let new_head_commit = repositories::revisions::get(repo, &remote_branch.commit_id)?
+        .ok_or_else(|| OxenError::RevisionNotFound(remote_branch.commit_id.to_owned().into()))?;
 
     match previous_head_commit {
         Some(previous_head_commit) => {
@@ -72,8 +71,8 @@ pub async fn pull_remote_branch(
                     }
                     Ok(None) => {
                         // Merge conflict, keep the previous commit
-                        return Err(OxenError::merge_conflict(
-                            "There was a merge conflict, please resolve it before pulling",
+                        return Err(OxenError::UpstreamMergeConflict(
+                            "There was a merge conflict, please resolve it before pulling.".into(),
                         ));
                     }
                     Err(e) => return Err(e),

--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -51,7 +51,7 @@ pub async fn push_remote_branch(
 
     let remote = repo
         .get_remote(&opts.remote)
-        .ok_or_else(|| OxenError::remote_not_set(&opts.remote))?;
+        .ok_or_else(|| OxenError::RemoteNotSet(opts.remote.to_string()))?;
 
     let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
 
@@ -72,7 +72,7 @@ async fn push_local_branch_to_remote_repo(
 ) -> Result<(), OxenError> {
     // Get the commit from the branch
     let Some(commit) = repositories::commits::get_by_id(repo, &local_branch.commit_id)? else {
-        return Err(OxenError::revision_not_found(
+        return Err(OxenError::RevisionNotFound(
             local_branch.commit_id.clone().into(),
         ));
     };
@@ -136,7 +136,7 @@ async fn push_to_existing_branch(
 
                 let latest_remote_commit =
                     repositories::commits::get_by_id(repo, &remote_branch.commit_id)?.ok_or_else(
-                        || OxenError::revision_not_found(remote_branch.commit_id.clone().into()),
+                        || OxenError::RevisionNotFound(remote_branch.commit_id.clone().into()),
                     )?;
 
                 let mut commits =

--- a/crates/lib/src/core/v_latest/revisions.rs
+++ b/crates/lib/src/core/v_latest/revisions.rs
@@ -12,10 +12,10 @@ pub async fn get_version_file_from_commit_id(
     let commit_id = commit_id.as_ref();
     let path = path.as_ref();
     let commit = repositories::commits::get_by_id(repo, commit_id)?
-        .ok_or(OxenError::commit_id_does_not_exist(commit_id))?;
+        .ok_or_else(|| OxenError::commit_id_does_not_exist(commit_id))?;
 
     let file_node = repositories::tree::get_file_by_path(repo, &commit, path)?
-        .ok_or(OxenError::entry_does_not_exist_in_commit(path, commit_id))?;
+        .ok_or_else(|| OxenError::entry_does_not_exist_in_commit(path, commit_id))?;
 
     let version_store = repo.version_store()?;
     let hash = file_node.hash().to_string();

--- a/crates/lib/src/core/v_latest/workspaces/commit.rs
+++ b/crates/lib/src/core/v_latest/workspaces/commit.rs
@@ -61,7 +61,7 @@ pub async fn commit(
 
         let conflicts = list_conflicts(workspace, &dir_entries, &branch)?;
         if !conflicts.is_empty() {
-            return Err(OxenError::workspace_behind(workspace));
+            return Err(OxenError::WorkspaceBehind(Box::new(workspace.clone())));
         }
 
         let dir_entries = export_tabular_data_frames(workspace, dir_entries).await?;
@@ -110,16 +110,14 @@ pub fn mergeability(
     let branch_name = branch_name.as_ref();
     let Some(branch) = repositories::branches::get_by_name(&workspace.base_repo, branch_name)?
     else {
-        return Err(OxenError::revision_not_found(
-            branch_name.to_string().into(),
-        ));
+        return Err(OxenError::BranchNotFound(branch_name.into()));
     };
 
     let base = &workspace.commit;
     let Some(head) = repositories::commits::get_by_id(&workspace.base_repo, &branch.commit_id)?
     else {
-        return Err(OxenError::revision_not_found(
-            branch.commit_id.clone().into(),
+        return Err(OxenError::RevisionNotFound(
+            branch.commit_id.as_str().into(),
         ));
     };
 
@@ -174,8 +172,8 @@ fn list_conflicts(
     let Some(branch_commit) =
         repositories::commits::get_by_id(&workspace.base_repo, &branch.commit_id)?
     else {
-        return Err(OxenError::revision_not_found(
-            branch.commit_id.clone().into(),
+        return Err(OxenError::RevisionNotFound(
+            branch.commit_id.as_str().into(),
         ));
     };
     log::debug!(
@@ -195,22 +193,22 @@ fn list_conflicts(
     let Some(branch_commit) =
         repositories::commits::get_by_id(&workspace.base_repo, &branch.commit_id)?
     else {
-        return Err(OxenError::revision_not_found(
-            branch.commit_id.clone().into(),
+        return Err(OxenError::RevisionNotFound(
+            branch.commit_id.as_str().into(),
         ));
     };
     let Some(branch_tree) =
         repositories::tree::get_root_with_children(&workspace.base_repo, &branch_commit)?
     else {
-        return Err(OxenError::revision_not_found(
-            branch.commit_id.clone().into(),
+        return Err(OxenError::RevisionNotFound(
+            branch.commit_id.as_str().into(),
         ));
     };
     let Some(workspace_tree) =
         repositories::tree::get_root_with_children(&workspace.base_repo, workspace_commit)?
     else {
-        return Err(OxenError::revision_not_found(
-            workspace.commit.id.clone().into(),
+        return Err(OxenError::RevisionNotFound(
+            workspace.commit.id.as_str().into(),
         ));
     };
 

--- a/crates/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -31,7 +31,7 @@ pub fn is_queryable_data_frame_indexed(
     match get_queryable_data_frame_workspace(repo, path, commit) {
         Ok(_workspace) => Ok(true),
         Err(e) => match e {
-            OxenError::QueryableWorkspaceNotFound() => Ok(false),
+            OxenError::QueryableWorkspaceNotFound => Ok(false),
             _ => Err(e),
         },
     }
@@ -47,7 +47,7 @@ pub fn is_queryable_data_frame_indexed_from_file_node(
     {
         Ok(_workspace) => Ok(true),
         Err(e) => match e {
-            OxenError::QueryableWorkspaceNotFound() => Ok(false),
+            OxenError::QueryableWorkspaceNotFound => Ok(false),
             _ => Err(e),
         },
     }
@@ -78,7 +78,7 @@ pub fn get_queryable_data_frame_workspace_from_file_node(
         }
     }
 
-    Err(OxenError::QueryableWorkspaceNotFound())
+    Err(OxenError::QueryableWorkspaceNotFound)
 }
 
 pub fn get_queryable_data_frame_workspace(
@@ -89,7 +89,7 @@ pub fn get_queryable_data_frame_workspace(
     let path = path.as_ref();
     log::debug!("get_queryable_data_frame_workspace path: {path:?}");
     let file_node = repositories::tree::get_file_by_path(repo, commit, path)?
-        .ok_or(OxenError::path_does_not_exist(path))?;
+        .ok_or_else(|| OxenError::path_does_not_exist(path))?;
     if *file_node.data_type() != EntryDataType::Tabular {
         return Err(OxenError::basic_str(
             "File format not supported, must be tabular.",
@@ -102,7 +102,7 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     // Is tabular just looks at the file extensions
     let file_node =
         repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
-            .ok_or(OxenError::path_does_not_exist(path))?;
+            .ok_or_else(|| OxenError::path_does_not_exist(path))?;
     if *file_node.data_type() != EntryDataType::Tabular {
         return Err(OxenError::basic_str(
             "File format not supported, must be tabular.",
@@ -242,9 +242,8 @@ pub async fn rename(
         log::debug!("rename: staged_entry after add: {staged_entry:?}");
     }
 
-    let mut new_staged_entry = staged_entry.ok_or(OxenError::basic_str(format!(
-        "rename: staged entry not found: {path:?}"
-    )))?;
+    let mut new_staged_entry = staged_entry
+        .ok_or_else(|| OxenError::basic_str(format!("rename: staged entry not found: {path:?}")))?;
 
     // Update the file name in the staged entry
     if let EMerkleTreeNode::File(file) = &mut new_staged_entry.node.node {

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/columns.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/columns.rs
@@ -71,9 +71,9 @@ pub fn delete(
             let column_data_type =
                 table_schema
                     .get_field(&column_to_delete.name)
-                    .ok_or(OxenError::Basic(
-                        "A column with the given name does not exist".into(),
-                    ))?;
+                    .ok_or_else(|| {
+                        OxenError::Basic("A column with the given name does not exist".into())
+                    })?;
 
             let result = columns::delete_column(conn, column_to_delete)?;
             Ok((result, column_data_type.to_owned()))
@@ -152,7 +152,7 @@ pub async fn update(
     repositories::workspaces::data_frames::schemas::update_schema(
         workspace,
         file_path,
-        &og_schema.ok_or(OxenError::basic_str("Original schema not found"))?,
+        &og_schema.ok_or_else(|| OxenError::basic_str("Original schema not found"))?,
         &column_to_update.name,
         &column_after_name,
     )?;
@@ -193,9 +193,12 @@ pub async fn restore(
                     name: change
                         .column_after
                         .clone()
-                        .ok_or(OxenError::Basic(
-                            "To restore an add, the column after object has to be defined".into(),
-                        ))?
+                        .ok_or_else(|| {
+                            OxenError::Basic(
+                                "To restore an add, the column after object has to be defined"
+                                    .into(),
+                            )
+                        })?
                         .column_name
                         .clone(),
                 };
@@ -206,9 +209,12 @@ pub async fn restore(
                     &db,
                     &change
                         .column_after
-                        .ok_or(OxenError::Basic(
-                            "To restore an add, the column after object has to be defined".into(),
-                        ))?
+                        .ok_or_else(|| {
+                            OxenError::Basic(
+                                "To restore an add, the column after object has to be defined"
+                                    .into(),
+                            )
+                        })?
                         .column_name,
                 )?;
                 repositories::workspaces::files::add(workspace, file_path).await?;
@@ -220,22 +226,26 @@ pub async fn restore(
                     name: change
                         .column_before
                         .clone()
-                        .ok_or(OxenError::Basic(
-                            "To restore a delete, the column before object has to be defined"
-                                .into(),
-                        ))?
+                        .ok_or_else(|| {
+                            OxenError::Basic(
+                                "To restore a delete, the column before object has to be defined"
+                                    .into(),
+                            )
+                        })?
                         .column_name,
                     data_type: change
                         .column_before
                         .clone()
-                        .ok_or(OxenError::Basic(
-                            "To restore a delete, the column before object has to be defined"
-                                .into(),
-                        ))?
+                        .ok_or_else(|| {
+                            OxenError::Basic(
+                                "To restore a delete, the column before object has to be defined"
+                                    .into(),
+                            )
+                        })?
                         .column_data_type
-                        .ok_or(OxenError::Basic(
-                            "Column data type is required but was None".into(),
-                        ))?,
+                        .ok_or_else(|| {
+                            OxenError::Basic("Column data type is required but was None".into())
+                        })?,
                 };
                 let result = with_df_db_manager(&db_path, |manager| {
                     manager.with_conn(|conn| columns::add_column(conn, &new_column))
@@ -244,10 +254,12 @@ pub async fn restore(
                     &db,
                     &change
                         .column_before
-                        .ok_or(OxenError::Basic(
-                            "To restore a delete, the column before object has to be defined"
-                                .into(),
-                        ))?
+                        .ok_or_else(|| {
+                            OxenError::Basic(
+                                "To restore a delete, the column before object has to be defined"
+                                    .into(),
+                            )
+                        })?
                         .column_name,
                 )?;
                 repositories::workspaces::files::add(workspace, file_path).await?;
@@ -258,30 +270,38 @@ pub async fn restore(
                 let new_data_type = change
                     .column_before
                     .clone()
-                    .ok_or(OxenError::Basic(
-                        "To restore a modify, the column before object has to be defined".into(),
-                    ))?
+                    .ok_or_else(|| {
+                        OxenError::Basic(
+                            "To restore a modify, the column before object has to be defined"
+                                .into(),
+                        )
+                    })?
                     .column_data_type
-                    .ok_or(OxenError::Basic(
-                        "column_data_type is None, cannot unwrap".into(),
-                    ))?;
+                    .ok_or_else(|| {
+                        OxenError::Basic("column_data_type is None, cannot unwrap".into())
+                    })?;
                 let column_to_update = ColumnToUpdate {
                     name: change
                         .column_after
                         .clone()
-                        .ok_or(OxenError::Basic(
-                            "To restore a modify, the column after object has to be defined".into(),
-                        ))?
+                        .ok_or_else(|| {
+                            OxenError::Basic(
+                                "To restore a modify, the column after object has to be defined"
+                                    .into(),
+                            )
+                        })?
                         .column_name,
                     new_data_type: Some(new_data_type.to_owned()),
                     new_name: Some(
                         change
                             .column_before
                             .clone()
-                            .ok_or(OxenError::Basic(
+                            .ok_or_else(|| {
+                                OxenError::Basic(
                                 "To restore a modify, the column before object has to be defined"
                                     .into(),
-                            ))?
+                            )
+                            })?
                             .column_name,
                     ),
                 };
@@ -297,14 +317,16 @@ pub async fn restore(
                     &change
                         .column_after
                         .clone()
-                        .ok_or(OxenError::Basic(
-                            "To restore a modify, the column before object has to be defined"
-                                .into(),
-                        ))?
+                        .ok_or_else(|| {
+                            OxenError::Basic(
+                                "To restore a modify, the column before object has to be defined"
+                                    .into(),
+                            )
+                        })?
                         .column_name,
                 )?;
                 let og_schema =
-                    og_schema.ok_or(OxenError::basic_str("Original schema not found"))?;
+                    og_schema.ok_or_else(|| OxenError::basic_str("Original schema not found"))?;
 
                 repositories::data_frames::schemas::restore_schema(
                     &workspace.workspace_repo,
@@ -313,16 +335,20 @@ pub async fn restore(
                     &change
                         .column_before
                         .clone()
-                        .ok_or(OxenError::basic_str(
-                            "To restore a modify, the column before object has to be defined",
-                        ))?
+                        .ok_or_else(|| {
+                            OxenError::basic_str(
+                                "To restore a modify, the column before object has to be defined",
+                            )
+                        })?
                         .column_name,
                     &change
                         .column_after
                         .clone()
-                        .ok_or(OxenError::basic_str(
-                            "To restore a modify, the column after object has to be defined",
-                        ))?
+                        .ok_or_else(|| {
+                            OxenError::basic_str(
+                                "To restore a modify, the column after object has to be defined",
+                            )
+                        })?
                         .column_name,
                 )?;
                 repositories::workspaces::files::add(workspace, file_path).await?;
@@ -360,9 +386,8 @@ pub fn add_column_metadata(
         } else {
             // Get the FileNode from the CommitMerkleTree
             let commit = workspace.commit.clone();
-            let node = repositories::tree::get_node_by_path(repo, &commit, &path)?.ok_or(
-                OxenError::basic_str("Node does not exist at the specified path"),
-            )?;
+            let node = repositories::tree::get_node_by_path(repo, &commit, &path)?
+                .ok_or_else(|| OxenError::basic_str("Node does not exist at the specified path"))?;
             let mut parent_id = node.parent_id;
             let mut dir_path = path.clone();
 

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/schemas.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/schemas.rs
@@ -56,7 +56,7 @@ pub fn update_schema(
             &workspace.commit,
             path.as_ref(),
         )?
-        .ok_or(OxenError::basic_str("File not found"))?;
+        .ok_or_else(|| OxenError::basic_str("File not found"))?;
     }
 
     if let Some(GenericMetadata::MetadataTabular(tabular_metadata)) = &file_node.metadata() {

--- a/crates/lib/src/core/v_latest/workspaces/diff.rs
+++ b/crates/lib/src/core/v_latest/workspaces/diff.rs
@@ -25,7 +25,7 @@ pub fn diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DiffResult,
     );
 
     let file_node = repositories::tree::get_file_by_path(repo, commit, path)?
-        .ok_or(OxenError::entry_does_not_exist(path))?;
+        .ok_or_else(|| OxenError::entry_does_not_exist(path))?;
 
     log::debug!("diff_workspace_df got file_node {file_node}");
 

--- a/crates/lib/src/core/v_latest/workspaces/files.rs
+++ b/crates/lib/src/core/v_latest/workspaces/files.rs
@@ -270,26 +270,40 @@ fn is_cgn_or_reserved_v4(octets: [u8; 4]) -> bool {
     false
 }
 
+#[derive(Debug, thiserror::Error)]
+enum InvalidUrlError {
+    #[error("URL has no host")]
+    NoHost,
+
+    #[error("DNS resolution failed for {host}: {source}")]
+    DnsResolutionFailed {
+        host: String,
+        source: std::io::Error,
+    },
+
+    #[error("URL resolves to a private/reserved IP address: {0}")]
+    PrivateIp(std::net::IpAddr),
+}
+
 /// Resolves a URL's hostname via DNS and rejects it if any resolved address is
 /// private/reserved. This prevents SSRF attacks where a user-supplied URL could reach
 /// internal services (e.g. cloud metadata at 169.254.169.254, internal APIs, etc.).
-async fn validate_url_target(url: &Url) -> Result<(), OxenError> {
-    let host = url
-        .host_str()
-        .ok_or_else(|| OxenError::file_import_error("URL has no host"))?;
+async fn validate_url_target(url: &Url) -> Result<(), InvalidUrlError> {
+    let host = url.host_str().ok_or(InvalidUrlError::NoHost)?;
     let port = url.port_or_known_default().unwrap_or(443);
     let addr = format!("{host}:{port}");
 
-    let resolved = tokio::net::lookup_host(&addr).await.map_err(|e| {
-        OxenError::file_import_error(format!("DNS resolution failed for {host}: {e}"))
-    })?;
+    let resolved =
+        tokio::net::lookup_host(&addr)
+            .await
+            .map_err(|e| InvalidUrlError::DnsResolutionFailed {
+                host: host.to_string(),
+                source: e,
+            })?;
 
     for socket_addr in resolved {
         if is_private_ip(&socket_addr.ip()) {
-            return Err(OxenError::file_import_error(format!(
-                "URL resolves to a private/reserved IP address: {}",
-                socket_addr.ip()
-            )));
+            return Err(InvalidUrlError::PrivateIp(socket_addr.ip()));
         }
     }
 
@@ -353,7 +367,9 @@ pub async fn import(
         ));
     }
 
-    validate_url_target(&parsed_url).await?;
+    validate_url_target(&parsed_url)
+        .await
+        .map_err(|e| OxenError::ImportFileError(format!("{e}").into()))?;
 
     let auth_header_value = HeaderValue::from_str(auth)
         .map_err(|_e| OxenError::file_import_error(format!("Invalid header auth value {auth}")))?;
@@ -407,12 +423,12 @@ pub async fn upload_zip(
             log::debug!("workspace::commit ✅ success! commit {commit:?}");
             Ok(commit)
         }
-        Err(OxenError::WorkspaceBehind(workspace)) => {
+        workspace_behind_error @ Err(OxenError::WorkspaceBehind(_)) => {
             log::error!(
                 "unable to commit branch {:?}. Workspace behind",
                 branch.name
             );
-            Err(OxenError::WorkspaceBehind(workspace))
+            workspace_behind_error
         }
         Err(err) => {
             log::error!("unable to commit branch {:?}. Err: {}", branch.name, err);
@@ -479,7 +495,9 @@ async fn fetch_file(
                     "Redirect to non-HTTP(S) URL is not allowed",
                 ));
             }
-            validate_url_target(&next_url).await?;
+            validate_url_target(&next_url)
+                .await
+                .map_err(|e| OxenError::ImportFileError(format!("{e}").into()))?;
 
             current_url = next_url;
             continue;

--- a/crates/lib/src/core/v_old/v0_19_0/entries.rs
+++ b/crates/lib/src/core/v_old/v0_19_0/entries.rs
@@ -56,9 +56,7 @@ pub fn get_meta_entry(
     let commit = parsed_resource
         .commit
         .clone()
-        .ok_or(OxenError::parsed_resource_not_found(
-            parsed_resource.clone(),
-        ))?;
+        .ok_or_else(|| OxenError::parsed_resource_not_found(parsed_resource.clone()))?;
     log::debug!("get_meta_entry path: {path:?} commit: {commit}");
     let node = repositories::tree::get_dir_without_children(repo, &commit, path, None)?;
     log::debug!("get_meta_entry node: {node:?}");
@@ -109,9 +107,10 @@ fn dir_node_to_metadata_entry(
     if let std::collections::hash_map::Entry::Vacant(e) =
         found_commits.entry(*dir_node.last_commit_id())
     {
-        let commit = repositories::commits::get_by_hash(repo, dir_node.last_commit_id())?.ok_or(
-            OxenError::commit_id_does_not_exist(dir_node.last_commit_id().to_string()),
-        )?;
+        let commit = repositories::commits::get_by_hash(repo, dir_node.last_commit_id())?
+            .ok_or_else(|| {
+                OxenError::commit_id_does_not_exist(dir_node.last_commit_id().to_string())
+            })?;
         e.insert(commit);
     }
 
@@ -153,9 +152,10 @@ fn file_node_to_metadata_entry(
     if let std::collections::hash_map::Entry::Vacant(e) =
         found_commits.entry(*file_node.last_commit_id())
     {
-        let commit = repositories::commits::get_by_hash(repo, file_node.last_commit_id())?.ok_or(
-            OxenError::commit_id_does_not_exist(file_node.last_commit_id().to_string()),
-        )?;
+        let commit = repositories::commits::get_by_hash(repo, file_node.last_commit_id())?
+            .ok_or_else(|| {
+                OxenError::commit_id_does_not_exist(file_node.last_commit_id().to_string())
+            })?;
         e.insert(commit);
     }
 

--- a/crates/lib/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
+++ b/crates/lib/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
@@ -50,10 +50,12 @@ impl CommitMerkleTree {
         // if you see it in the logs being called too much, it could be why the code is slow.
         log::debug!("Load tree from commit: {} in repo: {:?}", commit, repo.path);
         let node_hash = commit.id.parse()?;
-        let root =
-            CommitMerkleTree::read_node(repo, &node_hash, true)?.ok_or(OxenError::basic_str(
-                format!("Merkle tree hash not found for commit: '{}'", commit.id),
-            ))?;
+        let root = CommitMerkleTree::read_node(repo, &node_hash, true)?.ok_or_else(|| {
+            OxenError::basic_str(format!(
+                "Merkle tree hash not found for commit: '{}'",
+                commit.id
+            ))
+        })?;
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
         Ok(Self { root, dir_hashes })
     }
@@ -111,21 +113,21 @@ impl CommitMerkleTree {
         let root = if let Some(node_hash) = node_hash {
             // We are reading a node with children
             log::debug!("Look up dir 🗂️ {node_path:?}");
-            CommitMerkleTree::read_node(repo, &node_hash, load_recursive)?.ok_or(
+            CommitMerkleTree::read_node(repo, &node_hash, load_recursive)?.ok_or_else(|| {
                 OxenError::basic_str(format!(
                     "Merkle tree hash not found for parent: '{}'",
                     node_path.to_str().unwrap()
-                )),
-            )?
+                ))
+            })?
         } else {
             // We are skipping to a file in the tree using the dir_hashes db
             log::debug!("Look up file 📄 {node_path:?}");
-            CommitMerkleTree::read_file(repo, &dir_hashes, node_path)?.ok_or(
+            CommitMerkleTree::read_file(repo, &dir_hashes, node_path)?.ok_or_else(|| {
                 OxenError::basic_str(format!(
                     "Merkle tree hash not found for parent: '{}'",
                     node_path.to_str().unwrap()
-                )),
-            )?
+                ))
+            })?
         };
         Ok(Self { root, dir_hashes })
     }
@@ -338,12 +340,9 @@ impl CommitMerkleTree {
         path: impl AsRef<Path>,
     ) -> Result<HashSet<MerkleTreeNode>, OxenError> {
         let path = path.as_ref();
-        let node = self
-            .root
-            .get_by_path(path)?
-            .ok_or(OxenError::basic_str(format!(
-                "Merkle tree hash not found for parent: {path:?}"
-            )))?;
+        let node = self.root.get_by_path(path)?.ok_or_else(|| {
+            OxenError::basic_str(format!("Merkle tree hash not found for parent: {path:?}"))
+        })?;
         let mut children = HashSet::new();
         for child in &node.children {
             children.extend(child.children.iter().cloned());

--- a/crates/lib/src/core/v_old/v0_19_0/pull.rs
+++ b/crates/lib/src/core/v_old/v0_19_0/pull.rs
@@ -34,7 +34,7 @@ pub async fn pull_remote_branch(
 
     let remote = repo
         .get_remote(remote)
-        .ok_or(OxenError::remote_not_set(remote))?;
+        .ok_or_else(|| OxenError::remote_not_set(remote))?;
 
     let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
 
@@ -44,7 +44,7 @@ pub async fn pull_remote_branch(
     fetch::fetch_remote_branch(repo, &remote_repo, fetch_opts).await?;
 
     let new_head_commit = repositories::revisions::get(repo, branch)?
-        .ok_or(OxenError::revision_not_found(branch.to_owned().into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(branch.to_owned().into()))?;
 
     // Merge if there are changes
     if let Some(previous_head_commit) = &previous_head_commit {

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -8,13 +8,12 @@ use std::io;
 use std::num::ParseIntError;
 use std::path::Path;
 use std::path::PathBuf;
-use std::path::StripPrefixError;
 use tokio::task::JoinError;
 
+use crate::model::ParsedResource;
 use crate::model::RepoNew;
 use crate::model::Schema;
 use crate::model::Workspace;
-use crate::model::{Commit, ParsedResource};
 
 pub mod path_buf_error;
 pub mod string_error;
@@ -22,184 +21,309 @@ pub mod string_error;
 pub use crate::error::path_buf_error::PathBufError;
 pub use crate::error::string_error::StringError;
 
-pub const HEAD_NOT_FOUND: &str = "HEAD not found";
-
-pub const EMAIL_AND_NAME_NOT_FOUND: &str = "oxen not configured, set email and name with:\n\noxen config --name YOUR_NAME --email YOUR_EMAIL\n";
-
 pub const AUTH_TOKEN_NOT_FOUND: &str = "oxen authentication token not found, obtain one from your administrator and configure with:\n\noxen config --auth <HOST> <TOKEN>\n";
 
 #[derive(thiserror::Error, Debug)]
 pub enum OxenError {
-    // User
-    #[error("{0}")]
-    UserConfigNotFound(Box<StringError>),
+    //
+    // Configuration
+    //
+    /// The user configuration file cannot be found at $HOME/.config/oxen/user_config.toml
+    #[error(
+        "oxen not configured, set email and name with:\n\noxen config --name YOUR_NAME --email YOUR_EMAIL\n"
+    )]
+    UserConfigNotFound,
 
+    //
     // Repo
+    //
+    /// When an operation assumes a repository exists but it cannot be found.
     #[error("Repository '{0}' not found")]
     RepoNotFound(Box<RepoNew>),
+
+    /// When a local repository cannot be found at the given path.
     #[error("No oxen repository found at {0}")]
-    LocalRepoNotFound(Box<PathBufError>),
+    LocalRepoNotFound(PathBufError),
+
+    /// Error during repository creation: attempt to create a repository that already exists.
     #[error("Repository '{0}' already exists")]
     RepoAlreadyExists(Box<RepoNew>),
-    #[error("Repository already exists at destination: {0}")]
-    RepoAlreadyExistsAtDestination(Box<StringError>),
+
+    /// Error when creating a repository: repo names are restricted.
     #[error("Invalid repository or namespace name '{0}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+")]
     InvalidRepoName(StringError),
 
-    // Fork
-    #[error("{0}")]
-    ForkStatusNotFound(StringError),
-
+    /// When `get_fork_status` cannot obtain the fork status for a repository.
+    #[error("No fork status found.")]
+    ForkStatusNotFound,
+    //
     // Remotes
+    //
+    /// A remote repository with a given name was not located on the server.
     #[error("Remote repository not found: {0}")]
-    RemoteRepoNotFound(Box<StringError>),
-    #[error("{0}")]
-    RemoteAheadOfLocal(StringError),
-    #[error("{0}")]
-    IncompleteLocalHistory(StringError),
-    #[error("{0}")]
-    RemoteBranchLocked(StringError),
+    RemoteRepoNotFound(StringError),
+
+    /// A merge cannot occur because there's a conflict with its upstream tracking branch.
     #[error("{0}")]
     UpstreamMergeConflict(StringError),
 
-    // Branches/Commits
-    #[error("{0}")]
-    BranchNotFound(Box<StringError>),
-    #[error("Revision not found: {0}")]
-    RevisionNotFound(Box<StringError>),
-    #[error("Root commit does not match: {0}")]
-    RootCommitDoesNotMatch(Box<Commit>),
-    #[error("{0}")]
-    NothingToCommit(StringError),
-    #[error("{0}")]
-    NoCommitsFound(StringError),
-    #[error("{0}")]
-    HeadNotFound(StringError),
+    /// A remote with the given name was not found.
+    #[error(
+        "No remote named '{0}' is set. You can set a remote by running:\n\noxen config --set-remote '{0}' <url>\n"
+    )]
+    RemoteNotSet(String),
 
+    //
+    // Branches/Commits
+    //
+    /// A branch with a given name was not found in the repository.
+    #[error("{0}")]
+    BranchNotFound(StringError),
+
+    /// A given revision (commit hash) was not found in the repository.
+    #[error("Revision not found: {0}")]
+    RevisionNotFound(StringError),
+
+    /// The repository is empty: it has no commits.
+    #[error("No commits found.")]
+    NoCommitsFound,
+
+    /// The repository's current branch (head) cannot be located.
+    #[error("HEAD not found.")]
+    HeadNotFound,
+
+    //
     // Workspaces
+    //
+    /// The workspace wasn't found (either locally or on a remote server).
     #[error("Workspace not found: {0}")]
-    WorkspaceNotFound(Box<StringError>),
+    WorkspaceNotFound(StringError),
+
+    /// No queryable workspace was found.
     #[error("No queryable workspace found")]
-    QueryableWorkspaceNotFound(),
+    QueryableWorkspaceNotFound,
+
+    /// The workspace is behind the remote repository and cannot be automatically updated.
     #[error("Workspace is behind: {0}")]
     WorkspaceBehind(Box<Workspace>),
 
+    //
     // Resources (paths, uris, etc.)
+    //
+    /// A resource (entry, path, commit, etc.) was not found.
     #[error("Resource not found: {0}")]
     ResourceNotFound(StringError),
-    #[error("Path does not exist: {0}")]
-    PathDoesNotExist(Box<PathBufError>),
-    #[error("Resource not found: {0}")]
-    ParsedResourceNotFound(Box<PathBufError>),
 
+    /// The given path was not found, either in the repository or in the filesystem.
+    #[error("Path does not exist: {0}")]
+    PathDoesNotExist(PathBufError),
+
+    /// A parsed resource was not found.
+    #[error("Resource not found: {0}")]
+    ParsedResourceNotFound(PathBufError),
+
+    //
     // Versioning
+    //
+    /// The repository must be migrated before it can be used.
+    /// This is due to the repository being at an older version than the oxen server or client
+    /// being used on it.
     #[error("{0}")]
     MigrationRequired(StringError),
+
+    /// The oxen client or server must be updated before it can be used.
     #[error("{0}")]
     OxenUpdateRequired(StringError),
+
+    /// The version is invalid or unsupported.
     #[error("Invalid version: {0}")]
     InvalidVersion(StringError),
 
-    // Entry
+    /// A commit entry is not present in the repository.
     #[error("{0}")]
     CommitEntryNotFound(StringError),
 
-    // Schema
+    //
+    // Schema (dataframes)
+    //
+    /// The schema is invalid or unsupported for dataframe operations.
     #[error("Invalid schema: {0}")]
     InvalidSchema(Box<Schema>),
+
+    /// The schemas of the data frames are incompatible.
     #[error("Incompatible schemas: {0}")]
     IncompatibleSchemas(Box<Schema>),
+
+    /// The file type is unsupported for data frame operations.
     #[error("{0}")]
     InvalidFileType(StringError),
+
+    /// A column name already exists in the dataframe's schema and cannot be added again.
     #[error("{0}")]
     ColumnNameAlreadyExists(StringError),
+
+    /// A column name was requested in a dataframe, but no such column exists.
     #[error("{0}")]
     ColumnNameNotFound(StringError),
+
+    /// An operation is not supported for the the dataframe.
     #[error("{0}")]
     UnsupportedOperation(StringError),
 
+    //
     // Metadata
-    #[error("{0}")]
-    ImageMetadataParseError(StringError),
-    #[error("{0}")]
-    ThumbnailingNotEnabled(StringError),
+    //
+    /// Thumbnails can only be created when the ffmpeg feature is enabled.
+    #[error(
+        "Video thumbnail generation requires the 'ffmpeg' feature to be enabled. Build with --features liboxen/ffmpeg to enable this functionality."
+    )]
+    ThumbnailingNotEnabled,
 
-    // SQL
-    #[error("SQL parse error: {0}")]
-    SQLParseError(StringError),
-    #[error("{0}")]
-    NoRowsFound(StringError),
+    //
+    // Dataframes
+    //
+    /// No rows were found for a given SQL query.
+    #[error("Query returned no rows")]
+    NoRowsFound,
 
-    // CLI Interaction
-    #[error("{0}")]
-    OperationCancelled(StringError),
-
-    // fs / io
-    #[error("{0}")]
-    StripPrefixError(StringError),
-
-    // Dataframe Errors
+    /// An error encountered during dataframe operations.
+    /// Contains a human-readable description of the error.
     #[error("{0}")]
     DataFrameError(StringError),
 
-    // File Import Error
+    /// Adding a file into a workspace
     #[error("{0}")]
     ImportFileError(StringError),
 
-    // External Library Errors
+    /// An error encountered during SQL parsing.
+    #[error("{0}")]
+    SQLParseError(StringError),
+
+    //
+    //
+    // Wrappers
+    //
+    //
+    /// Wraps the error from std::path::strip_prefix.
+    #[error("Error stripping prefix: {0}")]
+    StripPrefixError(#[from] std::path::StripPrefixError),
+
+    /// Wraps errors encountered from file reading & writing operations.
     #[error("{0}")]
     IO(#[from] io::Error),
+
+    /// Encountered when authentication fails. Contains the authentication error message.
     #[error("Authentication failed: {0}")]
     Authentication(StringError),
+
+    /// Wraps errors from the Arrow library, which are encountered in dataframe operations.
     #[error("{0}")]
     ArrowError(#[from] ArrowError),
+
+    /// Wraps errors from bincode when serializing and deserializing Rust objects into binary data.
     #[error("{0}")]
     BinCodeError(#[from] bincode::Error),
+
+    /// Wraps errors encountered when trying to serialize TOML data.
     #[error("Configuration error: {0}")]
     TomlSer(#[from] toml::ser::Error),
+
+    /// Wraps errors encountered when deserializing invalid TOML data.
     #[error("Configuration error: {0}")]
     TomlDe(#[from] toml::de::Error),
+
+    /// Wraps errors encountered when parsing malformed URIs.
     #[error("Invalid URI: {0}")]
     URI(#[from] http::uri::InvalidUri),
+
+    /// Wraps errors encountered when parsing malformed URLs.
     #[error("Invalid URL: {0}")]
     URL(#[from] url::ParseError),
+
+    /// Wraps JSON serialization and deserialization errors.
     #[error("JSON error: {0}")]
     JSON(#[from] serde_json::Error),
+
+    /// Wraps any HTTP client errors we encounter.
     #[error("Network error: {0}")]
     HTTP(#[from] reqwest::Error),
+
+    /// Wraps any error we encounter from handling non-UTF-8 strings.
+    ///
+    /// Most often occurs when interacting with filesystem paths as much
+    /// of the oxen codebase relies on paths being valid UTF-8 strings.
     #[error("UTF-8 encoding error: {0}")]
     UTF8Error(#[from] std::str::Utf8Error),
+
+    /// Wraps any error we encounter from converting a byte slice to a UTF-8 string.
+    #[error("UTF-8 conversion error: {0}")]
+    Utf8ConvError(#[from] std::string::FromUtf8Error),
+
+    /// Wraps any error we encounter from interacting with RocksDB.
     #[error("Database error: {0}")]
     DB(#[from] rocksdb::Error),
+
+    /// Wraps any error we encounter from interacting with DuckDB.
     #[error("Query error: {0}")]
     DUCKDB(#[from] duckdb::Error),
+
+    /// Wraps any error we encounter from interacting with environment variables.
     #[error("Environment variable error: {0}")]
     ENV(#[from] std::env::VarError),
+
+    /// Wraps any error that we get from using the image crate (image processing).
     #[error("Image processing error: {0}")]
     ImageError(#[from] image::ImageError),
+
+    /// Wraps any error that we get from Redis client use.
     #[error("Redis error: {0}")]
     RedisError(#[from] redis::RedisError),
+
+    /// Wraps any error that we get from using r2d2 (the connection pool).
     #[error("Connection pool error: {0}")]
     R2D2Error(#[from] r2d2::Error),
+
+    /// Wraps any error that we get from using jwalk (directory traversal).
     #[error("Directory traversal error: {0}")]
     JwalkError(#[from] jwalk::Error),
+
+    /// Wraps any error that we get from parsing malformed glob patterns.
     #[error("Pattern error: {0}")]
     PatternError(#[from] glob::PatternError),
+
+    /// Wraps any error that we encounter when walking paths emitted from a glob pattern.
     #[error("Glob error: {0}")]
     GlobError(#[from] glob::GlobError),
+
+    /// Wraps any error that we get from using polars (dataframe operations).
     #[error("DataFrame error: {0}")]
     PolarsError(#[from] polars::prelude::PolarsError),
+
+    /// Wraps any error that we get from parsing integers from strings.
     #[error("Invalid integer: {0}")]
     ParseIntError(#[from] ParseIntError),
+
+    /// Wraps any error that we get from decoding message pack data.
     #[error("Decode error: {0}")]
     RmpDecodeError(#[from] rmp_serde::decode::Error),
 
+    /// Wraps any error that we get from joining tasks.
+    #[error("{0}")]
+    JoinError(#[from] JoinError),
+
     // Fallback
+    // TODO: remove all uses of `Basic` and replace with specific errors.
     #[error("{0}")]
     Basic(StringError),
 }
 
 impl OxenError {
+    //
+    //
+    // User-Facing
+    //
+    //
+
     /// Returns a user-facing hint for this error, or None if none applies.
     pub fn hint(&self) -> Option<String> {
         use OxenError::*;
@@ -217,8 +341,7 @@ impl OxenError {
             RevisionNotFound(_) => {
                 "Check available branches with `oxen branch --all` or commits with `oxen log`."
             }
-            NothingToCommit(_) => "Stage changes with `oxen add <path>` before committing.",
-            HeadNotFound(_) | NoCommitsFound(_) => {
+            HeadNotFound | NoCommitsFound => {
                 "This repository has no commits yet. Add files and create your first commit."
             }
             PathDoesNotExist(_)
@@ -251,165 +374,165 @@ impl OxenError {
         Some(hint)
     }
 
-    pub fn basic_str(s: impl AsRef<str>) -> Self {
-        OxenError::Basic(StringError::from(s.as_ref()))
-    }
+    //
+    //
+    // Property Identification
+    //  Does this error belong to some semantic category?
+    //
+    //
 
-    pub fn thumbnailing_not_enabled(s: impl AsRef<str>) -> Self {
-        OxenError::ThumbnailingNotEnabled(StringError::from(s.as_ref()))
-    }
-
-    pub fn authentication(s: impl AsRef<str>) -> Self {
-        OxenError::Authentication(StringError::from(s.as_ref()))
-    }
-
-    pub fn migration_required(s: impl AsRef<str>) -> Self {
-        OxenError::MigrationRequired(StringError::from(s.as_ref()))
-    }
-
-    pub fn invalid_version(s: impl AsRef<str>) -> Self {
-        OxenError::InvalidVersion(StringError::from(s.as_ref()))
-    }
-
-    pub fn oxen_update_required(s: impl AsRef<str>) -> Self {
-        OxenError::OxenUpdateRequired(StringError::from(s.as_ref()))
-    }
-
-    pub fn user_config_not_found(value: StringError) -> Self {
-        OxenError::UserConfigNotFound(Box::new(value))
-    }
-
-    pub fn repo_not_found(repo: RepoNew) -> Self {
-        OxenError::RepoNotFound(Box::new(repo))
-    }
-
-    pub fn file_import_error(s: impl AsRef<str>) -> Self {
-        OxenError::ImportFileError(StringError::from(s.as_ref()))
-    }
-
-    pub fn remote_not_set(name: impl AsRef<str>) -> Self {
-        let name = name.as_ref();
-        OxenError::basic_str(format!(
-            "Remote not set, you can set a remote by running:\n\noxen config --set-remote {name} <url>\n"
-        ))
-    }
-
-    pub fn remote_ahead_of_local() -> Self {
-        OxenError::RemoteAheadOfLocal(StringError::from(
-            "\nRemote ahead of local, must pull changes. To fix run:\n\n  oxen pull\n",
-        ))
-    }
-
-    pub fn upstream_merge_conflict() -> Self {
-        OxenError::UpstreamMergeConflict(StringError::from(
-            "\nRemote has conflicts with local branch. To fix run:\n\n  oxen pull\n\nThen resolve conflicts and commit changes.\n",
-        ))
-    }
-
-    pub fn merge_conflict(desc: impl AsRef<str>) -> Self {
-        OxenError::UpstreamMergeConflict(StringError::from(desc.as_ref()))
-    }
-
-    pub fn incomplete_local_history() -> Self {
-        OxenError::IncompleteLocalHistory(StringError::from(
-            "\nCannot push to an empty repository with an incomplete local history. To fix, pull the complete history from your remote:\n\n  oxen pull <remote> <branch> --all\n",
-        ))
-    }
-
-    pub fn remote_branch_locked() -> Self {
-        OxenError::RemoteBranchLocked(StringError::from(
-            "\nRemote branch is locked - another push is in progress. Wait a bit before pushing again, or try pushing to a new branch.\n",
-        ))
-    }
-
-    pub fn operation_cancelled() -> Self {
-        OxenError::OperationCancelled(StringError::from("\nOperation cancelled.\n"))
-    }
-
-    pub fn resource_not_found(value: impl AsRef<str>) -> Self {
-        OxenError::ResourceNotFound(StringError::from(value.as_ref()))
-    }
-
-    pub fn path_does_not_exist(path: impl AsRef<Path>) -> Self {
-        OxenError::PathDoesNotExist(Box::new(path.as_ref().into()))
-    }
-
-    pub fn image_metadata_error(s: impl AsRef<str>) -> Self {
-        OxenError::ImageMetadataParseError(StringError::from(s.as_ref()))
-    }
-
-    pub fn sql_parse_error(s: impl AsRef<str>) -> Self {
-        OxenError::SQLParseError(StringError::from(s.as_ref()))
-    }
-
-    pub fn parsed_resource_not_found(resource: ParsedResource) -> Self {
-        OxenError::ParsedResourceNotFound(Box::new(resource.resource.into()))
-    }
-
-    pub fn invalid_repo_name(s: impl AsRef<str>) -> Self {
-        OxenError::InvalidRepoName(StringError::from(s.as_ref()))
-    }
-
+    /// Is this error's source an authentication problem?
     pub fn is_auth_error(&self) -> bool {
         matches!(self, OxenError::Authentication(_))
     }
 
+    /// Is this error considered as something not existing?
     pub fn is_not_found(&self) -> bool {
         matches!(
             self,
             OxenError::PathDoesNotExist(_)
                 | OxenError::ResourceNotFound(_)
                 | OxenError::RemoteRepoNotFound(_)
+                | OxenError::LocalRepoNotFound(_)
+                | OxenError::ParsedResourceNotFound(_)
+                | OxenError::WorkspaceNotFound(_)
+                | OxenError::QueryableWorkspaceNotFound
         )
     }
 
-    pub fn repo_already_exists(repo: RepoNew) -> Self {
-        OxenError::RepoAlreadyExists(Box::new(repo))
+    //
+    //
+    // Constructors
+    //
+    //
+
+    /// Make a new OxenError::Authentication error.
+    pub fn authentication(s: impl AsRef<str>) -> Self {
+        OxenError::Authentication(StringError::from(s.as_ref()))
     }
 
-    pub fn repo_already_exists_at_destination(value: StringError) -> Self {
-        OxenError::RepoAlreadyExistsAtDestination(Box::new(value))
+    /// Make a new OxenError::InvalidVersion error.
+    pub fn invalid_version(s: impl AsRef<str>) -> Self {
+        OxenError::InvalidVersion(StringError::from(s.as_ref()))
     }
 
-    pub fn fork_status_not_found() -> Self {
-        OxenError::ForkStatusNotFound(StringError::from("No fork status found"))
+    /// Make a new OxenError::OxenUpdateRequired error.
+    pub fn oxen_update_required(s: impl AsRef<str>) -> Self {
+        OxenError::OxenUpdateRequired(StringError::from(s.as_ref()))
     }
 
-    pub fn revision_not_found(value: StringError) -> Self {
-        OxenError::RevisionNotFound(Box::new(value))
+    /// Make a new OxenError::RepoNotFound error.
+    pub fn repo_not_found(repo: RepoNew) -> Self {
+        OxenError::RepoNotFound(Box::new(repo))
     }
 
-    pub fn workspace_not_found(value: StringError) -> Self {
-        OxenError::WorkspaceNotFound(Box::new(value))
+    /// Make a new OxenError::FileImportError error.
+    pub fn file_import_error(s: impl AsRef<str>) -> Self {
+        OxenError::ImportFileError(StringError::from(s.as_ref()))
     }
 
-    pub fn workspace_behind(workspace: &Workspace) -> Self {
-        OxenError::WorkspaceBehind(Box::new(workspace.clone()))
+    /// Makes a new OxenError::ResourceNotFound error.
+    pub fn resource_not_found(value: impl AsRef<str>) -> Self {
+        OxenError::ResourceNotFound(StringError::from(value.as_ref()))
     }
 
-    pub fn root_commit_does_not_match(commit: Commit) -> Self {
-        OxenError::RootCommitDoesNotMatch(Box::new(commit))
+    /// Make a new OxenError::PathDoesNotExist error.
+    pub fn path_does_not_exist(path: impl AsRef<Path>) -> Self {
+        OxenError::PathDoesNotExist(path.as_ref().into())
     }
 
-    pub fn no_commits_found() -> Self {
-        OxenError::NoCommitsFound(StringError::from("\n No commits found.\n"))
+    /// Make a new ParsedResourceNotFound error.
+    pub fn parsed_resource_not_found(resource: ParsedResource) -> Self {
+        OxenError::ParsedResourceNotFound(resource.resource.into())
     }
 
+    /// Make a new OxenError::LocalRepoNotFound error.
     pub fn local_repo_not_found(dir: impl AsRef<Path>) -> OxenError {
-        OxenError::LocalRepoNotFound(Box::new(dir.as_ref().into()))
+        OxenError::LocalRepoNotFound(dir.as_ref().into())
     }
 
+    /// Make a new OxenError::UserConfigNotFound error.
     pub fn email_and_name_not_set() -> OxenError {
-        OxenError::user_config_not_found(EMAIL_AND_NAME_NOT_FOUND.to_string().into())
+        OxenError::UserConfigNotFound
     }
 
-    pub fn remote_repo_not_found(url: impl AsRef<str>) -> OxenError {
-        OxenError::RemoteRepoNotFound(Box::new(StringError::from(url.as_ref())))
+    /// Make a new OxenError::BranchNotFound error.
+    pub fn remote_branch_not_found(name: impl AsRef<str>) -> OxenError {
+        let err = format!("Remote branch '{}' not found", name.as_ref());
+        OxenError::BranchNotFound(err.into())
     }
 
-    pub fn head_not_found() -> OxenError {
-        OxenError::HeadNotFound(StringError::from(HEAD_NOT_FOUND))
+    /// Make a new OxenError::BranchNotFound error.
+    pub fn local_branch_not_found(name: impl AsRef<str>) -> OxenError {
+        let err = format!("Branch '{}' not found", name.as_ref());
+        OxenError::BranchNotFound(err.into())
     }
+
+    /// Make a new OxenError::ParsedResourceNotFound error.
+    pub fn entry_does_not_exist(path: impl AsRef<Path>) -> OxenError {
+        OxenError::ParsedResourceNotFound(path.as_ref().into())
+    }
+
+    /// Make a new OxenError::CommitEntryNotFound error.
+    pub fn entry_does_not_exist_in_commit(
+        path: impl AsRef<Path>,
+        commit_id: impl AsRef<str>,
+    ) -> OxenError {
+        let err = format!(
+            "Entry {:?} does not exist in commit {}",
+            path.as_ref(),
+            commit_id.as_ref()
+        );
+        OxenError::CommitEntryNotFound(err.into())
+    }
+
+    /// Make a new OxenError::InvalidFileType error.
+    pub fn invalid_file_type(file_type: impl AsRef<str>) -> OxenError {
+        let err = format!("Invalid file type: {:?}", file_type.as_ref());
+        OxenError::InvalidFileType(StringError::from(err))
+    }
+
+    /// Make a new OxenError::ColumnNameAlreadyExists error.
+    pub fn column_name_already_exists(column_name: &str) -> OxenError {
+        let err = format!("Column name already exists: {column_name:?}");
+        OxenError::ColumnNameAlreadyExists(StringError::from(err))
+    }
+
+    /// Make a new OxenError::ColumnNameNotFound error.
+    pub fn column_name_not_found(column_name: &str) -> OxenError {
+        let err = format!("Column name not found: {column_name:?}");
+        OxenError::ColumnNameNotFound(StringError::from(err))
+    }
+
+    /// Make a new OxenError::IncompatibleSchemas error.
+    pub fn incompatible_schemas(schema: Schema) -> OxenError {
+        OxenError::IncompatibleSchemas(Box::new(schema))
+    }
+
+    /// Make a new OxenError::Basic error.
+    pub fn basic_str(s: impl AsRef<str>) -> Self {
+        OxenError::Basic(StringError::from(s.as_ref()))
+    }
+
+    //
+    // OxenError::Basic constructors
+    //
+    //   TODO: these should all be replaced with specific variants.
+    //
+    //   CONTEXT:
+    //         It is very useful to be able to have fully structured errors for every specific
+    //         condition that can go wrong in oxen.
+    //
+    //         For readability & maintainability, it will be useful to break-out all of these error
+    //         variants into their own specific sub-error enums. Areas of operation that have similar
+    //         failure reasons (e.g. code working on the same data structure), are priority candidates
+    //         for their own sub-error enums.
+    //
+    //         It will be useful then to define `From` the sub-error enums into an `OxenError`. This
+    //         will allow using more specific per-oxen-module `Result<T, oxen sub-error>` functions
+    //         in contexts that use an `OxenError`. It also allows for a helper type to be written
+    //         that can preserve the original error type while still allowing conversion to `OxenError`.
+    //
 
     pub fn home_dir_not_found() -> OxenError {
         OxenError::basic_str("Home directory not found")
@@ -438,98 +561,90 @@ impl OxenError {
     }
 
     pub fn schema_does_not_exist_for_file(path: impl AsRef<Path>) -> OxenError {
-        let err = format!("Schema does not exist for file {:?}", path.as_ref());
-        OxenError::basic_str(err)
+        OxenError::basic_str(format!(
+            "Schema does not exist for file {:?}",
+            path.as_ref()
+        ))
     }
 
     pub fn schema_does_not_exist(path: impl AsRef<Path>) -> OxenError {
-        let err = format!("Schema does not exist {:?}", path.as_ref());
-        OxenError::basic_str(err)
+        OxenError::basic_str(format!("Schema does not exist {:?}", path.as_ref()))
     }
 
     pub fn schema_does_not_have_field(field: impl AsRef<str>) -> OxenError {
-        let err = format!("Schema does not have field {:?}", field.as_ref());
-        OxenError::basic_str(err)
+        OxenError::basic_str(format!("Schema does not have field {:?}", field.as_ref()))
     }
 
     pub fn schema_has_changed(old_schema: Schema, current_schema: Schema) -> OxenError {
-        let err =
-            format!("\nSchema has changed\n\nOld\n{old_schema}\n\nCurrent\n{current_schema}\n");
-        OxenError::basic_str(err)
-    }
-
-    pub fn remote_branch_not_found(name: impl AsRef<str>) -> OxenError {
-        let err = format!("Remote branch '{}' not found", name.as_ref());
-        OxenError::BranchNotFound(Box::new(StringError::from(err)))
-    }
-
-    pub fn local_branch_not_found(name: impl AsRef<str>) -> OxenError {
-        let err = format!("Branch '{}' not found", name.as_ref());
-        OxenError::BranchNotFound(Box::new(StringError::from(err)))
+        OxenError::basic_str(format!(
+            "\nSchema has changed\n\nOld\n{old_schema}\n\nCurrent\n{current_schema}\n"
+        ))
     }
 
     pub fn commit_db_corrupted(commit_id: impl AsRef<str>) -> OxenError {
-        let err = format!(
+        OxenError::basic_str(format!(
             "Commit db corrupted, could not find commit: {}",
             commit_id.as_ref()
-        );
-        OxenError::basic_str(err)
+        ))
     }
 
     pub fn commit_id_does_not_exist(commit_id: impl AsRef<str>) -> OxenError {
-        let err = format!("Could not find commit: {}", commit_id.as_ref());
-        OxenError::basic_str(err)
+        OxenError::basic_str(format!("Could not find commit: {}", commit_id.as_ref()))
     }
 
     pub fn local_parent_link_broken(commit_id: impl AsRef<str>) -> OxenError {
-        let err = format!("Broken link to parent commit: {}", commit_id.as_ref());
-        OxenError::basic_str(err)
-    }
-
-    pub fn entry_does_not_exist(path: impl AsRef<Path>) -> OxenError {
-        OxenError::ParsedResourceNotFound(Box::new(path.as_ref().into()))
+        OxenError::basic_str(format!(
+            "Broken link to parent commit: {}",
+            commit_id.as_ref()
+        ))
     }
 
     pub fn file_error(path: impl AsRef<Path>, error: std::io::Error) -> OxenError {
-        let err = format!("File does not exist: {:?} error {:?}", path.as_ref(), error);
-        OxenError::basic_str(err)
+        OxenError::basic_str(format!(
+            "File does not exist: {:?} error {:?}",
+            path.as_ref(),
+            error
+        ))
     }
 
     pub fn file_create_error(path: impl AsRef<Path>, error: std::io::Error) -> OxenError {
-        let err = format!(
+        OxenError::basic_str(format!(
             "Could not create file: {:?} error {:?}",
             path.as_ref(),
             error
-        );
-        OxenError::basic_str(err)
+        ))
     }
 
     pub fn dir_create_error(path: impl AsRef<Path>, error: std::io::Error) -> OxenError {
-        let err = format!(
+        OxenError::basic_str(format!(
             "Could not create directory: {:?} error {:?}",
             path.as_ref(),
             error
-        );
-        OxenError::basic_str(err)
+        ))
     }
 
     pub fn file_open_error(path: impl AsRef<Path>, error: std::io::Error) -> OxenError {
-        let err = format!("Could not open file: {:?} error {:?}", path.as_ref(), error,);
-        OxenError::basic_str(err)
+        OxenError::basic_str(format!(
+            "Could not open file: {:?} error {:?}",
+            path.as_ref(),
+            error
+        ))
     }
 
     pub fn file_read_error(path: impl AsRef<Path>, error: std::io::Error) -> OxenError {
-        let err = format!("Could not read file: {:?} error {:?}", path.as_ref(), error,);
-        OxenError::basic_str(err)
+        OxenError::basic_str(format!(
+            "Could not read file: {:?} error {:?}",
+            path.as_ref(),
+            error
+        ))
     }
 
     pub fn file_metadata_error(path: impl AsRef<Path>, error: std::io::Error) -> OxenError {
-        let err = format!(
+        OxenError::basic_str(format!(
             "Could not get file metadata: {:?} error {:?}",
             path.as_ref(),
             error
-        );
-        OxenError::basic_str(err)
+        ))
     }
 
     pub fn file_copy_error(
@@ -537,12 +652,11 @@ impl OxenError {
         dst: impl AsRef<Path>,
         err: impl std::fmt::Debug,
     ) -> OxenError {
-        let err = format!(
+        OxenError::basic_str(format!(
             "File copy error: {err:?}\nCould not copy from `{:?}` to `{:?}`",
             src.as_ref(),
             dst.as_ref()
-        );
-        OxenError::basic_str(err)
+        ))
     }
 
     pub fn file_rename_error(
@@ -550,20 +664,18 @@ impl OxenError {
         dst: impl AsRef<Path>,
         err: impl std::fmt::Debug,
     ) -> OxenError {
-        let err = format!(
+        OxenError::basic_str(format!(
             "File rename error: {err:?}\nCould not move from `{:?}` to `{:?}`",
             src.as_ref(),
             dst.as_ref()
-        );
-        OxenError::basic_str(err)
+        ))
     }
 
     pub fn workspace_add_file_not_in_repo(path: impl AsRef<Path>) -> OxenError {
-        let err = format!(
+        OxenError::basic_str(format!(
             "File is outside of the repo {:?}\n\nYou must specify a path you would like to add the file at with the -d flag.\n\n  oxen workspace add /path/to/file.png -d my-images/\n",
             path.as_ref()
-        );
-        OxenError::basic_str(err)
+        ))
     }
 
     pub fn cannot_overwrite_files(paths: &[PathBuf]) -> OxenError {
@@ -578,18 +690,6 @@ impl OxenError {
         ))
     }
 
-    pub fn entry_does_not_exist_in_commit(
-        path: impl AsRef<Path>,
-        commit_id: impl AsRef<str>,
-    ) -> OxenError {
-        let err = format!(
-            "Entry {:?} does not exist in commit {}",
-            path.as_ref(),
-            commit_id.as_ref()
-        );
-        OxenError::CommitEntryNotFound(err.into())
-    }
-
     pub fn must_supply_valid_api_key() -> OxenError {
         OxenError::basic_str(
             "Must supply valid API key. Create an account at https://oxen.ai and then set the API key with:\n\n  oxen config --auth hub.oxen.ai <API_KEY>\n",
@@ -597,71 +697,47 @@ impl OxenError {
     }
 
     pub fn file_has_no_parent(path: impl AsRef<Path>) -> OxenError {
-        let err = format!("File has no parent: {:?}", path.as_ref());
-        OxenError::basic_str(err)
+        OxenError::basic_str(format!("File has no parent: {:?}", path.as_ref()))
     }
 
     pub fn file_has_no_name(path: impl AsRef<Path>) -> OxenError {
-        let err = format!("File has no file_name: {:?}", path.as_ref());
-        OxenError::basic_str(err)
+        OxenError::basic_str(format!("File has no file_name: {:?}", path.as_ref()))
     }
 
     pub fn could_not_convert_path_to_str(path: impl AsRef<Path>) -> OxenError {
-        let err = format!("File has no name: {:?}", path.as_ref());
-        OxenError::basic_str(err)
+        OxenError::basic_str(format!("File has no name: {:?}", path.as_ref()))
     }
 
     pub fn local_revision_not_found(name: impl AsRef<str>) -> OxenError {
-        let err = format!(
+        OxenError::basic_str(format!(
             "Local branch or commit reference `{}` not found",
             name.as_ref()
-        );
-        OxenError::basic_str(err)
+        ))
     }
 
     pub fn could_not_find_merge_conflict(path: impl AsRef<Path>) -> OxenError {
-        let err = format!(
+        OxenError::basic_str(format!(
             "Could not find merge conflict for path: {:?}",
             path.as_ref()
-        );
-        OxenError::basic_str(err)
+        ))
     }
 
     pub fn could_not_decode_value_for_key_error(key: impl AsRef<str>) -> OxenError {
-        let err = format!("Could not decode value for key: {:?}", key.as_ref());
-        OxenError::basic_str(err)
+        OxenError::basic_str(format!(
+            "Could not decode value for key: {:?}",
+            key.as_ref()
+        ))
     }
 
     pub fn invalid_set_remote_url(url: impl AsRef<str>) -> OxenError {
-        let err = format!(
+        OxenError::basic_str(format!(
             "\nRemote invalid, must be fully qualified URL, got: {:?}\n\n  oxen config --set-remote origin https://hub.oxen.ai/<namespace>/<reponame>\n",
             url.as_ref()
-        );
-        OxenError::basic_str(err)
-    }
-
-    pub fn invalid_file_type(file_type: impl AsRef<str>) -> OxenError {
-        let err = format!("Invalid file type: {:?}", file_type.as_ref());
-        OxenError::InvalidFileType(StringError::from(err))
-    }
-
-    pub fn column_name_already_exists(column_name: &str) -> OxenError {
-        let err = format!("Column name already exists: {column_name:?}");
-        OxenError::ColumnNameAlreadyExists(StringError::from(err))
-    }
-
-    pub fn column_name_not_found(column_name: &str) -> OxenError {
-        let err = format!("Column name not found: {column_name:?}");
-        OxenError::ColumnNameNotFound(StringError::from(err))
-    }
-
-    pub fn incompatible_schemas(schema: Schema) -> OxenError {
-        OxenError::IncompatibleSchemas(Box::new(schema))
+        ))
     }
 
     pub fn parse_error(value: impl AsRef<str>) -> OxenError {
-        let err = format!("Parse error: {:?}", value.as_ref());
-        OxenError::basic_str(err)
+        OxenError::basic_str(format!("Parse error: {:?}", value.as_ref()))
     }
 
     pub fn unknown_subcommand(parent: impl AsRef<str>, name: impl AsRef<str>) -> OxenError {
@@ -677,23 +753,5 @@ impl OxenError {
 impl From<String> for OxenError {
     fn from(error: String) -> Self {
         OxenError::Basic(StringError::from(error))
-    }
-}
-
-impl From<StripPrefixError> for OxenError {
-    fn from(error: StripPrefixError) -> Self {
-        OxenError::basic_str(format!("Error stripping prefix: {error}"))
-    }
-}
-
-impl From<JoinError> for OxenError {
-    fn from(error: JoinError) -> Self {
-        OxenError::basic_str(error.to_string())
-    }
-}
-
-impl From<std::string::FromUtf8Error> for OxenError {
-    fn from(error: std::string::FromUtf8Error) -> Self {
-        OxenError::basic_str(format!("UTF8 conversion error: {error}"))
     }
 }

--- a/crates/lib/src/opts/storage_opts.rs
+++ b/crates/lib/src/opts/storage_opts.rs
@@ -125,13 +125,17 @@ impl StorageOpts {
                     }
                 }
                 "s3" => {
-                    let bucket = storage_backend_bucket.ok_or(OxenError::basic_str(
-                        "storage-backend-bucket is required when storage-backend is s3",
-                    ))?;
+                    let bucket = storage_backend_bucket.ok_or_else(|| {
+                        OxenError::basic_str(
+                            "storage-backend-bucket is required when storage-backend is s3",
+                        )
+                    })?;
 
-                    let prefix = storage_backend_path.ok_or(OxenError::basic_str(
-                        "storage-backend-path is required when storage-backend is s3",
-                    ))?;
+                    let prefix = storage_backend_path.ok_or_else(|| {
+                        OxenError::basic_str(
+                            "storage-backend-path is required when storage-backend is s3",
+                        )
+                    })?;
 
                     Ok(Some(StorageOpts {
                         type_: "s3".to_string(),

--- a/crates/lib/src/repositories.rs
+++ b/crates/lib/src/repositories.rs
@@ -218,12 +218,12 @@ pub async fn create(
 ) -> Result<LocalRepositoryWithEntries, OxenError> {
     // Validate repo name
     if !is_valid_repo_name(&new_repo.name) {
-        return Err(OxenError::invalid_repo_name(&new_repo.name));
+        return Err(OxenError::InvalidRepoName(new_repo.name.into()));
     }
 
     // Validate namespace
     if !is_valid_repo_name(&new_repo.namespace) {
-        return Err(OxenError::invalid_repo_name(&new_repo.namespace));
+        return Err(OxenError::InvalidRepoName(new_repo.namespace.into()));
     }
 
     let repo_dir = root_dir
@@ -231,7 +231,7 @@ pub async fn create(
         .join(Path::new(&new_repo.name));
     if repo_dir.exists() {
         log::error!("Repository already exists {repo_dir:?}");
-        return Err(OxenError::repo_already_exists(new_repo));
+        return Err(OxenError::RepoAlreadyExists(Box::new(new_repo)));
     }
 
     // Create the repo dir

--- a/crates/lib/src/repositories/branches.rs
+++ b/crates/lib/src/repositories/branches.rs
@@ -271,7 +271,7 @@ pub fn list_entry_versions_on_branch(
     path: &Path,
 ) -> Result<Vec<(Commit, CommitEntry)>, OxenError> {
     let branch = repositories::branches::get_by_name(local_repo, branch_name)?
-        .ok_or(OxenError::local_branch_not_found(branch_name))?;
+        .ok_or_else(|| OxenError::local_branch_not_found(branch_name))?;
     log::debug!(
         "get branch commits for branch {:?} -> {}",
         branch.name,

--- a/crates/lib/src/repositories/checkout.rs
+++ b/crates/lib/src/repositories/checkout.rs
@@ -28,7 +28,7 @@ pub async fn checkout(
 
         println!("Checkout branch: {value}");
         let commit = repositories::revisions::get(repo, value)?
-            .ok_or(OxenError::revision_not_found(value.into()))?;
+            .ok_or_else(|| OxenError::RevisionNotFound(value.into()))?;
         let subtree_paths = match repo.subtree_paths() {
             Some(paths_vec) => paths_vec, // If Some(vec), take the inner vector
             None => vec![Path::new("").to_path_buf()],
@@ -46,7 +46,7 @@ pub async fn checkout(
         }
 
         let commit = repositories::revisions::get(repo, value)?
-            .ok_or(OxenError::revision_not_found(value.into()))?;
+            .ok_or_else(|| OxenError::RevisionNotFound(value.into()))?;
 
         let previous_head_commit = repositories::commits::head_commit_maybe(repo)?;
         repositories::branches::checkout_commit_from_commit(repo, &commit, &previous_head_commit)

--- a/crates/lib/src/repositories/diffs.rs
+++ b/crates/lib/src/repositories/diffs.rs
@@ -174,7 +174,7 @@ pub async fn diff_uncommitted(
     let unstaged_files = status.unstaged_files();
     log::debug!("unstaged_files: {unstaged_files:?}");
     let commit_1 = repositories::revisions::get(repo, rev_1)?
-        .ok_or_else(|| OxenError::revision_not_found(rev_1.to_string().into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(rev_1.into()))?;
     log::debug!("commit_1: {commit_1:?}");
     let mut diff_result = Vec::new();
     log::debug!("diff_result: {diff_result:?}");
@@ -224,9 +224,9 @@ pub async fn diff_revs(
         path_2.display()
     );
     let commit_1 = repositories::revisions::get(repo, rev_1)?
-        .ok_or_else(|| OxenError::revision_not_found(rev_1.to_string().into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(rev_1.into()))?;
     let commit_2 = repositories::revisions::get(repo, rev_2)?
-        .ok_or_else(|| OxenError::revision_not_found(rev_2.to_string().into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(rev_2.into()))?;
 
     let dir_diff = diff_path(repo, &commit_1, &commit_2, path_1, path_2, opts).await?;
     log::debug!(

--- a/crates/lib/src/repositories/fetch.rs
+++ b/crates/lib/src/repositories/fetch.rs
@@ -19,7 +19,7 @@ pub async fn fetch_all(
 ) -> Result<Vec<Branch>, OxenError> {
     let remote = repo
         .get_remote(&fetch_opts.remote)
-        .ok_or(OxenError::remote_not_set(fetch_opts.remote.clone()))?;
+        .ok_or_else(|| OxenError::RemoteNotSet(fetch_opts.remote.clone()))?;
     let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
 
     api::client::repositories::pre_fetch(&remote_repo).await?;
@@ -87,7 +87,7 @@ pub async fn fetch_branch(
 ) -> Result<Branch, OxenError> {
     let remote = repo
         .get_remote(&fetch_opts.remote)
-        .ok_or(OxenError::remote_not_set(fetch_opts.remote.clone()))?;
+        .ok_or_else(|| OxenError::RemoteNotSet(fetch_opts.remote.clone()))?;
     let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
 
     api::client::repositories::pre_fetch(&remote_repo).await?;

--- a/crates/lib/src/repositories/fork.rs
+++ b/crates/lib/src/repositories/fork.rs
@@ -102,7 +102,7 @@ pub fn start_fork(
 }
 
 pub fn get_fork_status(repo_path: &Path) -> Result<ForkStatusResponse, OxenError> {
-    let status = read_status(repo_path)?.ok_or_else(OxenError::fork_status_not_found)?;
+    let status = read_status(repo_path)?.ok_or(OxenError::ForkStatusNotFound)?;
 
     Ok(ForkStatusResponse {
         repository: repo_path.to_string_lossy().to_string(),
@@ -222,7 +222,7 @@ mod tests {
                     current_status = match get_fork_status(&forked_repo_path) {
                         Ok(status) => status.status,
                         Err(e) => {
-                            if let OxenError::ForkStatusNotFound(_) = e {
+                            if matches!(e, OxenError::ForkStatusNotFound) {
                                 "in_progress".to_string()
                             } else {
                                 return Err(e);

--- a/crates/lib/src/repositories/load.rs
+++ b/crates/lib/src/repositories/load.rs
@@ -42,9 +42,9 @@ pub async fn load(
 
     println!("🐂 Unpacking files to working directory {dest_path:?}");
     let branch = repositories::branches::get_by_name(&repo, DEFAULT_BRANCH_NAME)?
-        .ok_or(OxenError::local_branch_not_found(DEFAULT_BRANCH_NAME))?;
+        .ok_or_else(|| OxenError::local_branch_not_found(DEFAULT_BRANCH_NAME))?;
     let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?
-        .ok_or(OxenError::commit_id_does_not_exist(&branch.commit_id))?;
+        .ok_or_else(|| OxenError::commit_id_does_not_exist(&branch.commit_id))?;
     repositories::branches::set_working_repo_to_commit(&repo, &commit, &None).await?;
 
     println!("{done_msg}");

--- a/crates/lib/src/repositories/metadata.rs
+++ b/crates/lib/src/repositories/metadata.rs
@@ -23,7 +23,9 @@ pub mod video;
 /// Returns the metadata given a file path
 pub fn get(path: impl AsRef<Path>) -> Result<MetadataEntry, OxenError> {
     let path = path.as_ref();
-    let base_name = path.file_name().ok_or(OxenError::file_has_no_name(path))?;
+    let base_name = path
+        .file_name()
+        .ok_or_else(|| OxenError::file_has_no_name(path))?;
     let size = get_file_size(path)?;
     let mime_type = util::fs::file_mime_type(path);
     let data_type = util::fs::datatype_from_mimetype(path, mime_type.as_str());
@@ -49,7 +51,9 @@ pub fn get(path: impl AsRef<Path>) -> Result<MetadataEntry, OxenError> {
 /// Returns the metadata given a file path
 pub fn from_path(path: impl AsRef<Path>) -> Result<MetadataEntry, OxenError> {
     let path = path.as_ref();
-    let base_name = path.file_name().ok_or(OxenError::file_has_no_name(path))?;
+    let base_name = path
+        .file_name()
+        .ok_or_else(|| OxenError::file_has_no_name(path))?;
     let size = get_file_size(path)?;
     let mime_type = util::fs::file_mime_type(path);
     let data_type = util::fs::datatype_from_mimetype(path, mime_type.as_str());

--- a/crates/lib/src/repositories/metadata/video.rs
+++ b/crates/lib/src/repositories/metadata/video.rs
@@ -37,7 +37,7 @@ pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataVideo, OxenError> 
 
             let video = video_tracks
                 .first()
-                .ok_or(OxenError::basic_str("Could not get video track"))?;
+                .ok_or_else(|| OxenError::basic_str("Could not get video track"))?;
 
             Ok(MetadataVideo::new(
                 duration,

--- a/crates/lib/src/repositories/revisions.rs
+++ b/crates/lib/src/repositories/revisions.rs
@@ -21,7 +21,7 @@ pub fn get(repo: &LocalRepository, revision: impl AsRef<str>) -> Result<Option<C
     if repositories::branches::exists(repo, revision)? {
         log::debug!("revision is a branch: {revision}");
         let branch = repositories::branches::get_by_name(repo, revision)?;
-        let branch = branch.ok_or(OxenError::local_branch_not_found(revision))?;
+        let branch = branch.ok_or_else(|| OxenError::local_branch_not_found(revision))?;
         let commit = repositories::commits::get_by_id(repo, &branch.commit_id)?;
         Ok(commit)
     } else {

--- a/crates/lib/src/repositories/tree.rs
+++ b/crates/lib/src/repositories/tree.rs
@@ -485,9 +485,9 @@ pub fn collect_nodes_along_path(
     // Grab the first path or error if empty
     let root_path = paths
         .first()
-        .ok_or(OxenError::basic_str("No paths provided"))?;
+        .ok_or_else(|| OxenError::basic_str("No paths provided"))?;
     let node = get_node_by_path_with_children(repo, commit, root_path)?
-        .ok_or(OxenError::basic_str("Node not found"))?;
+        .ok_or_else(|| OxenError::basic_str("Node not found"))?;
 
     let (_root_node, nodes) = node.get_nodes_along_paths(paths)?;
 
@@ -550,7 +550,7 @@ pub async fn list_missing_file_hashes_from_commits(
         let commit_id_str = commit_id.to_string();
         let Some(commit) = repositories::commits::get_by_id(repo, &commit_id_str)? else {
             log::error!("list_missing_file_hashes_from_commits Commit {commit_id_str} not found");
-            return Err(OxenError::revision_not_found(commit_id_str.into()));
+            return Err(OxenError::RevisionNotFound(commit_id_str.into()));
         };
         // Handle the case where we are given a list of subtrees to check
         // It is much faster to check the subtree directly than to walk the entire tree
@@ -1159,7 +1159,7 @@ pub fn get_node_hashes_between_commits(
     );
     let (first_commit, new_commits) = commits
         .split_first()
-        .ok_or(OxenError::basic_str("Must provide at least one commit"))?;
+        .ok_or_else(|| OxenError::basic_str("Must provide at least one commit"))?;
 
     let mut starting_node_hashes = HashSet::new();
 

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -307,7 +307,7 @@ pub fn delete(workspace: &Workspace) -> Result<(), OxenError> {
     let workspace_id = workspace.id.to_string();
     let workspace_dir = workspace.dir();
     if !workspace_dir.exists() {
-        return Err(OxenError::workspace_not_found(workspace_id.into()));
+        return Err(OxenError::WorkspaceNotFound(workspace_id.into()));
     }
 
     log::debug!("workspace::delete cleaning up workspace dir: {workspace_dir:?}");
@@ -338,7 +338,7 @@ pub fn update_commit(workspace: &Workspace, new_commit_id: &str) -> Result<(), O
 
     if !config_path.exists() {
         log::error!("Workspace config not found: {config_path:?}");
-        return Err(OxenError::workspace_not_found(workspace.id.clone().into()));
+        return Err(OxenError::WorkspaceNotFound(workspace.id.as_str().into()));
     }
 
     let config_contents = util::fs::read_from_path(&config_path)?;

--- a/crates/lib/src/repositories/workspaces/data_frames/columns.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/columns.rs
@@ -209,15 +209,15 @@ pub fn handle_data_frame_column_change(
             previous: None,
         })),
         "modified" => {
-            let column_before = change.column_before.ok_or(OxenError::basic_str(
-                "A modified column needs to have a column before value",
-            ))?;
+            let column_before = change.column_before.ok_or_else(|| {
+                OxenError::basic_str("A modified column needs to have a column before value")
+            })?;
 
             let previous_field = PreviousField {
                 name: column_before.column_name.clone(),
-                dtype: column_before.column_data_type.ok_or(OxenError::basic_str(
-                    "A modified column needs to have a before datatype value",
-                ))?,
+                dtype: column_before.column_data_type.ok_or_else(|| {
+                    OxenError::basic_str("A modified column needs to have a before datatype value")
+                })?,
                 metadata: None,
             };
 
@@ -251,18 +251,18 @@ pub fn reinsert_deleted_columns_into_schema(
     }
 
     for deleted_column in &deleted_columns {
-        let before_column = deleted_column.clone().ok_or(OxenError::basic_str(
-            "A deleted column needs to have a column before value",
-        ))?;
+        let before_column = deleted_column.clone().ok_or_else(|| {
+            OxenError::basic_str("A deleted column needs to have a column before value")
+        })?;
 
         df_views.source.schema.fields.push(Field {
             name: before_column.column_name.clone(),
             dtype: before_column
                 .column_data_type
                 .clone()
-                .ok_or(OxenError::basic_str(
-                    "A deleted column needs to have a before datatype value",
-                ))?
+                .ok_or_else(|| {
+                    OxenError::basic_str("A deleted column needs to have a before datatype value")
+                })?
                 .clone(),
             metadata: None,
             changes: None,
@@ -272,9 +272,9 @@ pub fn reinsert_deleted_columns_into_schema(
             name: before_column.column_name.clone(),
             dtype: before_column
                 .column_data_type
-                .ok_or(OxenError::basic_str(
-                    "A deleted column needs to have a before datatype value",
-                ))?
+                .ok_or_else(|| {
+                    OxenError::basic_str("A deleted column needs to have a before datatype value")
+                })?
                 .clone(),
             metadata: None,
             changes: None,

--- a/crates/lib/src/repositories/workspaces/data_frames/embeddings.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/embeddings.rs
@@ -563,7 +563,7 @@ fn get_avg_embedding(result_set: Vec<RecordBatch>) -> Result<Vec<f32>, OxenError
     }
 
     if embeddings.is_empty() {
-        return Err(OxenError::NoRowsFound("Query returned no rows".into()));
+        return Err(OxenError::NoRowsFound);
     }
 
     if vector_length == 0 {

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -1735,10 +1735,7 @@ pub async fn handle_video_thumbnail(
     #[cfg(not(feature = "ffmpeg"))]
     {
         let _ = (version_store, file_hash, video_thumbnail);
-        Err(OxenError::thumbnailing_not_enabled(
-            "Video thumbnail generation requires the 'ffmpeg' feature to be enabled. \
-             Build with --features liboxen/ffmpeg to enable this functionality.",
-        ))
+        Err(OxenError::ThumbnailingNotEnabled)
     }
 
     #[cfg(feature = "ffmpeg")]

--- a/crates/lib/src/view/compare.rs
+++ b/crates/lib/src/view/compare.rs
@@ -269,9 +269,7 @@ impl TabularCompareTargetBody {
         self.left
             .clone()
             .or_else(|| self.right.clone())
-            .ok_or(OxenError::basic_str(
-                "Both 'left' and 'right' fields are None",
-            ))
+            .ok_or_else(|| OxenError::basic_str("Both 'left' and 'right' fields are None"))
     }
 }
 

--- a/crates/oxen-py/src/py_remote_data_frame.rs
+++ b/crates/oxen-py/src/py_remote_data_frame.rs
@@ -26,7 +26,7 @@ impl PyRemoteDataFrame {
 
     fn size(&self) -> Result<(usize, usize), PyOxenError> {
         let Some(revision) = &self.repo.revision else {
-            return Err(OxenError::no_commits_found().into());
+            return Err(OxenError::NoCommitsFound.into());
         };
 
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
@@ -50,7 +50,7 @@ impl PyRemoteDataFrame {
 
     fn get_row_by_index(&self, row: usize) -> Result<String, PyOxenError> {
         let Some(revision) = &self.repo.revision else {
-            return Err(OxenError::no_commits_found().into());
+            return Err(OxenError::NoCommitsFound.into());
         };
 
         let data = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
@@ -78,7 +78,7 @@ impl PyRemoteDataFrame {
         columns: Vec<String>,
     ) -> Result<String, PyOxenError> {
         let Some(revision) = &self.repo.revision else {
-            return Err(OxenError::no_commits_found().into());
+            return Err(OxenError::NoCommitsFound.into());
         };
 
         let data = pyo3_async_runtimes::tokio::get_runtime().block_on(async {

--- a/crates/oxen-py/src/py_repo.rs
+++ b/crates/oxen-py/src/py_repo.rs
@@ -143,7 +143,7 @@ impl PyRepo {
             repositories::branches::delete(&repo, name)
         } else {
             repositories::branches::get_by_name(&repo, name)?
-                .ok_or(OxenError::local_branch_not_found(name))
+                .ok_or_else(|| OxenError::local_branch_not_found(name))
         };
         Ok(PyBranch::from(branch?))
     }
@@ -162,7 +162,7 @@ impl PyRepo {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
                 repositories::checkout(&repo, revision)
                     .await?
-                    .ok_or(OxenError::local_branch_not_found(revision))
+                    .ok_or_else(|| OxenError::local_branch_not_found(revision))
             })?
         };
 

--- a/crates/server/src/controllers/branches.rs
+++ b/crates/server/src/controllers/branches.rs
@@ -105,7 +105,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
 
     log::debug!("show branch {branch_name:?}");
     let branch = repositories::branches::get_by_name(&repository, &branch_name)?
-        .ok_or(OxenError::remote_branch_not_found(&branch_name))?;
+        .ok_or_else(|| OxenError::remote_branch_not_found(&branch_name))?;
     log::debug!("show branch found {branch:?}");
 
     let view = BranchResponse {
@@ -227,7 +227,7 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     let repository = get_repo(&app_data.path, namespace, name)?;
 
     let branch = repositories::branches::get_by_name(&repository, &branch_name)?
-        .ok_or(OxenError::remote_branch_not_found(&branch_name))?;
+        .ok_or_else(|| OxenError::remote_branch_not_found(&branch_name))?;
 
     repositories::branches::force_delete(&repository, &branch.name)?;
     Ok(HttpResponse::Ok().json(BranchResponse {
@@ -316,17 +316,17 @@ pub async fn maybe_create_merge(
     let repository = get_repo(&app_data.path, namespace, name)?;
     let branch_name = path_param(&req, "branch_name")?;
     let branch = repositories::branches::get_by_name(&repository, &branch_name)?
-        .ok_or(OxenError::remote_branch_not_found(&branch_name))?;
+        .ok_or_else(|| OxenError::remote_branch_not_found(&branch_name))?;
 
     let data: Result<BranchRemoteMerge, serde_json::Error> = serde_json::from_str(&body);
     let data = data.map_err(|err| OxenHttpError::BadRequest(format!("{err:?}").into()))?;
     let incoming_commit_id = data.client_commit_id;
     let incoming_commit = repositories::commits::get_by_id(&repository, &incoming_commit_id)?
-        .ok_or(OxenError::resource_not_found(&incoming_commit_id))?;
+        .ok_or_else(|| OxenError::resource_not_found(&incoming_commit_id))?;
 
     let current_commit_id = data.server_commit_id;
     let current_commit = repositories::commits::get_by_id(&repository, &current_commit_id)?
-        .ok_or(OxenError::resource_not_found(&current_commit_id))?;
+        .ok_or_else(|| OxenError::resource_not_found(&current_commit_id))?;
 
     log::debug!("maybe_create_merge got client head commit {incoming_commit_id:?}");
 
@@ -387,7 +387,7 @@ pub async fn list_entry_versions(
     // Get branch
     let repo = get_repo(&app_data.path, namespace.clone(), &repo_name)?;
     let branch = repositories::branches::get_by_name(&repo, &branch_name)?
-        .ok_or(OxenError::remote_branch_not_found(&branch_name))?;
+        .ok_or_else(|| OxenError::remote_branch_not_found(&branch_name))?;
 
     let path = PathBuf::from(path_param(&req, "path")?);
     let repo = get_repo(&app_data.path, namespace, &repo_name)?;

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -306,7 +306,7 @@ pub async fn list_missing_files(
     };
 
     let head_commit = repositories::commits::get_by_id(&repo, &query.head)?
-        .ok_or(OxenError::revision_not_found(query.head.clone().into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(query.head.as_str().into()))?;
 
     let missing_files = repositories::entries::list_missing_files_in_commit_range(
         &repo,
@@ -399,7 +399,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     let commit_id = path_param(&req, "commit_id")?;
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
     let commit = repositories::commits::get_by_id(&repo, &commit_id)?
-        .ok_or(OxenError::revision_not_found(commit_id.into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(commit_id.into()))?;
 
     Ok(HttpResponse::Ok().json(CommitResponse {
         status: StatusMessage::resource_found(),
@@ -430,7 +430,7 @@ pub async fn parents(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHt
     let commit_or_branch = path_param(&req, "commit_or_branch")?;
     let repository = get_repo(&app_data.path, namespace, name)?;
     let commit = repositories::revisions::get(&repository, &commit_or_branch)?
-        .ok_or(OxenError::revision_not_found(commit_or_branch.into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(commit_or_branch.into()))?;
     let parents = repositories::commits::list_from(&repository, &commit.id)?;
     Ok(HttpResponse::Ok().json(ListCommitResponse {
         status: StatusMessage::resource_found(),
@@ -524,9 +524,9 @@ pub async fn download_dir_hashes_db(
         let base_commit_id = split[0];
         let head_commit_id = split[1];
         let base_commit = repositories::revisions::get(&repository, base_commit_id)?
-            .ok_or(OxenError::revision_not_found(base_commit_id.into()))?;
+            .ok_or_else(|| OxenError::RevisionNotFound(base_commit_id.into()))?;
         let head_commit = repositories::revisions::get(&repository, head_commit_id)?
-            .ok_or(OxenError::revision_not_found(head_commit_id.into()))?;
+            .ok_or_else(|| OxenError::RevisionNotFound(head_commit_id.into()))?;
 
         repositories::commits::list_between(&repository, &base_commit, &head_commit)?
     } else {
@@ -563,7 +563,7 @@ pub async fn download_commit_entries_db(
     let repository = get_repo(&app_data.path, namespace, name)?;
 
     let commit = repositories::revisions::get(&repository, &commit_or_branch)?
-        .ok_or(OxenError::revision_not_found(commit_or_branch.into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(commit_or_branch.into()))?;
     let buffer = compress_commit(&repository, &commit)?;
 
     Ok(HttpResponse::Ok().body(buffer))
@@ -710,10 +710,6 @@ pub async fn create(
             status: StatusMessage::resource_created(),
             commit: commit.to_owned(),
         })),
-        Err(OxenError::RootCommitDoesNotMatch(commit_id)) => {
-            log::error!("Err create_commit: RootCommitDoesNotMatch {commit_id}");
-            Err(OxenHttpError::BadRequest("Remote commit history does not match local commit history. Make sure you are pushing to the correct remote.".into()))
-        }
         Err(err) => {
             log::error!("Err create_commit: {err}");
             Err(OxenHttpError::InternalServerError)

--- a/crates/server/src/controllers/diff.rs
+++ b/crates/server/src/controllers/diff.rs
@@ -73,8 +73,8 @@ pub async fn commits(
     let (base, head) = parse_base_head(&base_head)?;
     let (base_commit, head_commit) = resolve_base_head(&repository, &base, &head)?;
 
-    let base_commit = base_commit.ok_or(OxenError::revision_not_found(base.into()))?;
-    let head_commit = head_commit.ok_or(OxenError::revision_not_found(head.into()))?;
+    let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
+    let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
 
     let commits = repositories::commits::list_between(&repository, &base_commit, &head_commit)?;
     let (paginated, pagination) = util::paginate(commits, page, page_size);
@@ -132,8 +132,8 @@ pub async fn entries(
     let (base, head) = parse_base_head(&base_head)?;
     let (base_commit, head_commit) = resolve_base_head(&repository, &base, &head)?;
 
-    let base_commit = base_commit.ok_or(OxenError::revision_not_found(base.into()))?;
-    let head_commit = head_commit.ok_or(OxenError::revision_not_found(head.into()))?;
+    let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
+    let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
 
     let entries_diff = repositories::diffs::list_diff_entries(
         &repository,
@@ -207,8 +207,8 @@ pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenH
     let (base, head) = parse_base_head(&base_head)?;
     let (base_commit, head_commit) = resolve_base_head(&repository, &base, &head)?;
 
-    let base_commit = base_commit.ok_or(OxenError::revision_not_found(base.into()))?;
-    let head_commit = head_commit.ok_or(OxenError::revision_not_found(head.into()))?;
+    let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
+    let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
 
     let dir_diffs =
         repositories::diffs::list_changed_dirs(&repository, &base_commit, &head_commit)?;
@@ -264,8 +264,8 @@ pub async fn dir_entries(
     let (base, head) = parse_base_head(&base_head)?;
     let (base_commit, head_commit) = resolve_base_head(&repository, &base, &head)?;
 
-    let base_commit = base_commit.ok_or(OxenError::revision_not_found(base.into()))?;
-    let head_commit = head_commit.ok_or(OxenError::revision_not_found(head.into()))?;
+    let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
+    let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
     let dir = PathBuf::from(dir);
 
     let entries_diff = repositories::diffs::list_diff_entries(
@@ -430,10 +430,10 @@ pub async fn create_df_diff(
     let compare_id = data.compare_id.clone();
 
     let commit_1 = repositories::revisions::get(&repository, &data.left.version)?
-        .ok_or_else(|| OxenError::revision_not_found(data.left.version.into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(data.left.version.into()))?;
 
     let commit_2 = repositories::revisions::get(&repository, &data.right.version)?
-        .ok_or_else(|| OxenError::revision_not_found(data.right.version.into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(data.right.version.into()))?;
 
     let node_1 =
         repositories::entries::get_file(&repository, &commit_1, &resource_1)?.ok_or_else(|| {
@@ -539,9 +539,9 @@ pub async fn update_df_diff(
     log::debug!("display by col is {display_by_column:?}");
 
     let commit_1 = repositories::revisions::get(&repository, &data.left.version)?
-        .ok_or_else(|| OxenError::revision_not_found(data.left.version.into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(data.left.version.into()))?;
     let commit_2 = repositories::revisions::get(&repository, &data.right.version)?
-        .ok_or_else(|| OxenError::revision_not_found(data.right.version.into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(data.right.version.into()))?;
 
     let node_1 =
         repositories::entries::get_file(&repository, &commit_1, &resource_1)?.ok_or_else(|| {
@@ -632,8 +632,8 @@ pub async fn get_df_diff(
     let (left, right) = parse_base_head(&base_head)?;
     let (left_commit, right_commit) = resolve_base_head(&repository, &left, &right)?;
 
-    let left_commit = left_commit.ok_or(OxenError::revision_not_found(left.into()))?;
-    let right_commit = right_commit.ok_or(OxenError::revision_not_found(right.into()))?;
+    let left_commit = left_commit.ok_or_else(|| OxenError::RevisionNotFound(left.into()))?;
+    let right_commit = right_commit.ok_or_else(|| OxenError::RevisionNotFound(right.into()))?;
 
     let left_entry = repositories::entries::get_commit_entry(
         &repository,
@@ -866,13 +866,13 @@ fn parse_base_head_resource(
     let mut split = base_head.split("..");
     let base = split
         .next()
-        .ok_or(OxenError::resource_not_found(base_head))?;
+        .ok_or_else(|| OxenError::resource_not_found(base_head))?;
     let head = split
         .next()
-        .ok_or(OxenError::resource_not_found(base_head))?;
+        .ok_or_else(|| OxenError::resource_not_found(base_head))?;
 
     let base_commit = repositories::revisions::get(repo, base)?
-        .ok_or(OxenError::revision_not_found(base.into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
 
     // Split on / and find longest branch name
     let split_head = head.split('/');
@@ -897,8 +897,8 @@ fn parse_base_head_resource(
     log::debug!("Got head_commit: {head_commit:?}");
     log::debug!("Got resource: {resource:?}");
 
-    let head_commit = head_commit.ok_or(OxenError::revision_not_found(head.into()))?;
-    let resource = resource.ok_or(OxenError::revision_not_found(head.into()))?;
+    let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
+    let resource = resource.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
 
     Ok((base_commit, head_commit, resource))
 }

--- a/crates/server/src/controllers/entries.rs
+++ b/crates/server/src/controllers/entries.rs
@@ -142,7 +142,7 @@ pub async fn list_tabular(
     let commit_or_branch = path_param(&req, "commit_or_branch")?;
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
     let commit = repositories::revisions::get(&repo, &commit_or_branch)?
-        .ok_or_else(|| OxenError::revision_not_found(commit_or_branch.into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(commit_or_branch.into()))?;
 
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);

--- a/crates/server/src/controllers/file.rs
+++ b/crates/server/src/controllers/file.rs
@@ -164,13 +164,13 @@ pub async fn get(
                 // Fall back to commit tree using workspace's commit
                 let commit = &ws.commit;
                 repositories::tree::get_file_by_path(base_repo, commit, &path)?
-                    .ok_or(OxenError::path_does_not_exist(path.clone()))?
+                    .ok_or_else(|| OxenError::path_does_not_exist(path.clone()))?
             }
         }
         None => {
             let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
             repositories::tree::get_file_by_path(base_repo, &commit, &path)?
-                .ok_or(OxenError::path_does_not_exist(path.clone()))?
+                .ok_or_else(|| OxenError::path_does_not_exist(path.clone()))?
         }
     };
 
@@ -278,9 +278,7 @@ pub async fn put(
     let branch = resource
         .branch
         .clone()
-        .ok_or(OxenError::local_branch_not_found(
-            resource.version.to_string_lossy(),
-        ))?;
+        .ok_or_else(|| OxenError::local_branch_not_found(resource.version.to_string_lossy()))?;
     let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
     let node = repositories::tree::get_node_by_path(&repo, &commit, &resource.path)?;
     let upload_mode = resolve_upload_mode(
@@ -383,9 +381,7 @@ pub async fn delete(
     let branch = resource
         .branch
         .clone()
-        .ok_or(OxenError::local_branch_not_found(
-            resource.version.to_string_lossy(),
-        ))?;
+        .ok_or_else(|| OxenError::local_branch_not_found(resource.version.to_string_lossy()))?;
     let commit = resource.commit.clone().ok_or(OxenHttpError::NotFound)?;
     let path = resource.path;
 
@@ -476,9 +472,7 @@ pub async fn mv(req: HttpRequest, body: String) -> actix_web::Result<HttpRespons
     let branch = resource
         .branch
         .clone()
-        .ok_or(OxenError::local_branch_not_found(
-            resource.version.to_string_lossy(),
-        ))?;
+        .ok_or_else(|| OxenError::local_branch_not_found(resource.version.to_string_lossy()))?;
     let commit = resource.commit.clone().ok_or(OxenHttpError::NotFound)?;
     let source_path = resource.path;
 
@@ -668,9 +662,9 @@ fn build_files_from_upload_parts(
 }
 
 fn take_single_file_part(file_part: Option<&TempFileNew>) -> Result<&TempFileNew, OxenHttpError> {
-    file_part.ok_or(OxenHttpError::BadRequest(
-        "Missing file data: expected one `file` part".into(),
-    ))
+    file_part.ok_or_else(|| {
+        OxenHttpError::BadRequest("Missing file data: expected one `file` part".into())
+    })
 }
 
 fn normalize_relative_upload_path(

--- a/crates/server/src/controllers/fork.rs
+++ b/crates/server/src/controllers/fork.rs
@@ -52,11 +52,6 @@ pub async fn fork(
             log::info!("Successfully forked repository to {:?}", &new_repo_path);
             Ok(HttpResponse::Accepted().json(fork_start_response))
         }
-        Err(OxenError::RepoAlreadyExistsAtDestination(path)) => {
-            log::debug!("Repo already exists: {path:?}");
-            Ok(HttpResponse::Conflict()
-                .json(StatusMessage::error("Repo already exists at destination.")))
-        }
         Err(err) => {
             log::error!("Failed to fork repository: {err:?}");
             Err(OxenHttpError::from(err))
@@ -90,7 +85,7 @@ pub async fn get_status(req: HttpRequest) -> Result<HttpResponse, OxenHttpError>
 
     match repositories::fork::get_fork_status(&repo_path) {
         Ok(status) => Ok(HttpResponse::Ok().json(status)),
-        Err(OxenError::ForkStatusNotFound(_)) => {
+        Err(OxenError::ForkStatusNotFound) => {
             Ok(HttpResponse::NotFound().json(StatusMessage::error("Fork status not found")))
         }
         Err(e) => {

--- a/crates/server/src/controllers/import.rs
+++ b/crates/server/src/controllers/import.rs
@@ -107,9 +107,7 @@ pub async fn import(
     let branch = resource
         .branch
         .clone()
-        .ok_or(OxenError::local_branch_not_found(
-            resource.version.to_string_lossy(),
-        ))?;
+        .ok_or_else(|| OxenError::local_branch_not_found(resource.version.to_string_lossy()))?;
     let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
     let directory = resource.path.clone();
     log::debug!("workspace::files::import_file Got directory: {directory:?}");
@@ -247,9 +245,7 @@ pub async fn upload_zip(
     let branch = resource
         .branch
         .clone()
-        .ok_or(OxenError::local_branch_not_found(
-            resource.version.to_string_lossy(),
-        ))?;
+        .ok_or_else(|| OxenError::local_branch_not_found(resource.version.to_string_lossy()))?;
     let directory = resource.path.clone();
     let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
 

--- a/crates/server/src/controllers/merger.rs
+++ b/crates/server/src/controllers/merger.rs
@@ -39,8 +39,8 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
     let (base_commit, head_commit) = resolve_base_head_branches(&repository, &base, &head)?;
-    let base = base_commit.ok_or(OxenError::revision_not_found(base.into()))?;
-    let head = head_commit.ok_or(OxenError::revision_not_found(head.into()))?;
+    let base = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
+    let head = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
 
     // Check if mergeable
     let conflicts =
@@ -98,10 +98,12 @@ pub async fn merge(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
     let (maybe_base_branch, maybe_head_branch) = resolve_base_head_branches(&repo, &base, &head)?;
-    let base_branch =
-        maybe_base_branch.ok_or(OxenError::revision_not_found(base.clone().into()))?;
-    let head_branch =
-        maybe_head_branch.ok_or(OxenError::revision_not_found(head.clone().into()))?;
+    let Some(base_branch) = maybe_base_branch else {
+        return Err(OxenError::RevisionNotFound(base.into()).into());
+    };
+    let Some(head_branch) = maybe_head_branch else {
+        return Err(OxenError::RevisionNotFound(head.into()).into());
+    };
 
     // .unwrap() safe because branches must have commits
     let base_commit = repositories::commits::get_by_id(&repo, &base_branch.commit_id)?.unwrap();
@@ -126,9 +128,9 @@ pub async fn merge(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
         }
         Ok(None) => {
             log::debug!("Merge has conflicts");
-            Err(OxenError::merge_conflict(format!(
-                "Unable to merge {head} into {base} due to conflicts"
-            )))?
+            Err(OxenError::UpstreamMergeConflict(
+                format!("Unable to merge {head} into {base} due to conflicts.").into(),
+            ))?
         }
         Err(err) => {
             log::debug!("Err merging branches {err:?}");

--- a/crates/server/src/controllers/metadata.rs
+++ b/crates/server/src/controllers/metadata.rs
@@ -51,7 +51,7 @@ pub async fn file(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     );
 
     let latest_commit = repositories::commits::get_by_id(&repo, &commit.id)?
-        .ok_or(OxenError::revision_not_found(commit.id.clone().into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(commit.id.as_str().into()))?;
 
     log::debug!(
         "{} resolve commit {} -> '{}'",
@@ -126,7 +126,7 @@ pub async fn update_metadata(req: HttpRequest) -> actix_web::Result<HttpResponse
     let version_str = resource
         .version
         .to_str()
-        .ok_or(OxenHttpError::BadRequest("Missing resource version".into()))?;
+        .ok_or_else(|| OxenHttpError::BadRequest("Missing resource version".into()))?;
 
     repositories::entries::update_metadata(&repo, version_str)?;
     Ok(HttpResponse::Ok().json(StatusMessage::resource_updated()))

--- a/crates/server/src/controllers/repositories.rs
+++ b/crates/server/src/controllers/repositories.rs
@@ -307,7 +307,7 @@ async fn handle_json_creation(
                 },
                 metadata_entries: None,
             })),
-            Err(OxenError::NoCommitsFound(_)) => {
+            Err(OxenError::NoCommitsFound) => {
                 Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
                     status: STATUS_SUCCESS.to_string(),
                     status_message: MSG_RESOURCE_FOUND.to_string(),
@@ -420,10 +420,10 @@ async fn handle_multipart_creation(
                     user: User {
                         name: name
                             .clone()
-                            .ok_or(OxenHttpError::BadRequest("Name is required".into()))?,
+                            .ok_or_else(|| OxenHttpError::BadRequest("Name is required".into()))?,
                         email: email
                             .clone()
-                            .ok_or(OxenHttpError::BadRequest("Email is required".into()))?,
+                            .ok_or_else(|| OxenHttpError::BadRequest("Email is required".into()))?,
                     },
                 });
             }
@@ -453,7 +453,7 @@ async fn handle_multipart_creation(
                 },
                 metadata_entries: repo.entries,
             })),
-            Err(OxenError::NoCommitsFound(_)) => {
+            Err(OxenError::NoCommitsFound) => {
                 Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
                     status: STATUS_SUCCESS.to_string(),
                     status_message: MSG_RESOURCE_FOUND.to_string(),

--- a/crates/server/src/controllers/schemas.rs
+++ b/crates/server/src/controllers/schemas.rs
@@ -59,7 +59,7 @@ pub async fn list_or_get(req: HttpRequest) -> actix_web::Result<HttpResponse, Ox
     let revision = path_param(&req, "resource")?;
 
     let commit = repositories::revisions::get(&repo, &revision)?
-        .ok_or(OxenError::revision_not_found(revision.to_owned().into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(revision.as_str().into()))?;
 
     log::debug!("schemas::list_or_get revision {revision} commit {commit}");
 

--- a/crates/server/src/controllers/tree.rs
+++ b/crates/server/src/controllers/tree.rs
@@ -231,7 +231,7 @@ pub async fn download_tree_nodes(
 
     let (base_commit_id, maybe_head_commit_id) = maybe_parse_base_head(base_head_str)?;
     let base_commit = repositories::commits::get_by_id(&repository, &base_commit_id)?
-        .ok_or(OxenError::revision_not_found(base_commit_id.into()))?;
+        .ok_or_else(|| OxenError::RevisionNotFound(base_commit_id.into()))?;
 
     // Parse the subtrees
     let subtrees = get_subtree_paths(&query.subtrees)?;
@@ -283,7 +283,7 @@ fn get_commit_list(
     // The first pull doesn't have a head commit, but subsequent pulls do
     let mut commits = if let Some(head_commit_id) = maybe_head_commit_id {
         let head_commit = repositories::commits::get_by_id(repository, head_commit_id)?
-            .ok_or(OxenError::resource_not_found(head_commit_id))?;
+            .ok_or_else(|| OxenError::resource_not_found(head_commit_id))?;
         repositories::commits::list_between(repository, base_commit, &head_commit)?
     } else {
         // If the subtree is specified, we only want to get the latest commit

--- a/crates/server/src/controllers/versions.rs
+++ b/crates/server/src/controllers/versions.rs
@@ -126,7 +126,7 @@ pub async fn download(
     log::debug!("Download resource {namespace}/{repo_name}/{resource} version file");
 
     let entry = repositories::entries::get_file(&repo, &commit, &path)?
-        .ok_or(OxenError::path_does_not_exist(path.clone()))?;
+        .ok_or_else(|| OxenError::path_does_not_exist(path.clone()))?;
     let file_hash = entry.hash();
     let hash_str = file_hash.to_string();
     let mime_type = entry.mime_type();

--- a/crates/server/src/controllers/workspaces/data_frames.rs
+++ b/crates/server/src/controllers/workspaces/data_frames.rs
@@ -489,10 +489,10 @@ pub async fn get_by_branch(
 
     // Staged dataframes must be on a branch.
     let branch = repositories::branches::get_by_name(&repo, branch_name)?
-        .ok_or(OxenError::remote_branch_not_found(branch_name))?;
+        .ok_or_else(|| OxenError::remote_branch_not_found(branch_name))?;
 
     let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?
-        .ok_or(OxenError::resource_not_found(&branch.commit_id))?;
+        .ok_or_else(|| OxenError::resource_not_found(&branch.commit_id))?;
 
     let entries = repositories::entries::list_tabular_files_in_repo(&repo, &commit)?;
     log::debug!("got {} tabular entries", entries.len());

--- a/crates/server/src/controllers/workspaces/data_frames/columns.rs
+++ b/crates/server/src/controllers/workspaces/data_frames/columns.rs
@@ -315,7 +315,7 @@ pub async fn add_column_metadata(
     // Extract the column_name and metadata from the parsed JSON
     let column_name = parsed_json["column_name"]
         .as_str()
-        .ok_or(OxenHttpError::BasicError("column_name is required".into()))?;
+        .ok_or_else(|| OxenHttpError::BasicError("column_name is required".into()))?;
     let column_metadata = &parsed_json["metadata"];
 
     repositories::workspaces::data_frames::columns::add_column_metadata(

--- a/crates/server/src/errors.rs
+++ b/crates/server/src/errors.rs
@@ -241,14 +241,12 @@ impl error::ResponseError for OxenHttpError {
                 match error {
                     OxenError::RepoNotFound(repo) => {
                         log::debug!("Repo not found: {repo}");
-
                         HttpResponse::NotFound().json(StatusMessageDescription::not_found(format!(
                             "Repository '{repo}' not found"
                         )))
                     }
                     OxenError::ResourceNotFound(resource) => {
                         log::debug!("Resource not found: {resource}");
-
                         let error_json = json!({
                             "error": {
                                 "type": MSG_RESOURCE_NOT_FOUND,
@@ -258,12 +256,10 @@ impl error::ResponseError for OxenHttpError {
                             "status": STATUS_ERROR,
                             "status_message": MSG_RESOURCE_NOT_FOUND,
                         });
-
                         HttpResponse::NotFound().json(error_json)
                     }
                     OxenError::ParsedResourceNotFound(resource) => {
                         log::debug!("Resource not found: {resource}");
-
                         let error_json = json!({
                             "error": {
                                 "type": MSG_RESOURCE_NOT_FOUND,
@@ -273,7 +269,6 @@ impl error::ResponseError for OxenHttpError {
                             "status": STATUS_ERROR,
                             "status_message": MSG_RESOURCE_NOT_FOUND,
                         });
-
                         HttpResponse::NotFound().json(error_json)
                     }
                     OxenError::BranchNotFound(branch) => {
@@ -286,7 +281,6 @@ impl error::ResponseError for OxenHttpError {
                             "status": STATUS_ERROR,
                             "status_message": MSG_RESOURCE_NOT_FOUND,
                         });
-
                         HttpResponse::NotFound().json(error_json)
                     }
                     OxenError::RevisionNotFound(revision) => {
@@ -299,12 +293,10 @@ impl error::ResponseError for OxenHttpError {
                             "status": STATUS_ERROR,
                             "status_message": MSG_RESOURCE_NOT_FOUND,
                         });
-
                         HttpResponse::NotFound().json(error_json)
                     }
                     OxenError::PathDoesNotExist(path) => {
                         log::debug!("Path does not exist: {path}");
-
                         let error_json = json!({
                             "error": {
                                 "type": MSG_RESOURCE_NOT_FOUND,
@@ -314,12 +306,10 @@ impl error::ResponseError for OxenHttpError {
                             "status": STATUS_ERROR,
                             "status_message": MSG_RESOURCE_NOT_FOUND,
                         });
-
                         HttpResponse::NotFound().json(error_json)
                     }
                     OxenError::WorkspaceNotFound(workspace) => {
                         log::error!("Workspace not found: {workspace}");
-
                         let error_json = json!({
                             "error": {
                                 "type": MSG_RESOURCE_NOT_FOUND,
@@ -329,19 +319,16 @@ impl error::ResponseError for OxenHttpError {
                             "status": STATUS_ERROR,
                             "status_message": MSG_RESOURCE_NOT_FOUND,
                         });
-
                         HttpResponse::NotFound().json(error_json)
                     }
                     OxenError::RemoteRepoNotFound(remote) => {
                         log::debug!("Remote repo not found: {remote}");
-
                         HttpResponse::NotFound().json(StatusMessageDescription::not_found(format!(
                             "Remote repository not found: {remote}"
                         )))
                     }
                     OxenError::CommitEntryNotFound(msg) => {
                         log::error!("{msg}");
-
                         let error_json = json!({
                             "error": {
                                 "type": MSG_RESOURCE_NOT_FOUND,
@@ -351,12 +338,10 @@ impl error::ResponseError for OxenHttpError {
                             "status": STATUS_ERROR,
                             "status_message": MSG_RESOURCE_NOT_FOUND,
                         });
-
                         HttpResponse::NotFound().json(error_json)
                     }
                     OxenError::UpstreamMergeConflict(desc) => {
                         log::error!("Upstream merge conflict: {desc}");
-
                         let error_json = json!({
                             "error": {
                                 "type": MSG_CONFLICT,
@@ -366,28 +351,15 @@ impl error::ResponseError for OxenHttpError {
                             "status": STATUS_ERROR,
                             "status_message": MSG_CONFLICT,
                         });
-
                         HttpResponse::Conflict().json(error_json)
                     }
                     OxenError::InvalidSchema(schema) => {
                         log::error!("Invalid schema: {schema}");
-
                         HttpResponse::BadRequest().json(StatusMessageDescription::bad_request(
                             format!("Schema is invalid: '{schema}'"),
                         ))
                     }
-                    OxenError::RemoteAheadOfLocal(desc) => {
-                        log::error!("Remote ahead of local: {desc}");
 
-                        HttpResponse::BadRequest()
-                            .json(StatusMessageDescription::bad_request(format!("{desc}")))
-                    }
-                    OxenError::IncompleteLocalHistory(desc) => {
-                        log::error!("Cannot push repo with incomplete local history: {desc}");
-
-                        HttpResponse::BadRequest()
-                            .json(StatusMessageDescription::bad_request(format!("{desc}")))
-                    }
                     OxenError::IncompatibleSchemas(schema) => {
                         log::error!("Incompatible schemas: {schema}");
 
@@ -447,8 +419,10 @@ impl error::ResponseError for OxenHttpError {
                         let error_json = json!({
                             "error": {
                                 "type": "invalid_repo_name",
-                                "title": "Invalid Repository Name",
-                                "detail": format!("Invalid repository or namespace name '{name}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+"),
+                                "title":
+                                    "Invalid Repository Name",
+                                "detail":
+                                    format!("Invalid repository or namespace name '{name}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+"),
                             },
                             "status": STATUS_ERROR,
                             "status_message": MSG_BAD_REQUEST,
@@ -471,7 +445,6 @@ impl error::ResponseError for OxenHttpError {
                     }
                     OxenError::DUCKDB(error) => {
                         log::error!("DuckDB error: {error}");
-
                         let error_json = json!({
                             "error": {
                                 "type": "query_error",
@@ -512,13 +485,13 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::InternalServerError().json(error_json)
                     }
-                    OxenError::ThumbnailingNotEnabled(error) => {
-                        log::error!("Thumbnailing not enabled: {error}");
+                    thumbnail_error @ OxenError::ThumbnailingNotEnabled => {
+                        log::error!("Thumbnailing not enabled: {thumbnail_error}");
                         let error_json = json!({
                             "error": {
                                 "type": "thumbnailing_not_enabled",
                                 "title": "Thumbnailing Not Enabled",
-                                "detail": format!("{}", error),
+                                "detail": format!("{thumbnail_error}"),
                             },
                             "status": STATUS_ERROR,
                             "status_message": MSG_INTERNAL_SERVER_ERROR,
@@ -536,18 +509,83 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::InternalServerError().json(error_json)
                     }
-                    OxenError::NoRowsFound(msg) => {
-                        log::error!("No rows found: {msg}");
+                    e @ OxenError::NoRowsFound => {
+                        log::error!("No rows found: {e}");
                         let error_json = json!({
                             "error": {
                                 "type": "no_rows_found",
                                 "title": "No rows found",
-                                "detail": format!("{}", msg),
+                                "detail": format!("{e}"),
                             },
                             "status": STATUS_ERROR,
                             "status_message": MSG_INTERNAL_SERVER_ERROR,
                         });
                         HttpResponse::NotFound().json(error_json)
+                    }
+                    OxenError::LocalRepoNotFound(path) => {
+                        log::debug!("Local repo not found: {path}");
+                        let error_json = json!({
+                            "error": {
+                                "type": MSG_RESOURCE_NOT_FOUND,
+                                "title": "Local repository not found",
+                                "detail": format!("No oxen repository found at {path}")
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_RESOURCE_NOT_FOUND,
+                        });
+                        HttpResponse::NotFound().json(error_json)
+                    }
+                    OxenError::HeadNotFound => {
+                        log::debug!("HEAD not found");
+                        let error_json = json!({
+                            "error": {
+                                "type": MSG_RESOURCE_NOT_FOUND,
+                                "title": "HEAD not found",
+                                "detail": "HEAD not found."
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_RESOURCE_NOT_FOUND,
+                        });
+                        HttpResponse::NotFound().json(error_json)
+                    }
+                    OxenError::NoCommitsFound => {
+                        log::debug!("No commits found");
+                        let error_json = json!({
+                            "error": {
+                                "type": MSG_RESOURCE_NOT_FOUND,
+                                "title": "No commits found",
+                                "detail": "No commits found."
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_RESOURCE_NOT_FOUND,
+                        });
+                        HttpResponse::NotFound().json(error_json)
+                    }
+                    OxenError::QueryableWorkspaceNotFound => {
+                        log::debug!("Queryable workspace not found");
+                        let error_json = json!({
+                            "error": {
+                                "type": MSG_RESOURCE_NOT_FOUND,
+                                "title": "Queryable workspace not found",
+                                "detail": "Queryable workspace not found."
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_RESOURCE_NOT_FOUND,
+                        });
+                        HttpResponse::NotFound().json(error_json)
+                    }
+                    OxenError::WorkspaceBehind(workspace) => {
+                        log::error!("Workspace behind: {workspace}");
+                        let error_json = json!({
+                            "error": {
+                                "type": MSG_CONFLICT,
+                                "title": "Workspace is behind",
+                                "detail": format!("Workspace '{}' is behind at commit {}", workspace.id, workspace.commit.id)
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_CONFLICT,
+                        });
+                        HttpResponse::Conflict().json(error_json)
                     }
                     err => {
                         log::error!("Internal server error: {err:?}");

--- a/crates/server/src/helpers.rs
+++ b/crates/server/src/helpers.rs
@@ -31,8 +31,8 @@ pub fn create_user_from_options(
     email: Option<String>,
 ) -> actix_web::Result<User, OxenHttpError> {
     Ok(User {
-        name: name.ok_or(OxenHttpError::BadRequest("Name is required".into()))?,
-        email: email.ok_or(OxenHttpError::BadRequest("Email is required".into()))?,
+        name: name.ok_or_else(|| OxenHttpError::BadRequest("Name is required".into()))?,
+        email: email.ok_or_else(|| OxenHttpError::BadRequest("Email is required".into()))?,
     })
 }
 

--- a/crates/server/src/params.rs
+++ b/crates/server/src/params.rs
@@ -76,7 +76,7 @@ pub fn path_param(req: &HttpRequest, param: &str) -> Result<String, OxenHttpErro
     Ok(req
         .match_info()
         .get(param)
-        .ok_or(OxenHttpError::PathParamDoesNotExist(param.into()))?
+        .ok_or_else(|| OxenHttpError::PathParamDoesNotExist(param.into()))?
         .to_string())
 }
 
@@ -110,7 +110,7 @@ pub fn parse_resource(
         "parse_resource_from_path looking for resource: {resource:?} decoded_resource: {decoded_resource:?}"
     );
     parse_resource_from_path(repo, &decoded_resource)?
-        .ok_or(OxenError::path_does_not_exist(resource).into())
+        .ok_or_else(|| OxenError::path_does_not_exist(resource).into())
 }
 
 /// Split the base..head string into base and head strings


### PR DESCRIPTION
**`OxenError` Variants**:
Adding docstrings to all `OxenError` variants. Docstring explains what the variant is
and, if applicable, the situations and code paths where it is encountered. Also,
formatted and re-structured the `impl` block to focus on user-facing elements (hints),
introspection-based functions (`is_...)`, and constructor functions. To organize the
constructors, they're now separated by ones that produce variants and ones that are
`OxenError::Basic` string. The latter has TODO documentation put in describing the
next step of migrating these to their own structured `OxenError` variant.

Audited all `OxenError` variants and identified variants that are never used in code.
These variants have been removed.

Additionally, some variants only ever use statically allocated strings as their inner
value. These have been replaced with non-value bearing enum variants.

A new `RemoteNotSet(String)` enum has replaced the `basic_str` use of `remote_not_set`.

**`.ok_or_else(|| OxenError...)`**:
Audit uncovered unnecessary allocation of many `OxenError` variants in `.ok_or(...)`
constructs on `Result` values. This allocates space for the error even if the `Result`
itself is `Ok`: this value is created and immediately discarded.

All locations of `.ok_or(..)` that were creating an `OxenError` have now been changed
to use the lazily-called variant, `.ok_or_else(|| ...)`, which only constructs
the `OxenError` variant when it is necessary.

**Not-Found & OxenHttpError**
Adds new `OxenHttpError::error_response` match arms for the newly promoted
`OxenError::Basic`-str to structured variants that are considered "not found" to treat
these as `404 Not Found` instead of `500 Internal Server Error`.

**Workspace Behind is HTTP Conflict**
Adds a new match arm in `OxenHttpError::error_response` to treat the `WorkspaceBehind`
error as a HTTP conflict (`409 Conflict`) instead of a 500 error.