### PR TITLE
Use a larger runner for Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -22,7 +22,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -73,14 +73,10 @@ jobs:
           # Use ramdisk for cargo build artifacts
           echo "CARGO_TARGET_DIR=R:\target" >> $env:GITHUB_ENV
 
-          # Move repo data directory to ramdisk for faster test I/O
-          if (Test-Path "data") {
-            Copy-Item -Recurse -Path "data" -Destination "R:\data"
-            Remove-Item -Recurse -Force "data"
-          } else {
-            New-Item -ItemType Directory -Path "R:\data" | Out-Null
-          }
-          cmd /c mklink /J data R:\data
+          # Junction only the test runs directory to ramdisk for faster test I/O
+          New-Item -ItemType Directory -Path "R:\runs" | Out-Null
+          New-Item -ItemType Directory -Path "data\test" -Force | Out-Null
+          cmd /c mklink /J data\test\runs R:\runs
 
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -83,6 +83,7 @@ jobs:
           cache: true # This is the default--making it explicit. This uses Swatinem/rust-cache under the hood.
           cache-all-crates: true
           cache-workspace-crates: true
+          cache-directories: ${{ env.CARGO_TARGET_DIR }} # Cache cargo build artifacts on the ramdisk in windows
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -139,8 +139,7 @@ jobs:
           mkdir .\data\test\runs
 
       - name: Build oxen rust project
-        run: |
-          cargo build --workspace
+        run: cargo build --workspace --profile test # use test profile so we don't have to rebuild later
 
       - name: Setup oxen-server user (Linux/macOS)
         if: matrix.platform != 'windows'
@@ -206,7 +205,7 @@ jobs:
 
           uv sync --no-install-project
           source .venv/bin/activate
-          maturin develop
+          maturin develop --profile test
           pytest -s tests
 
       - name: Run oxen-python tests (Windows)
@@ -219,5 +218,5 @@ jobs:
           uv sync --no-install-project
           dir .venv
           .venv\Scripts\Activate.ps1
-          maturin develop
+          maturin develop --profile test
           pytest -s tests --ignore=tests/test_data_frame.py --ignore=tests/test_embeddings.py --ignore=tests/test_fsspec_backend.py

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -102,7 +102,7 @@ jobs:
           mkdir .\data\test\runs
 
       - name: Build oxen rust project
-        run: cargo build --workspace
+        run: cargo test --no-run --workspace
 
       - name: Setup oxen-server user (Linux/macOS)
         if: matrix.platform != 'windows'
@@ -120,13 +120,13 @@ jobs:
         if: matrix.platform != 'windows'
         run: |
           ./target/debug/oxen-server start &
-          cargo nextest run --workspace --profile ci --cargo-profile dev
+          cargo nextest run --workspace --profile ci
 
       - name: Run oxen rust tests (Windows)
         if: matrix.platform == 'windows'
         run: |
           Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start"
-          cargo nextest run --workspace --profile ci --cargo-profile dev
+          cargo nextest run --workspace --profile ci
 
       # CLI Tests
       - name: Run CLI tests (Linux/macOS)
@@ -215,8 +215,25 @@ jobs:
           brew install redis pkg-config
           brew services start redis
 
-      - name: Build oxen rust project
-        run: cargo build --workspace
+      - name: Setup Python venv
+        run: |
+          cd ${{ github.workspace }}/oxen-python
+          uv sync --no-install-project
+
+      # maturin compiles liboxen and all shared deps for the Python extension.
+      - name: Build oxen (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: |
+          cd ${{ github.workspace }}/oxen-python
+          source .venv/bin/activate
+          maturin develop
+
+      - name: Build oxen (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          cd ${{ github.workspace }}\oxen-python
+          .venv\Scripts\Activate.ps1
+          maturin develop
 
       - name: Setup test directories (Linux/macOS)
         if: matrix.platform != 'windows'
@@ -266,17 +283,12 @@ jobs:
         if: matrix.platform != 'windows'
         run: |
           cd ${{ github.workspace }}/oxen-python
-          uv sync --no-install-project
           source .venv/bin/activate
-          maturin develop
           pytest -s tests
 
       - name: Run oxen-python tests (Windows)
         if: matrix.platform == 'windows'
         run: |
           cd ${{ github.workspace }}\oxen-python
-          uv sync --no-install-project
-          dir .venv
           .venv\Scripts\Activate.ps1
-          maturin develop
           pytest -s tests --ignore=tests/test_data_frame.py --ignore=tests/test_embeddings.py --ignore=tests/test_fsspec_backend.py

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -67,13 +67,13 @@ jobs:
       - name: Setup ramdisk (Windows)
         if: matrix.platform == 'windows'
         run: |
-          # Layer 1: imdisk ramdisk at T: (RAM-backed, but driver lacks full NTFS support, so building libduckdb-sys fails)
+          # Layer 1: imdisk ramdisk at T: (RAM-backed, but driver lacks full NTFS support, so building libduckdb-sys )
           choco install imdisk -y
-          imdisk -a -s 12G -m T: -p "/fs:ntfs /q /y"
+          imdisk -a -s 18G -m T: -p "/fs:ntfs /q /y"
 
           # Layer 2: VHD file on the ramdisk, mounted at R: (standard NTFS driver, full support)
           @"
-          create vdisk file="T:\build.vhdx" maximum=11264 type=fixed
+          create vdisk file="T:\build.vhdx" maximum=17920 type=fixed
           select vdisk file="T:\build.vhdx"
           attach vdisk
           create partition primary

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -67,27 +67,22 @@ jobs:
       - name: Setup ramdisk (Windows)
         if: matrix.platform == 'windows'
         run: |
-          # Layer 1: imdisk ramdisk at T: (RAM-backed, but driver lacks full NTFS support, so building libduckdb-sys )
+          # Layer 1: imdisk ramdisk at T: (RAM-backed, but driver lacks full NTFS support)
           choco install imdisk -y
           imdisk -a -s 18G -m T: -p "/fs:ntfs /q /y"
 
-          # Layer 2: VHD file on the ramdisk, mounted at R: (standard NTFS driver, full support)
+          # Layer 2: VHD file on the ramdisk, mounted at R: (standard NTFS driver, full canonicalize support)
           @"
           create vdisk file="T:\build.vhdx" maximum=17920 type=fixed
           select vdisk file="T:\build.vhdx"
           attach vdisk
           create partition primary
-          format fs=ntfs quick label=CargoBuild
+          format fs=ntfs quick label=TestData
           assign letter=R
           "@ | diskpart
 
-          # Use ramdisk for cargo build artifacts
-          echo "CARGO_TARGET_DIR=R:\target" >> $env:GITHUB_ENV
-
-          # Use ramdisk for oxen-server sync directory
+          # Use ramdisk for oxen-server sync directory and test runs (not cargo target--too large)
           echo "SYNC_DIR=R:\sync" >> $env:GITHUB_ENV
-
-          # Use ramdisk for test harness run directories
           echo "OXEN_TEST_RUN_DIR=R:\test\runs" >> $env:GITHUB_ENV
 
       - name: Setup Rust Toolchain
@@ -97,7 +92,7 @@ jobs:
           cache: true # This is the default--making it explicit. This uses Swatinem/rust-cache under the hood.
           cache-all-crates: true
           cache-workspace-crates: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }} # Cache cargo build artifacts on the ramdisk in windows
+          cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -181,7 +176,7 @@ jobs:
       - name: Setup oxen-server user (Windows)
         if: matrix.platform == 'windows'
         run: |
-          & "$env:CARGO_TARGET_DIR\debug\oxen-server.exe" add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
           copy user_config.toml data\test\config\user_config.toml
 
       - name: Run oxen rust tests (Linux/macOS)
@@ -193,7 +188,7 @@ jobs:
       - name: Run oxen rust tests (Windows)
         if: matrix.platform == 'windows'
         run: |
-          Start-Process "$env:CARGO_TARGET_DIR\debug\oxen-server.exe" -ArgumentList "start"
+          Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start"
           cargo nextest run --workspace --profile ci --cargo-profile dev
 
       # CLI Tests
@@ -209,7 +204,7 @@ jobs:
       - name: Run CLI tests (Windows)
         if: matrix.platform == 'windows'
         env:
-          PATH: ${{ env.PATH }};${{ env.CARGO_TARGET_DIR }}\debug
+          PATH: ${{ env.PATH }};${{ github.workspace }}\target\debug
         run: |
           cd ${{ github.workspace }}\cli-test
           uv sync
@@ -225,7 +220,7 @@ jobs:
       - name: Copy binaries for Python tests (Windows)
         if: matrix.platform == 'windows'
         run: |
-          copy "$env:CARGO_TARGET_DIR\debug\oxen.exe" ${{ github.workspace }}\oxen.exe
+          copy target\debug\oxen.exe ${{ github.workspace }}\oxen.exe
 
       - name: Run oxen-python tests (Linux/macOS)
         if: matrix.platform != 'windows'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -102,7 +102,7 @@ jobs:
           mkdir .\data\test\runs
 
       - name: Build oxen rust project
-        run: cargo test --no-run --workspace
+        run: cargo build --workspace
 
       - name: Setup oxen-server user (Linux/macOS)
         if: matrix.platform != 'windows'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -3,9 +3,17 @@ name: 🐂📝 Continuous integration - Test Suite
 on:
   workflow_call:
 
+env:
+  AWS_REGION: us-west-1
+  AWS_ROLE: arn:aws:iam::213020545630:role/ci-test-integration-role
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
-  test:
-    name: Test Suite
+  rust-tests:
+    name: Rust Tests
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -24,14 +32,6 @@ jobs:
             platform: windows
             shell: powershell
       fail-fast: false
-
-    env:
-      AWS_REGION: us-west-1
-      AWS_ROLE: arn:aws:iam::213020545630:role/ci-test-integration-role
-
-    permissions:
-      id-token: write
-      contents: read
 
     steps:
       - name: Free up disk space
@@ -64,16 +64,6 @@ jobs:
           role-duration-seconds: 3600
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Setup ramdisk (Windows)
-        if: matrix.platform == 'windows'
-        run: |
-          choco install imdisk -y
-          imdisk -a -s 16G -m R: -p "/fs:ntfs /q /y"
-
-          # Use ramdisk for oxen-server sync directory and test runs (not cargo target--too large)
-          echo "SYNC_DIR=R:\sync" >> $env:GITHUB_ENV
-          echo "OXEN_TEST_RUN_DIR=R:\test\runs" >> $env:GITHUB_ENV
-
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -81,7 +71,6 @@ jobs:
           cache: true # This is the default--making it explicit. This uses Swatinem/rust-cache under the hood.
           cache-all-crates: true
           cache-workspace-crates: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -94,45 +83,6 @@ jobs:
           brew update
           brew install redis pkg-config
           brew services start redis
-
-          # NOTE: This adds a lot of bloat and takes a long time to build.
-          #       we have ffmpeg disabled by default in the CI pipeline
-          # Set PKG_CONFIG_PATH so pkg-config can find FFmpeg libraries
-          # brew install ffmpeg@7 imagemagick
-          # echo "PKG_CONFIG_PATH=$(brew --prefix ffmpeg@7)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
-
-      # NOTE: This adds a lot of bloat to the Windows image and takes a long time to build.
-      #       we have ffmpeg disabled by default in the CI pipeline
-      # - name: Install dependencies (Linux)
-      #   if: matrix.platform == 'linux'
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt install -y clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev pkg-config
-
-      # - name: Install dependencies (Windows)
-      #   if: matrix.platform == 'windows'
-      #   run: |
-      #     # Install clang (via llvm) and pkg-config via Chocolatey
-      #     choco install -y llvm pkgconfiglite
-
-      #     # Install vcpkg for FFmpeg static development libraries (libavcodec, libavformat, libavutil, libavfilter, libavdevice)
-      #     # Using x64-windows-static-md for static libraries with dynamic MSVC runtime (better compatibility)
-      #     git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
-      #     cd C:\vcpkg
-      #     .\bootstrap-vcpkg.bat
-
-      #     # Install FFmpeg (includes libavutil, libavcodec, libavformat, libavfilter, libavdevice)
-      #     # FFmpeg installation provides libavutil.pc and other .pc files needed by pkg-config
-      #     .\vcpkg.exe install ffmpeg:x64-windows-static-md
-
-      #     # Set VCPKG_ROOT for cargo to find FFmpeg libraries
-      #     echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
-
-      #     # Set PKG_CONFIG_PATH so pkg-config can find libavutil.pc and other FFmpeg .pc files
-      #     # vcpkg installs pkg-config files in the installed/<triplet>/lib/pkgconfig directory
-      #     # This must be set before cargo build runs, as ffmpeg-sys-next uses pkg-config during build
-      #     $pkgConfigPath = "C:\vcpkg\installed\x64-windows-static-md\lib\pkgconfig"
-      #     echo "PKG_CONFIG_PATH=$pkgConfigPath" >> $env:GITHUB_ENV
 
       - name: Install nextest runner
         uses: taiki-e/install-action@v2
@@ -150,8 +100,6 @@ jobs:
         if: matrix.platform == 'windows'
         run: |
           mkdir .\data\test\runs
-          mkdir R:\test\runs
-          mkdir R:\sync
 
       - name: Build oxen rust project
         run: cargo build --workspace
@@ -199,25 +147,125 @@ jobs:
           uv sync
           uv run pytest tests -v
 
-      # Oxen Python Tests
-      - name: Copy binaries for Python tests (Linux/macOS)
+  python-tests:
+    name: Python Tests
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-x64-8cpu-32ram-300ssd]
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            shell: bash -leo pipefail {0}
+          - os: macos-latest
+            platform: macos
+            shell: bash -leo pipefail {0}
+          - os: windows-x64-8cpu-32ram-300ssd
+            platform: windows
+            shell: powershell
+      fail-fast: false
+
+    steps:
+      - name: Free up disk space
+        if: matrix.platform == 'linux'
+        run: |
+          echo "=== Before cleanup ==="
+          df -h
+
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo apt-get clean
+
+          echo "=== After cleanup ==="
+          df -h
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          role-duration-seconds: 3600
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ${{ matrix.platform == 'windows' && '-D warnings -C link-arg=/DEBUG:NONE' || '-D warnings' }}
+          cache: true
+          cache-all-crates: true
+          cache-workspace-crates: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies (macOS)
+        if: matrix.platform == 'macos'
+        run: |
+          brew update
+          brew install redis pkg-config
+          brew services start redis
+
+      - name: Build oxen binaries
+        run: cargo build -p oxen-cli -p oxen-server
+
+      - name: Setup test directories (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: |
+          mkdir -p data/test/runs
+          mkdir -p /tmp/oxen_sync/
+
+      - name: Setup test directories (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          mkdir .\data\test\runs
+
+      - name: Setup oxen-server user (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: |
+          ./target/debug/oxen-server add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          cp user_config.toml data/test/config/user_config.toml
+
+      - name: Setup oxen-server user (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          copy user_config.toml data\test\config\user_config.toml
+
+      - name: Start oxen-server (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: ./target/debug/oxen-server start &
+
+      - name: Start oxen-server (Windows)
+        if: matrix.platform == 'windows'
+        run: Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start"
+
+      - name: Configure oxen user (Linux/macOS)
         if: matrix.platform != 'windows'
         run: |
           cp ${{ github.workspace }}/target/debug/oxen ~/oxen
-          chmod +x ~/oxen ~/oxen
+          chmod +x ~/oxen
+          ~/oxen config --name "Bessie Testington" --email "bessie@yourcompany.com"
 
-      - name: Copy binaries for Python tests (Windows)
+      - name: Configure oxen user (Windows)
         if: matrix.platform == 'windows'
         run: |
           copy target\debug\oxen.exe ${{ github.workspace }}\oxen.exe
+          ${{ github.workspace }}\oxen.exe config --name "Bessie Testington" --email "bessie@yourcompany.com"
 
       - name: Run oxen-python tests (Linux/macOS)
         if: matrix.platform != 'windows'
         run: |
           cd ${{ github.workspace }}/oxen-python
-
-          ~/oxen config --name "Bessie Testington" --email "bessie@yourcompany.com"
-
           uv sync --no-install-project
           source .venv/bin/activate
           maturin develop
@@ -227,9 +275,6 @@ jobs:
         if: matrix.platform == 'windows'
         run: |
           cd ${{ github.workspace }}\oxen-python
-
-          ${{ github.workspace }}\oxen.exe config --name "Bessie Testington" --email "bessie@yourcompany.com"
-
           uv sync --no-install-project
           dir .venv
           .venv\Scripts\Activate.ps1

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -215,8 +215,8 @@ jobs:
           brew install redis pkg-config
           brew services start redis
 
-      - name: Build oxen binaries
-        run: cargo build -p oxen-cli -p oxen-server
+      - name: Build oxen rust project
+        run: cargo build --workspace
 
       - name: Setup test directories (Linux/macOS)
         if: matrix.platform != 'windows'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -220,13 +220,15 @@ jobs:
           cd ${{ github.workspace }}/oxen-python
           uv sync --no-install-project
 
-      # maturin compiles liboxen and all shared deps for the Python extension.
+      # maturin compiles liboxen and all shared deps for the Python extension (dev profile).
+      # cargo build then (hopefully) reuses those artifacts and only links the CLI/server binaries.
       - name: Build oxen (Linux/macOS)
         if: matrix.platform != 'windows'
         run: |
           cd ${{ github.workspace }}/oxen-python
           source .venv/bin/activate
           maturin develop
+          cargo build -p oxen-cli -p oxen-server
 
       - name: Build oxen (Windows)
         if: matrix.platform == 'windows'
@@ -234,6 +236,7 @@ jobs:
           cd ${{ github.workspace }}\oxen-python
           .venv\Scripts\Activate.ps1
           maturin develop
+          cargo build -p oxen-cli -p oxen-server
 
       - name: Setup test directories (Linux/macOS)
         if: matrix.platform != 'windows'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -64,6 +64,24 @@ jobs:
           role-duration-seconds: 3600
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Setup ramdisk (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          choco install imdisk -y
+          imdisk -a -s 12G -m R: -p "/fs:ntfs /q /y"
+
+          # Use ramdisk for cargo build artifacts
+          echo "CARGO_TARGET_DIR=R:\target" >> $env:GITHUB_ENV
+
+          # Move repo data directory to ramdisk for faster test I/O
+          if (Test-Path "data") {
+            Copy-Item -Recurse -Path "data" -Destination "R:\data"
+            Remove-Item -Recurse -Force "data"
+          } else {
+            New-Item -ItemType Directory -Path "R:\data" | Out-Null
+          }
+          cmd /c mklink /J data R:\data
+
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -152,7 +170,7 @@ jobs:
       - name: Setup oxen-server user (Windows)
         if: matrix.platform == 'windows'
         run: |
-          .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          & "$env:CARGO_TARGET_DIR\debug\oxen-server.exe" add-user --email ox@oxen.ai --name Ox --output user_config.toml
           copy user_config.toml data\test\config\user_config.toml
 
       - name: Run oxen rust tests (Linux/macOS)
@@ -164,7 +182,7 @@ jobs:
       - name: Run oxen rust tests (Windows)
         if: matrix.platform == 'windows'
         run: |
-          Start-Process -FilePath "${{ github.workspace }}\target\debug\oxen-server.exe" -WindowStyle Hidden -ArgumentList "start"
+          Start-Process "$env:CARGO_TARGET_DIR\debug\oxen-server.exe" -ArgumentList "start"
           cargo nextest run --workspace --profile ci --cargo-profile dev
 
       # CLI Tests
@@ -180,7 +198,7 @@ jobs:
       - name: Run CLI tests (Windows)
         if: matrix.platform == 'windows'
         env:
-          PATH: ${{ env.PATH }};${{ github.workspace }}/target/debug
+          PATH: ${{ env.PATH }};${{ env.CARGO_TARGET_DIR }}\debug
         run: |
           cd ${{ github.workspace }}\cli-test
           uv sync
@@ -196,7 +214,7 @@ jobs:
       - name: Copy binaries for Python tests (Windows)
         if: matrix.platform == 'windows'
         run: |
-          copy target\debug\oxen.exe ${{ github.workspace }}\oxen.exe
+          copy "$env:CARGO_TARGET_DIR\debug\oxen.exe" ${{ github.workspace }}\oxen.exe
 
       - name: Run oxen-python tests (Linux/macOS)
         if: matrix.platform != 'windows'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -139,7 +139,7 @@ jobs:
           mkdir .\data\test\runs
 
       - name: Build oxen rust project
-        run: cargo build --workspace --profile test # use test profile so we don't have to rebuild later
+        run: cargo build --workspace
 
       - name: Setup oxen-server user (Linux/macOS)
         if: matrix.platform != 'windows'
@@ -157,13 +157,13 @@ jobs:
         if: matrix.platform != 'windows'
         run: |
           ./target/debug/oxen-server start &
-          cargo nextest run --workspace --profile ci
+          cargo nextest run --workspace --profile ci --cargo-profile dev
 
       - name: Run oxen rust tests (Windows)
         if: matrix.platform == 'windows'
         run: |
           Start-Process -FilePath "${{ github.workspace }}\target\debug\oxen-server.exe" -WindowStyle Hidden -ArgumentList "start"
-          cargo nextest run --workspace --profile ci
+          cargo nextest run --workspace --profile ci --cargo-profile dev
 
       # CLI Tests
       - name: Run CLI tests (Linux/macOS)
@@ -205,7 +205,7 @@ jobs:
 
           uv sync --no-install-project
           source .venv/bin/activate
-          maturin develop --profile test
+          maturin develop
           pytest -s tests
 
       - name: Run oxen-python tests (Windows)
@@ -218,5 +218,5 @@ jobs:
           uv sync --no-install-project
           dir .venv
           .venv\Scripts\Activate.ps1
-          maturin develop --profile test
+          maturin develop
           pytest -s tests --ignore=tests/test_data_frame.py --ignore=tests/test_embeddings.py --ignore=tests/test_fsspec_backend.py

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -67,19 +67,8 @@ jobs:
       - name: Setup ramdisk (Windows)
         if: matrix.platform == 'windows'
         run: |
-          # Layer 1: imdisk ramdisk at T: (RAM-backed, but driver lacks full NTFS support)
           choco install imdisk -y
-          imdisk -a -s 18G -m T: -p "/fs:ntfs /q /y"
-
-          # Layer 2: VHD file on the ramdisk, mounted at R: (standard NTFS driver, full canonicalize support)
-          @"
-          create vdisk file="T:\build.vhdx" maximum=17920 type=fixed
-          select vdisk file="T:\build.vhdx"
-          attach vdisk
-          create partition primary
-          format fs=ntfs quick label=TestData
-          assign letter=R
-          "@ | diskpart
+          imdisk -a -s 16G -m R: -p "/fs:ntfs /q /y"
 
           # Use ramdisk for oxen-server sync directory and test runs (not cargo target--too large)
           echo "SYNC_DIR=R:\sync" >> $env:GITHUB_ENV

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -12,7 +12,7 @@ jobs:
         shell: ${{ matrix.shell }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-x64-8cpu-32ram-300ssd]
         include:
           - os: ubuntu-latest
             platform: linux
@@ -20,7 +20,7 @@ jobs:
           - os: macos-latest
             platform: macos
             shell: bash -leo pipefail {0}
-          - os: windows-latest
+          - os: windows-x64-8cpu-32ram-300ssd
             platform: windows
             shell: powershell
       fail-fast: false

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -74,7 +74,7 @@ jobs:
           cache-key: rust
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           python-version: "3.11" # Test against the earliest supported Python version
 
@@ -206,7 +206,7 @@ jobs:
           cache-key: python
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -68,19 +68,14 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: ${{ matrix.platform == 'windows' && '-D warnings -C link-arg=/DEBUG:NONE' || '-D warnings' }}
+          cache: true # This is the default--making it explicit. This uses Swatinem/rust-cache under the hood.
+          cache-all-crates: true
+          cache-workspace-crates: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.11" # Test against the earliest supported Python version
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          # Only cache builds from main. Otherwise our caches will be too big and start to churn. (10 GB limit in GitHub Actions)
-          # Other branches will still use the cache but won't save it.
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          workspaces: "."
 
       - name: Install dependencies (macOS)
         if: matrix.platform == 'macos'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -67,8 +67,19 @@ jobs:
       - name: Setup ramdisk (Windows)
         if: matrix.platform == 'windows'
         run: |
+          # Layer 1: imdisk ramdisk at T: (RAM-backed, but driver lacks full NTFS support, so building libduckdb-sys fails)
           choco install imdisk -y
-          imdisk -a -s 12G -m R: -p "/fs:ntfs /q /y"
+          imdisk -a -s 12G -m T: -p "/fs:ntfs /q /y"
+
+          # Layer 2: VHD file on the ramdisk, mounted at R: (standard NTFS driver, full support)
+          @"
+          create vdisk file="T:\build.vhdx" maximum=11264 type=fixed
+          select vdisk file="T:\build.vhdx"
+          attach vdisk
+          create partition primary
+          format fs=ntfs quick label=CargoBuild
+          assign letter=R
+          "@ | diskpart
 
           # Use ramdisk for cargo build artifacts
           echo "CARGO_TARGET_DIR=R:\target" >> $env:GITHUB_ENV

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  rust-tests:
-    name: Rust Tests
+  test:
+    name: Test Suite
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -71,7 +71,6 @@ jobs:
           cache: true # This is the default--making it explicit. This uses Swatinem/rust-cache under the hood.
           cache-all-crates: true
           cache-workspace-crates: true
-          cache-key: rust
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.0.0
@@ -148,128 +147,25 @@ jobs:
           uv sync
           uv run pytest tests -v
 
-  python-tests:
-    name: Python Tests
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: ${{ matrix.shell }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-x64-8cpu-32ram-300ssd]
-        include:
-          - os: ubuntu-latest
-            platform: linux
-            shell: bash -leo pipefail {0}
-          - os: macos-latest
-            platform: macos
-            shell: bash -leo pipefail {0}
-          - os: windows-x64-8cpu-32ram-300ssd
-            platform: windows
-            shell: powershell
-      fail-fast: false
-
-    steps:
-      - name: Free up disk space
-        if: matrix.platform == 'linux'
-        run: |
-          echo "=== Before cleanup ==="
-          df -h
-
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/share/powershell
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo apt-get clean
-
-          echo "=== After cleanup ==="
-          df -h
-
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ env.AWS_ROLE }}
-          role-duration-seconds: 3600
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Setup Rust Toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          rustflags: ${{ matrix.platform == 'windows' && '-D warnings -C link-arg=/DEBUG:NONE' || '-D warnings' }}
-          cache: true
-          cache-all-crates: true
-          cache-workspace-crates: true
-          cache-key: python
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies (macOS)
-        if: matrix.platform == 'macos'
-        run: |
-          brew update
-          brew install redis pkg-config
-          brew services start redis
-
+      # Oxen Python Tests
       - name: Setup Python venv
         run: |
           cd ${{ github.workspace }}/oxen-python
           uv sync --no-install-project
 
-      # maturin compiles liboxen and all shared deps for the Python extension (dev profile).
-      # cargo build then (hopefully) reuses those artifacts and only links the CLI/server binaries.
-      - name: Build oxen (Linux/macOS)
+      - name: Build Python extension (Linux/macOS)
         if: matrix.platform != 'windows'
         run: |
           cd ${{ github.workspace }}/oxen-python
           source .venv/bin/activate
           maturin develop
-          cargo build -p oxen-cli -p oxen-server
 
-      - name: Build oxen (Windows)
+      - name: Build Python extension (Windows)
         if: matrix.platform == 'windows'
         run: |
           cd ${{ github.workspace }}\oxen-python
           .venv\Scripts\Activate.ps1
           maturin develop
-          cargo build -p oxen-cli -p oxen-server
-
-      - name: Setup test directories (Linux/macOS)
-        if: matrix.platform != 'windows'
-        run: |
-          mkdir -p data/test/runs
-          mkdir -p /tmp/oxen_sync/
-
-      - name: Setup test directories (Windows)
-        if: matrix.platform == 'windows'
-        run: |
-          mkdir .\data\test\runs
-
-      - name: Setup oxen-server user (Linux/macOS)
-        if: matrix.platform != 'windows'
-        run: |
-          ./target/debug/oxen-server add-user --email ox@oxen.ai --name Ox --output user_config.toml
-          cp user_config.toml data/test/config/user_config.toml
-
-      - name: Setup oxen-server user (Windows)
-        if: matrix.platform == 'windows'
-        run: |
-          .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
-          copy user_config.toml data\test\config\user_config.toml
-
-      - name: Start oxen-server (Linux/macOS)
-        if: matrix.platform != 'windows'
-        run: ./target/debug/oxen-server start &
-
-      - name: Start oxen-server (Windows)
-        if: matrix.platform == 'windows'
-        run: Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start"
 
       - name: Configure oxen user (Linux/macOS)
         if: matrix.platform != 'windows'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -71,6 +71,7 @@ jobs:
           cache: true # This is the default--making it explicit. This uses Swatinem/rust-cache under the hood.
           cache-all-crates: true
           cache-workspace-crates: true
+          cache-key: rust
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -202,6 +203,7 @@ jobs:
           cache: true
           cache-all-crates: true
           cache-workspace-crates: true
+          cache-key: python
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -55,10 +55,10 @@ jobs:
           df -h
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.AWS_ROLE }}
           role-duration-seconds: 3600
@@ -73,7 +73,7 @@ jobs:
           cache-workspace-crates: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11" # Test against the earliest supported Python version
 
@@ -124,7 +124,9 @@ jobs:
       #     echo "PKG_CONFIG_PATH=$pkgConfigPath" >> $env:GITHUB_ENV
 
       - name: Install nextest runner
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.114
 
       # Oxen Rust Tests
       - name: Setup test directories (Linux/macOS)

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -73,10 +73,8 @@ jobs:
           # Use ramdisk for cargo build artifacts
           echo "CARGO_TARGET_DIR=R:\target" >> $env:GITHUB_ENV
 
-          # Junction only the test runs directory to ramdisk for faster test I/O
-          New-Item -ItemType Directory -Path "R:\runs" | Out-Null
-          New-Item -ItemType Directory -Path "data\test" -Force | Out-Null
-          cmd /c mklink /J data\test\runs R:\runs
+          # Use ramdisk for oxen-server sync directory
+          echo "SYNC_DIR=R:\sync" >> $env:GITHUB_ENV
 
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -153,6 +151,7 @@ jobs:
         if: matrix.platform == 'windows'
         run: |
           mkdir .\data\test\runs
+          mkdir R:\sync
 
       - name: Build oxen rust project
         run: cargo build --workspace

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -87,6 +87,9 @@ jobs:
           # Use ramdisk for oxen-server sync directory
           echo "SYNC_DIR=R:\sync" >> $env:GITHUB_ENV
 
+          # Use ramdisk for test harness run directories
+          echo "OXEN_TEST_RUN_DIR=R:\test\runs" >> $env:GITHUB_ENV
+
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -163,6 +166,7 @@ jobs:
         if: matrix.platform == 'windows'
         run: |
           mkdir .\data\test\runs
+          mkdir R:\test\runs
           mkdir R:\sync
 
       - name: Build oxen rust project

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -146,9 +146,6 @@ jobs:
       - name: Build oxen rust project
         run: |
           cargo build --workspace
-        env:
-          TEMP: ${{ matrix.platform == 'windows' && 'D:\a\_temp' || runner.temp }}
-          TMP: ${{ matrix.platform == 'windows' && 'D:\a\_temp' || runner.temp }}
 
       - name: Setup oxen-server user (Linux/macOS)
         if: matrix.platform != 'windows'

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -63,6 +63,9 @@ cleanup() {
         echo "==> Removing test data..."
         rm -rf ./data/ox
         rm -rf ./data/test/runs
+        if [ -n "${OXEN_TEST_RUN_DIR:-}" ]; then
+            rm -rf "$OXEN_TEST_RUN_DIR"
+        fi
     else
         echo "==> Keeping test data in data/ox and data/test/runs"
     fi

--- a/crates/lib/src/core/v_latest/workspaces/files.rs
+++ b/crates/lib/src/core/v_latest/workspaces/files.rs
@@ -772,7 +772,7 @@ pub fn decompress_zip(zip_filepath: &PathBuf) -> Result<Vec<PathBuf>, OxenError>
 
     // Get the canonical (absolute) path of the parent directory
     let parent = match zip_filepath.parent() {
-        Some(p) => p.canonicalize()?,
+        Some(p) => crate::util::fs::canonicalize(p)?,
         None => std::env::current_dir()?,
     };
 

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -45,7 +45,10 @@ pub static REPO_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
 pub static TEST_DATA_DIR: LazyLock<PathBuf> = LazyLock::new(|| REPO_ROOT.join("data"));
 
 pub fn test_run_dir() -> PathBuf {
-    TEST_DATA_DIR.join("test").join("runs")
+    match std::env::var("OXEN_TEST_RUN_DIR") {
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => TEST_DATA_DIR.join("test").join("runs"),
+    }
 }
 
 pub fn test_host() -> String {

--- a/crates/oxen-py/Cargo.toml
+++ b/crates/oxen-py/Cargo.toml
@@ -28,5 +28,5 @@ uuid = { workspace = true }
 [build-dependencies]
 bindgen = { version = "0.71.1", default-features = false, features = ["runtime"] }
 cc = { version = "1.0", features = ["parallel"] }
-glob = "0.3"
+glob = { workspace = true }
 pkg-config = { version = "0.3", optional = true }

--- a/crates/server/src/test.rs
+++ b/crates/server/src/test.rs
@@ -16,8 +16,7 @@ use liboxen::test::init_test_env;
 
 pub fn get_sync_dir() -> Result<PathBuf, OxenError> {
     init_test_env();
-    let sync_dir =
-        liboxen::test::REPO_ROOT.join(format!("data/test/runs/{}", uuid::Uuid::new_v4()));
+    let sync_dir = liboxen::test::test_run_dir().join(uuid::Uuid::new_v4().to_string());
     util::fs::create_dir_all(&sync_dir)?;
     Ok(sync_dir)
 }


### PR DESCRIPTION
Decrease cache-miss (on windows) CI run time from 50 -> 40 minutes. Decrease cache-hit (on windows) CI run time from 30 -> 20 minutes.

- Use a larger runner for Windows (configured with @jcelliott)
  - The larger runner doesn't have a separate `D:` drive like the free runner does, so stop using that
- The `actions-rust-lang/setup-rust-toolchain` action was already calling `Swatinem/rust-cache` under-the-hood, and that was actually running, so make that explicit and set a couple flags to cache more
- Our `Swatinum/rust-cache` step wasn't actually getting used, so remove that
  - Note: this was configured to only upload cache on `main`, but we were actually uploading on every build through `setup-rust-toolchain` (above). `setup-rust-toolchain` doesn't plumb-through that option, but it wasn't using that option _anyway_...so it's no change.
- Use the `lld` linker that ships with Rust on Windows
- Add ability to specify `OXEN_TEST_RUN_DIR` to customize the output directory for tests that write directly to disk.
  - Our I/O-heavy tests can run faster if we run them on a ramdisk. Unfortunately, we currently use filename canonicalization that doesn't support ramdisks, so that needs to be fixed first before we can use this functionality to speed up CI.