### PR TITLE
add force_update param on upload

### DIFF
--- a/crates/lib/src/api/client/import.rs
+++ b/crates/lib/src/api/client/import.rs
@@ -64,7 +64,7 @@ pub async fn import_url(
     directory: impl AsRef<str>,
     download_url: impl AsRef<str>,
     commit: &NewCommitBody,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<crate::model::Commit, OxenError> {
     let branch_name = branch_name.as_ref();
     let directory = directory.as_ref();
@@ -78,8 +78,8 @@ pub async fn import_url(
         "email": commit.email,
         "message": commit.message,
     });
-    if force_update {
-        body["force_update"] = serde_json::Value::Bool(true);
+    if update_timestamp {
+        body["update_timestamp"] = serde_json::Value::Bool(true);
     }
 
     let client = client::new_for_url(&url)?;
@@ -227,7 +227,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_import_url_with_force_update() -> Result<(), OxenError> {
+    async fn test_import_url_with_update_timestamp() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
             let branch_name = DEFAULT_BRANCH_NAME;
             let download_url =
@@ -251,7 +251,7 @@ mod tests {
             .await?;
             assert!(!first_commit.id.is_empty());
 
-            // Second import of same file WITHOUT force_update should fail (no changes)
+            // Second import of same file WITHOUT update_timestamp should fail (no changes)
             let result = api::client::import::import_url(
                 &remote_repo,
                 branch_name,
@@ -269,7 +269,7 @@ mod tests {
                 "Expected import to fail with no changes: {result:?}"
             );
 
-            // Third import of same file WITH force_update should succeed
+            // Third import of same file WITH update_timestamp should succeed
             let third_commit = api::client::import::import_url(
                 &remote_repo,
                 branch_name,
@@ -284,7 +284,7 @@ mod tests {
             .await?;
             assert_ne!(first_commit.id, third_commit.id);
 
-            // Verify latest_commit on the entry matches the force_update commit
+            // Verify latest_commit on the entry matches the update_timestamp commit
             let entries = api::client::dir::list(
                 &remote_repo,
                 branch_name,
@@ -303,7 +303,7 @@ mod tests {
                 .expect("Entry should have latest_commit");
             assert_eq!(
                 latest_commit.id, third_commit.id,
-                "latest_commit should match the force_update commit"
+                "latest_commit should match the update_timestamp commit"
             );
 
             Ok(remote_repo)

--- a/crates/lib/src/api/client/import.rs
+++ b/crates/lib/src/api/client/import.rs
@@ -1,7 +1,8 @@
 use crate::api;
 use crate::api::client;
 use crate::error::OxenError;
-use crate::model::RemoteRepository;
+use crate::model::{NewCommitBody, RemoteRepository};
+use crate::view::CommitResponse;
 
 use std::path::Path;
 
@@ -56,6 +57,45 @@ pub async fn upload_zip(
     Ok(response.commit)
 }
 
+/// Import a file from a URL into a repository branch
+pub async fn import_url(
+    remote_repo: &RemoteRepository,
+    branch_name: impl AsRef<str>,
+    directory: impl AsRef<str>,
+    download_url: impl AsRef<str>,
+    commit: &NewCommitBody,
+    force_update: bool,
+) -> Result<crate::model::Commit, OxenError> {
+    let branch_name = branch_name.as_ref();
+    let directory = directory.as_ref();
+
+    let uri = format!("/import/{branch_name}/{directory}");
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+
+    let mut body = serde_json::json!({
+        "download_url": download_url.as_ref(),
+        "name": commit.author,
+        "email": commit.email,
+        "message": commit.message,
+    });
+    if force_update {
+        body["force_update"] = serde_json::Value::Bool(true);
+    }
+
+    let client = client::new_for_url(&url)?;
+    let response = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .await?;
+    let body = client::parse_json_body(&url, response).await?;
+    let response: CommitResponse = serde_json::from_str(&body)
+        .map_err(|e| OxenError::basic_str(format!("Failed to parse response: {e}\n\n{body}")))?;
+
+    Ok(response.commit)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test;
@@ -63,10 +103,12 @@ mod tests {
 
     use crate::constants::DEFAULT_BRANCH_NAME;
     use crate::error::OxenError;
+    use crate::model::NewCommitBody;
 
     use crate::api;
 
     use std::io::Write;
+    use std::path::Path;
 
     #[tokio::test]
     async fn test_upload_zip_file() -> Result<(), OxenError> {
@@ -177,6 +219,91 @@ mod tests {
             assert_eq!(
                 bytes_2.as_ref().unwrap(),
                 &Bytes::from_static(b"fake png data 2")
+            );
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_import_url_with_force_update() -> Result<(), OxenError> {
+        test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
+            let branch_name = DEFAULT_BRANCH_NAME;
+            let download_url =
+                "https://hub.oxen.ai/api/repos/ox/Oxen-AI-Assets/file/main/images/bloxy_white_background.png";
+
+            let commit_body = NewCommitBody {
+                message: "First import".to_string(),
+                author: "Test User".to_string(),
+                email: "test@oxen.ai".to_string(),
+            };
+
+            // First import
+            let first_commit = api::client::import::import_url(
+                &remote_repo,
+                branch_name,
+                "imported",
+                download_url,
+                &commit_body,
+                false,
+            )
+            .await?;
+            assert!(!first_commit.id.is_empty());
+
+            // Second import of same file WITHOUT force_update should fail (no changes)
+            let result = api::client::import::import_url(
+                &remote_repo,
+                branch_name,
+                "imported",
+                download_url,
+                &NewCommitBody {
+                    message: "Second import no force".to_string(),
+                    ..commit_body.clone()
+                },
+                false,
+            )
+            .await;
+            assert!(
+                result.is_err(),
+                "Expected import to fail with no changes: {result:?}"
+            );
+
+            // Third import of same file WITH force_update should succeed
+            let third_commit = api::client::import::import_url(
+                &remote_repo,
+                branch_name,
+                "imported",
+                download_url,
+                &NewCommitBody {
+                    message: "Force update import".to_string(),
+                    ..commit_body.clone()
+                },
+                true,
+            )
+            .await?;
+            assert_ne!(first_commit.id, third_commit.id);
+
+            // Verify latest_commit on the entry matches the force_update commit
+            let entries = api::client::dir::list(
+                &remote_repo,
+                branch_name,
+                Path::new("imported"),
+                1,
+                100,
+            )
+            .await?;
+            let file_entry = entries
+                .entries
+                .iter()
+                .find(|e| e.filename() == "bloxy_white_background.png")
+                .expect("Should find the imported file");
+            let latest_commit = file_entry
+                .latest_commit()
+                .expect("Entry should have latest_commit");
+            assert_eq!(
+                latest_commit.id, third_commit.id,
+                "latest_commit should match the force_update commit"
             );
 
             Ok(remote_repo)

--- a/crates/lib/src/api/client/versions.rs
+++ b/crates/lib/src/api/client/versions.rs
@@ -110,7 +110,7 @@ pub async fn parallel_large_file_upload(
     file_path: impl AsRef<Path>,
     dst_dir: Option<impl AsRef<Path>>, // dst_dir is provided for workspace add workflow
     workspace_id: Option<String>,
-    force_update: bool,
+    update_timestamp: bool,
     entry: Option<Entry>,                 // entry is provided for push workflow
     progress: Option<&Arc<PushProgress>>, // for push workflow
 ) -> Result<MultipartLargeFileUpload, OxenError> {
@@ -138,7 +138,7 @@ pub async fn parallel_large_file_upload(
         upload,
         num_chunks,
         workspace_id,
-        force_update,
+        update_timestamp,
     )
     .await
 }
@@ -449,7 +449,7 @@ async fn complete_multipart_large_file_upload(
     upload: MultipartLargeFileUpload,
     num_chunks: usize,
     workspace_id: Option<String>,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<MultipartLargeFileUpload, OxenError> {
     let file_hash = &upload.hash.to_string();
 
@@ -472,7 +472,7 @@ async fn complete_multipart_large_file_upload(
             upload_results: None,
         }],
         workspace_id,
-        force_update,
+        update_timestamp,
     };
 
     let body = serde_json::to_string(&body)?;

--- a/crates/lib/src/api/client/versions.rs
+++ b/crates/lib/src/api/client/versions.rs
@@ -110,6 +110,7 @@ pub async fn parallel_large_file_upload(
     file_path: impl AsRef<Path>,
     dst_dir: Option<impl AsRef<Path>>, // dst_dir is provided for workspace add workflow
     workspace_id: Option<String>,
+    force_update: bool,
     entry: Option<Entry>,                 // entry is provided for push workflow
     progress: Option<&Arc<PushProgress>>, // for push workflow
 ) -> Result<MultipartLargeFileUpload, OxenError> {
@@ -132,7 +133,14 @@ pub async fn parallel_large_file_upload(
     .await?;
     let num_chunks = results.len();
     log::debug!("multipart_large_file_upload num_chunks: {num_chunks:?}");
-    complete_multipart_large_file_upload(remote_repo, upload, num_chunks, workspace_id).await
+    complete_multipart_large_file_upload(
+        remote_repo,
+        upload,
+        num_chunks,
+        workspace_id,
+        force_update,
+    )
+    .await
 }
 
 /// Creates a new multipart large file upload
@@ -441,6 +449,7 @@ async fn complete_multipart_large_file_upload(
     upload: MultipartLargeFileUpload,
     num_chunks: usize,
     workspace_id: Option<String>,
+    force_update: bool,
 ) -> Result<MultipartLargeFileUpload, OxenError> {
     let file_hash = &upload.hash.to_string();
 
@@ -463,6 +472,7 @@ async fn complete_multipart_large_file_upload(
             upload_results: None,
         }],
         workspace_id,
+        force_update,
     };
 
     let body = serde_json::to_string(&body)?;
@@ -826,6 +836,7 @@ mod tests {
                 path,
                 dst_dir,
                 workspace_id,
+                false,
                 None,
                 None,
             )

--- a/crates/lib/src/api/client/workspaces/commits.rs
+++ b/crates/lib/src/api/client/workspaces/commits.rs
@@ -515,7 +515,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reupload_same_file_without_force_update_fails() -> Result<(), OxenError> {
+    async fn test_reupload_same_file_without_update_timestamp_fails() -> Result<(), OxenError> {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
             let branch_name = "main";
 
@@ -544,7 +544,7 @@ mod tests {
                     .await?;
             assert!(!first_commit.id.is_empty());
 
-            // Re-upload the same file without force_update
+            // Re-upload the same file without update_timestamp
             let workspace_id_2 = UserConfig::identifier()? + "_2";
             api::client::workspaces::create(&remote_repo, branch_name, &workspace_id_2).await?;
 
@@ -579,7 +579,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reupload_same_file_with_force_update_succeeds() -> Result<(), OxenError> {
+    async fn test_reupload_same_file_with_update_timestamp_succeeds() -> Result<(), OxenError> {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
             let branch_name = "main";
 
@@ -608,7 +608,7 @@ mod tests {
                     .await?;
             assert!(!first_commit.id.is_empty());
 
-            // Re-upload the same file WITH force_update
+            // Re-upload the same file WITH update_timestamp
             let workspace_id_2 = UserConfig::identifier()? + "_2";
             api::client::workspaces::create(&remote_repo, branch_name, &workspace_id_2).await?;
 
@@ -619,12 +619,12 @@ mod tests {
                 "images",
                 paths,
                 &None,
-                true, // force_update
+                true, // update_timestamp
             )
             .await;
             assert!(result.is_ok(), "{result:?}");
 
-            // Commit should succeed because force_update forces timestamp update
+            // Commit should succeed because update_timestamp forces timestamp update
             let body = NewCommitBody {
                 message: "Force update same image".to_string(),
                 author: "Test User".to_string(),
@@ -655,7 +655,7 @@ mod tests {
                 .expect("File entry should have a latest_commit");
             assert_eq!(
                 latest_commit.id, second_commit.id,
-                "latest_commit on the file entry should match the force_update commit, got {} expected {}",
+                "latest_commit on the file entry should match the update_timestamp commit, got {} expected {}",
                 latest_commit.id, second_commit.id,
             );
 
@@ -665,7 +665,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reupload_same_large_file_with_force_update_succeeds() -> Result<(), OxenError> {
+    async fn test_reupload_same_large_file_with_update_timestamp_succeeds() -> Result<(), OxenError>
+    {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
             let branch_name = "main";
 
@@ -735,7 +736,7 @@ mod tests {
                 .expect("File entry should have a latest_commit");
             assert_eq!(
                 latest_commit.id, second_commit.id,
-                "latest_commit on the large file entry should match the force_update commit, got {} expected {}",
+                "latest_commit on the large file entry should match the update_timestamp commit, got {} expected {}",
                 latest_commit.id, second_commit.id,
             );
 

--- a/crates/lib/src/api/client/workspaces/commits.rs
+++ b/crates/lib/src/api/client/workspaces/commits.rs
@@ -513,4 +513,154 @@ mod tests {
         })
         .await
     }
+
+    #[tokio::test]
+    async fn test_reupload_same_file_without_force_update_fails() -> Result<(), OxenError> {
+        test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
+            let branch_name = "main";
+
+            // First upload and commit
+            let workspace_id = UserConfig::identifier()?;
+            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
+
+            let paths = vec![test::test_img_file()];
+            let result = api::client::workspaces::files::add(
+                &remote_repo,
+                &workspace_id,
+                "images",
+                paths,
+                &None,
+            )
+            .await;
+            assert!(result.is_ok(), "{result:?}");
+
+            let body = NewCommitBody {
+                message: "Add image".to_string(),
+                author: "Test User".to_string(),
+                email: "test@oxen.ai".to_string(),
+            };
+            let first_commit =
+                api::client::workspaces::commit(&remote_repo, branch_name, &workspace_id, &body)
+                    .await?;
+            assert!(!first_commit.id.is_empty());
+
+            // Re-upload the same file without force_update
+            let workspace_id_2 = UserConfig::identifier()? + "_2";
+            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id_2).await?;
+
+            let paths = vec![test::test_img_file()];
+            let result = api::client::workspaces::files::add(
+                &remote_repo,
+                &workspace_id_2,
+                "images",
+                paths,
+                &None,
+            )
+            .await;
+            assert!(result.is_ok(), "{result:?}");
+
+            // Commit should fail because there are no changes
+            let body = NewCommitBody {
+                message: "Re-add same image".to_string(),
+                author: "Test User".to_string(),
+                email: "test@oxen.ai".to_string(),
+            };
+            let result =
+                api::client::workspaces::commit(&remote_repo, branch_name, &workspace_id_2, &body)
+                    .await;
+            assert!(
+                result.is_err(),
+                "Expected commit to fail with no changes, but got: {result:?}"
+            );
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_reupload_same_file_with_force_update_succeeds() -> Result<(), OxenError> {
+        test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
+            let branch_name = "main";
+
+            // First upload and commit
+            let workspace_id = UserConfig::identifier()?;
+            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
+
+            let paths = vec![test::test_img_file()];
+            let result = api::client::workspaces::files::add(
+                &remote_repo,
+                &workspace_id,
+                "images",
+                paths,
+                &None,
+            )
+            .await;
+            assert!(result.is_ok(), "{result:?}");
+
+            let body = NewCommitBody {
+                message: "Add image".to_string(),
+                author: "Test User".to_string(),
+                email: "test@oxen.ai".to_string(),
+            };
+            let first_commit =
+                api::client::workspaces::commit(&remote_repo, branch_name, &workspace_id, &body)
+                    .await?;
+            assert!(!first_commit.id.is_empty());
+
+            // Re-upload the same file WITH force_update
+            let workspace_id_2 = UserConfig::identifier()? + "_2";
+            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id_2).await?;
+
+            let paths = vec![test::test_img_file()];
+            let result = api::client::workspaces::files::add_with_opts(
+                &remote_repo,
+                &workspace_id_2,
+                "images",
+                paths,
+                &None,
+                true, // force_update
+            )
+            .await;
+            assert!(result.is_ok(), "{result:?}");
+
+            // Commit should succeed because force_update forces timestamp update
+            let body = NewCommitBody {
+                message: "Force update same image".to_string(),
+                author: "Test User".to_string(),
+                email: "test@oxen.ai".to_string(),
+            };
+            let second_commit =
+                api::client::workspaces::commit(&remote_repo, branch_name, &workspace_id_2, &body)
+                    .await?;
+            assert!(!second_commit.id.is_empty());
+
+            // The commit IDs should be different
+            assert_ne!(
+                first_commit.id, second_commit.id,
+                "Expected different commit IDs after force update"
+            );
+
+            // Verify latest_commit on the file entry matches the second commit
+            let entries =
+                api::client::dir::list(&remote_repo, branch_name, Path::new("images"), 1, 100)
+                    .await?;
+            let file_entry = entries
+                .entries
+                .iter()
+                .find(|e| e.filename() == "dwight_vince.jpeg")
+                .expect("Should find the uploaded file in the directory listing");
+            let latest_commit = file_entry
+                .latest_commit()
+                .expect("File entry should have a latest_commit");
+            assert_eq!(
+                latest_commit.id, second_commit.id,
+                "latest_commit on the file entry should match the force_update commit, got {} expected {}",
+                latest_commit.id, second_commit.id,
+            );
+
+            Ok(remote_repo)
+        })
+        .await
+    }
 }

--- a/crates/lib/src/api/client/workspaces/commits.rs
+++ b/crates/lib/src/api/client/workspaces/commits.rs
@@ -663,4 +663,84 @@ mod tests {
         })
         .await
     }
+
+    #[tokio::test]
+    async fn test_reupload_same_large_file_with_force_update_succeeds() -> Result<(), OxenError> {
+        test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
+            let branch_name = "main";
+
+            let workspace_id = UserConfig::identifier()?;
+            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
+
+            let paths = vec![test::test_30k_parquet()];
+            let result = api::client::workspaces::files::add(
+                &remote_repo,
+                &workspace_id,
+                "parquet",
+                paths.clone(),
+                &None,
+            )
+            .await;
+            assert!(result.is_ok(), "{result:?}");
+
+            let body = NewCommitBody {
+                message: "Add large parquet".to_string(),
+                author: "Test User".to_string(),
+                email: "test@oxen.ai".to_string(),
+            };
+            let first_commit =
+                api::client::workspaces::commit(&remote_repo, branch_name, &workspace_id, &body)
+                    .await?;
+            assert!(!first_commit.id.is_empty());
+
+            let workspace_id_2 = UserConfig::identifier()? + "_2";
+            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id_2).await?;
+
+            let result = api::client::workspaces::files::add_with_opts(
+                &remote_repo,
+                &workspace_id_2,
+                "parquet",
+                paths,
+                &None,
+                true,
+            )
+            .await;
+            assert!(result.is_ok(), "{result:?}");
+
+            let body = NewCommitBody {
+                message: "Force update same large parquet".to_string(),
+                author: "Test User".to_string(),
+                email: "test@oxen.ai".to_string(),
+            };
+            let second_commit =
+                api::client::workspaces::commit(&remote_repo, branch_name, &workspace_id_2, &body)
+                    .await?;
+            assert!(!second_commit.id.is_empty());
+
+            assert_ne!(
+                first_commit.id, second_commit.id,
+                "Expected different commit IDs after force update on a large file"
+            );
+
+            let entries =
+                api::client::dir::list(&remote_repo, branch_name, Path::new("parquet"), 1, 100)
+                    .await?;
+            let file_entry = entries
+                .entries
+                .iter()
+                .find(|e| e.filename() == "wiki_30k.parquet")
+                .expect("Should find the uploaded large file in the directory listing");
+            let latest_commit = file_entry
+                .latest_commit()
+                .expect("File entry should have a latest_commit");
+            assert_eq!(
+                latest_commit.id, second_commit.id,
+                "latest_commit on the large file entry should match the force_update commit, got {} expected {}",
+                latest_commit.id, second_commit.id,
+            );
+
+            Ok(remote_repo)
+        })
+        .await
+    }
 }

--- a/crates/lib/src/api/client/workspaces/files.rs
+++ b/crates/lib/src/api/client/workspaces/files.rs
@@ -70,7 +70,7 @@ pub async fn add_with_opts(
     directory: impl AsRef<str>,
     paths: Vec<PathBuf>,
     local_repo: &Option<LocalRepository>,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<UploadFails, OxenError> {
     let workspace_id = workspace_id.as_ref();
     let directory = directory.as_ref();
@@ -104,7 +104,7 @@ pub async fn add_with_opts(
             .clone()
             .map(|local| LocalOrBase::Local(local.clone()))
             .as_ref(),
-        force_update,
+        update_timestamp,
     )
     .await;
 
@@ -298,7 +298,7 @@ async fn upload_multiple_files(
     directory: impl AsRef<Path>,
     paths: Vec<PathBuf>,
     local_or_base: Option<&LocalOrBase>,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     if paths.is_empty() {
         return Ok(vec![]);
@@ -374,7 +374,7 @@ async fn upload_multiple_files(
             &path,
             Some(&dst_dir),
             Some(workspace_id.to_string()),
-            force_update,
+            update_timestamp,
             None,
             None,
         )
@@ -401,7 +401,7 @@ async fn upload_multiple_files(
         small_files,
         small_files_size,
         local_or_base,
-        force_update,
+        update_timestamp,
     )
     .await?;
 
@@ -417,7 +417,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
     small_files: Vec<(PathBuf, u64)>,
     small_files_size: u64,
     local_or_base: Option<&LocalOrBase>,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     if small_files.is_empty() {
         return Ok(vec![]);
@@ -538,8 +538,8 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                     )?;
 
                                     // In remote-mode repos, skip adding files already present in tree
-                                    // unless force_update is set
-                                    if !force_update
+                                    // unless update_timestamp is set
+                                    if !update_timestamp
                                         && let Some((ref head_commit, ref local_repository)) =
                                             head_commit_local_repo_maybe_clone
                                         && let Some(file_node) =
@@ -705,7 +705,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                         Arc::new(files_to_stage),
                                         &directory_str,
                                         upload_err_files,
-                                        force_update,
+                                        update_timestamp,
                                     )
                                     .await
                                     {
@@ -818,7 +818,7 @@ pub async fn stage_files_to_workspace_with_retry(
     files_to_add: Arc<Vec<FileWithHash>>,
     directory_str: impl AsRef<str>,
     err_files: Vec<ErrorFileInfo>,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let mut retry_count: usize = 0;
     let directory_str = directory_str.as_ref();
@@ -835,7 +835,7 @@ pub async fn stage_files_to_workspace_with_retry(
             files_to_add.clone(),
             directory_str,
             err_files.clone(),
-            force_update,
+            update_timestamp,
         )
         .await
         {
@@ -874,12 +874,12 @@ pub async fn stage_files_to_workspace(
     files_to_add: Arc<Vec<FileWithHash>>,
     directory_str: impl AsRef<str>,
     err_files: Vec<ErrorFileInfo>,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let workspace_id = workspace_id.as_ref();
     let directory_str = directory_str.as_ref();
-    let uri = if force_update {
-        format!("/workspaces/{workspace_id}/versions/{directory_str}?force_update=true")
+    let uri = if update_timestamp {
+        format!("/workspaces/{workspace_id}/versions/{directory_str}?update_timestamp=true")
     } else {
         format!("/workspaces/{workspace_id}/versions/{directory_str}")
     };

--- a/crates/lib/src/api/client/workspaces/files.rs
+++ b/crates/lib/src/api/client/workspaces/files.rs
@@ -53,6 +53,25 @@ pub async fn add(
     paths: Vec<PathBuf>,
     local_repo: &Option<LocalRepository>,
 ) -> Result<UploadFails, OxenError> {
+    add_with_opts(
+        remote_repo,
+        workspace_id,
+        directory,
+        paths,
+        local_repo,
+        false,
+    )
+    .await
+}
+
+pub async fn add_with_opts(
+    remote_repo: &RemoteRepository,
+    workspace_id: impl AsRef<str>,
+    directory: impl AsRef<str>,
+    paths: Vec<PathBuf>,
+    local_repo: &Option<LocalRepository>,
+    force_update: bool,
+) -> Result<UploadFails, OxenError> {
     let workspace_id = workspace_id.as_ref();
     let directory = directory.as_ref();
 
@@ -85,6 +104,7 @@ pub async fn add(
             .clone()
             .map(|local| LocalOrBase::Local(local.clone()))
             .as_ref(),
+        force_update,
     )
     .await;
 
@@ -192,6 +212,7 @@ pub async fn add_files(
         //    for a single API call.
         paths,
         Some(&base_dir_enum),
+        false,
     )
     .await
     {
@@ -276,6 +297,7 @@ async fn upload_multiple_files(
     directory: impl AsRef<Path>,
     paths: Vec<PathBuf>,
     local_or_base: Option<&LocalOrBase>,
+    force_update: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     if paths.is_empty() {
         return Ok(vec![]);
@@ -377,6 +399,7 @@ async fn upload_multiple_files(
         small_files,
         small_files_size,
         local_or_base,
+        force_update,
     )
     .await?;
 
@@ -392,6 +415,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
     small_files: Vec<(PathBuf, u64)>,
     small_files_size: u64,
     local_or_base: Option<&LocalOrBase>,
+    force_update: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     if small_files.is_empty() {
         return Ok(vec![]);
@@ -512,8 +536,10 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                     )?;
 
                                     // In remote-mode repos, skip adding files already present in tree
-                                    if let Some((ref head_commit, ref local_repository)) =
-                                        head_commit_local_repo_maybe_clone
+                                    // unless force_update is set
+                                    if !force_update
+                                        && let Some((ref head_commit, ref local_repository)) =
+                                            head_commit_local_repo_maybe_clone
                                         && let Some(file_node) =
                                             repositories::tree::get_file_by_path(
                                                 local_repository,
@@ -677,6 +703,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                         Arc::new(files_to_stage),
                                         &directory_str,
                                         upload_err_files,
+                                        force_update,
                                     )
                                     .await
                                     {
@@ -789,6 +816,7 @@ pub async fn stage_files_to_workspace_with_retry(
     files_to_add: Arc<Vec<FileWithHash>>,
     directory_str: impl AsRef<str>,
     err_files: Vec<ErrorFileInfo>,
+    force_update: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let mut retry_count: usize = 0;
     let directory_str = directory_str.as_ref();
@@ -805,6 +833,7 @@ pub async fn stage_files_to_workspace_with_retry(
             files_to_add.clone(),
             directory_str,
             err_files.clone(),
+            force_update,
         )
         .await
         {
@@ -843,10 +872,15 @@ pub async fn stage_files_to_workspace(
     files_to_add: Arc<Vec<FileWithHash>>,
     directory_str: impl AsRef<str>,
     err_files: Vec<ErrorFileInfo>,
+    force_update: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let workspace_id = workspace_id.as_ref();
     let directory_str = directory_str.as_ref();
-    let uri = format!("/workspaces/{workspace_id}/versions/{directory_str}");
+    let uri = if force_update {
+        format!("/workspaces/{workspace_id}/versions/{directory_str}?force_update=true")
+    } else {
+        format!("/workspaces/{workspace_id}/versions/{directory_str}")
+    };
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
     let files_to_send = if !err_files.is_empty() {

--- a/crates/lib/src/api/client/workspaces/files.rs
+++ b/crates/lib/src/api/client/workspaces/files.rs
@@ -267,6 +267,7 @@ pub async fn upload_single_file(
             path,
             Some(directory),
             Some(workspace_id.as_ref().to_string()),
+            false,
             None,
             None,
         )
@@ -373,6 +374,7 @@ async fn upload_multiple_files(
             &path,
             Some(&dst_dir),
             Some(workspace_id.to_string()),
+            force_update,
             None,
             None,
         )

--- a/crates/lib/src/core/v_latest/add.rs
+++ b/crates/lib/src/core/v_latest/add.rs
@@ -964,6 +964,7 @@ pub fn stage_file_with_hash(
     hash: &str,
     staged_db_manager: &StagedDBManager,
     seen_dirs: &Arc<Mutex<HashSet<PathBuf>>>,
+    force_update: bool,
 ) -> Result<(), OxenError> {
     let workspace_repo = &workspace.workspace_repo;
     let base_repo = &workspace.base_repo;
@@ -971,13 +972,24 @@ pub fn stage_file_with_hash(
 
     let relative_path = util::fs::path_relative_to_dir(dst_path, base_repo.path.clone())?;
     let metadata = util::fs::metadata(data_path)?;
-    let mtime = FileTime::from_last_modification_time(&metadata);
+    let mtime = if force_update {
+        // Use current time to force a timestamp update
+        FileTime::now()
+    } else {
+        FileTime::from_last_modification_time(&metadata)
+    };
     let maybe_file_node =
         repositories::tree::get_file_by_path(base_repo, head_commit, &relative_path)?;
 
     let file_status = if let Some(file_node) = maybe_file_node {
         let previous_metadata = file_node.metadata();
         let status = if util::fs::is_modified_from_node(data_path, &file_node)? {
+            StagedEntryStatus::Modified
+        } else if force_update {
+            // Force staging even though the content hasn't changed
+            log::info!(
+                "file {data_path:?} has not changed but force_update is set - staging as modified"
+            );
             StagedEntryStatus::Modified
         } else {
             // Don't add the file if it hasn't changed

--- a/crates/lib/src/core/v_latest/add.rs
+++ b/crates/lib/src/core/v_latest/add.rs
@@ -964,7 +964,7 @@ pub fn stage_file_with_hash(
     hash: &str,
     staged_db_manager: &StagedDBManager,
     seen_dirs: &Arc<Mutex<HashSet<PathBuf>>>,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<(), OxenError> {
     let workspace_repo = &workspace.workspace_repo;
     let base_repo = &workspace.base_repo;
@@ -972,7 +972,7 @@ pub fn stage_file_with_hash(
 
     let relative_path = util::fs::path_relative_to_dir(dst_path, base_repo.path.clone())?;
     let metadata = util::fs::metadata(data_path)?;
-    let mtime = if force_update {
+    let mtime = if update_timestamp {
         // Use current time to force a timestamp update
         FileTime::now()
     } else {
@@ -985,10 +985,10 @@ pub fn stage_file_with_hash(
         let previous_metadata = file_node.metadata();
         let status = if util::fs::is_modified_from_node(data_path, &file_node)? {
             StagedEntryStatus::Modified
-        } else if force_update {
+        } else if update_timestamp {
             // Force staging even though the content hasn't changed
             log::info!(
-                "file {data_path:?} has not changed but force_update is set - staging as modified"
+                "file {data_path:?} has not changed but update_timestamp is set - staging as modified"
             );
             StagedEntryStatus::Modified
         } else {

--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -624,6 +624,7 @@ async fn chunk_and_send_large_entries(
                     &*version_path,
                     None::<PathBuf>,
                     None,
+                    false,
                     Some(entry.clone()),
                     Some(&bar),
                 )

--- a/crates/lib/src/core/v_latest/workspaces/files.rs
+++ b/crates/lib/src/core/v_latest/workspaces/files.rs
@@ -1,4 +1,5 @@
 use bytes::BytesMut;
+use filetime::FileTime;
 use futures::StreamExt;
 use parking_lot::Mutex;
 use reqwest::Client;
@@ -38,13 +39,28 @@ const MAX_COMPRESSION_RATIO: u64 = 100; // Maximum allowed
 
 // TODO: Do we depreciate this, if we always upload to version store?
 pub async fn add(workspace: &Workspace, filepath: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
+    add_with_opts(workspace, filepath, false).await
+}
+
+pub async fn add_with_opts(
+    workspace: &Workspace,
+    filepath: impl AsRef<Path>,
+    force_update: bool,
+) -> Result<PathBuf, OxenError> {
     let filepath = filepath.as_ref();
     let workspace_repo = &workspace.workspace_repo;
     let base_repo = &workspace.base_repo;
 
     // Stage the file using the repositories::add method
     let commit = workspace.commit.clone();
-    p_add_file(base_repo, workspace_repo, &Some(commit), filepath).await?;
+    p_add_file(
+        base_repo,
+        workspace_repo,
+        &Some(commit),
+        filepath,
+        force_update,
+    )
+    .await?;
 
     // Return the relative path of the file in the workspace
     let relative_path = util::fs::path_relative_to_dir(filepath, &workspace_repo.path)?;
@@ -71,6 +87,7 @@ pub fn add_version_file(
     version_path: impl AsRef<Path>,
     dst_path: impl AsRef<Path>,
     file_hash: &str,
+    force_update: bool,
 ) -> Result<PathBuf, OxenError> {
     // version_path is where the file is stored, dst_path is the relative path to the repo
     // let version_path = version_path.as_ref();
@@ -86,6 +103,7 @@ pub fn add_version_file(
         file_hash,
         &staged_db_manager,
         &Arc::new(Mutex::new(HashSet::new())),
+        force_update,
     )?;
 
     Ok(dst_path.to_path_buf())
@@ -96,6 +114,7 @@ pub async fn add_version_files(
     workspace: &Workspace,
     files_with_hash: &[FileWithHash],
     directory: impl AsRef<str>,
+    force_update: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let version_store = repo.version_store()?;
 
@@ -127,6 +146,7 @@ pub async fn add_version_files(
             &item.hash,
             &staged_db_manager,
             &seen_dirs,
+            force_update,
         ) {
             Ok(_) => {
                 // Add parents to staged db
@@ -342,6 +362,7 @@ pub async fn import(
     directory: PathBuf,
     filename: Option<String>,
     workspace: &Workspace,
+    force_update: bool,
 ) -> Result<(), OxenError> {
     let parsed_url =
         Url::parse(url).map_err(|_| OxenError::file_import_error(format!("Invalid URL: {url}")))?;
@@ -364,6 +385,7 @@ pub async fn import(
         directory,
         filename,
         workspace,
+        force_update,
     )
     .await?;
 
@@ -434,6 +456,7 @@ async fn fetch_file(
     directory: PathBuf,
     caller_filename: Option<String>,
     workspace: &Workspace,
+    force_update: bool,
 ) -> Result<(), OxenError> {
     let client = Client::builder()
         .redirect(redirect::Policy::none())
@@ -603,12 +626,16 @@ async fn fetch_file(
 
         for file in files.iter() {
             log::debug!("file::import add file {file:?}");
-            let path = repositories::workspaces::files::add(workspace, file).await?;
+            let path =
+                repositories::workspaces::files::add_with_opts(workspace, file, force_update)
+                    .await?;
             log::debug!("file::import add file ✅ success! staged file {path:?}");
         }
     } else {
         log::debug!("file::import add file {:?}", &filepath);
-        let path = repositories::workspaces::files::add(workspace, &save_path).await?;
+        let path =
+            repositories::workspaces::files::add_with_opts(workspace, &save_path, force_update)
+                .await?;
         log::debug!("file::import add file ✅ success! staged file {path:?}");
     }
 
@@ -818,6 +845,7 @@ async fn p_add_file(
     workspace_repo: &LocalRepository,
     maybe_head_commit: &Option<Commit>,
     path: &Path,
+    force_update: bool,
 ) -> Result<(), OxenError> {
     let version_store = base_repo.version_store()?;
     let mut maybe_dir_node = None;
@@ -838,8 +866,18 @@ async fn p_add_file(
     }
 
     // See if this is a new file or a modified file
-    let file_status =
+    let mut file_status =
         core::v_latest::add::determine_file_status(&maybe_dir_node, &file_name, &full_path)?;
+
+    // When force_update is set, override Unmodified status to Modified
+    // and use the current time so the commit gets a new merkle tree hash
+    if force_update && file_status.status == StagedEntryStatus::Unmodified {
+        log::info!(
+            "file {full_path:?} has not changed but force_update is set - staging as modified"
+        );
+        file_status.status = StagedEntryStatus::Modified;
+        file_status.mtime = FileTime::now();
+    }
 
     // Store the file in the version store using the hash as the key
     let hash_str = file_status.hash.to_string();

--- a/crates/lib/src/core/v_latest/workspaces/files.rs
+++ b/crates/lib/src/core/v_latest/workspaces/files.rs
@@ -45,7 +45,7 @@ pub async fn add(workspace: &Workspace, filepath: impl AsRef<Path>) -> Result<Pa
 pub async fn add_with_opts(
     workspace: &Workspace,
     filepath: impl AsRef<Path>,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<PathBuf, OxenError> {
     let filepath = filepath.as_ref();
     let workspace_repo = &workspace.workspace_repo;
@@ -58,7 +58,7 @@ pub async fn add_with_opts(
         workspace_repo,
         &Some(commit),
         filepath,
-        force_update,
+        update_timestamp,
     )
     .await?;
 
@@ -87,7 +87,7 @@ pub fn add_version_file(
     version_path: impl AsRef<Path>,
     dst_path: impl AsRef<Path>,
     file_hash: &str,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<PathBuf, OxenError> {
     // version_path is where the file is stored, dst_path is the relative path to the repo
     // let version_path = version_path.as_ref();
@@ -103,7 +103,7 @@ pub fn add_version_file(
         file_hash,
         &staged_db_manager,
         &Arc::new(Mutex::new(HashSet::new())),
-        force_update,
+        update_timestamp,
     )?;
 
     Ok(dst_path.to_path_buf())
@@ -114,7 +114,7 @@ pub async fn add_version_files(
     workspace: &Workspace,
     files_with_hash: &[FileWithHash],
     directory: impl AsRef<str>,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let version_store = repo.version_store()?;
 
@@ -146,7 +146,7 @@ pub async fn add_version_files(
             &item.hash,
             &staged_db_manager,
             &seen_dirs,
-            force_update,
+            update_timestamp,
         ) {
             Ok(_) => {
                 // Add parents to staged db
@@ -362,7 +362,7 @@ pub async fn import(
     directory: PathBuf,
     filename: Option<String>,
     workspace: &Workspace,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<(), OxenError> {
     let parsed_url =
         Url::parse(url).map_err(|_| OxenError::file_import_error(format!("Invalid URL: {url}")))?;
@@ -385,7 +385,7 @@ pub async fn import(
         directory,
         filename,
         workspace,
-        force_update,
+        update_timestamp,
     )
     .await?;
 
@@ -456,7 +456,7 @@ async fn fetch_file(
     directory: PathBuf,
     caller_filename: Option<String>,
     workspace: &Workspace,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<(), OxenError> {
     let client = Client::builder()
         .redirect(redirect::Policy::none())
@@ -627,14 +627,14 @@ async fn fetch_file(
         for file in files.iter() {
             log::debug!("file::import add file {file:?}");
             let path =
-                repositories::workspaces::files::add_with_opts(workspace, file, force_update)
+                repositories::workspaces::files::add_with_opts(workspace, file, update_timestamp)
                     .await?;
             log::debug!("file::import add file ✅ success! staged file {path:?}");
         }
     } else {
         log::debug!("file::import add file {:?}", &filepath);
         let path =
-            repositories::workspaces::files::add_with_opts(workspace, &save_path, force_update)
+            repositories::workspaces::files::add_with_opts(workspace, &save_path, update_timestamp)
                 .await?;
         log::debug!("file::import add file ✅ success! staged file {path:?}");
     }
@@ -845,7 +845,7 @@ async fn p_add_file(
     workspace_repo: &LocalRepository,
     maybe_head_commit: &Option<Commit>,
     path: &Path,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<(), OxenError> {
     let version_store = base_repo.version_store()?;
     let mut maybe_dir_node = None;
@@ -869,11 +869,11 @@ async fn p_add_file(
     let mut file_status =
         core::v_latest::add::determine_file_status(&maybe_dir_node, &file_name, &full_path)?;
 
-    // When force_update is set, override Unmodified status to Modified
+    // When update_timestamp is set, override Unmodified status to Modified
     // and use the current time so the commit gets a new merkle tree hash
-    if force_update && file_status.status == StagedEntryStatus::Unmodified {
+    if update_timestamp && file_status.status == StagedEntryStatus::Unmodified {
         log::info!(
-            "file {full_path:?} has not changed but force_update is set - staging as modified"
+            "file {full_path:?} has not changed but update_timestamp is set - staging as modified"
         );
         file_status.status = StagedEntryStatus::Modified;
         file_status.mtime = FileTime::now();

--- a/crates/lib/src/repositories/commits/commit_writer.rs
+++ b/crates/lib/src/repositories/commits/commit_writer.rs
@@ -986,13 +986,6 @@ fn r_create_dir_node(
                     file_node.set_last_commit_id(&last_commit_id);
                     file_node.set_name(file_name);
 
-                    // if let Some(vnode_db) = &mut maybe_vnode_db {
-                    // log::debug!(
-                    //     "Adding file {} to vnode {} in commit {}",
-                    //     file_name,
-                    //     vnode.id,
-                    //     commit_id
-                    // );
                     vnode_db.add_child(&file_node)?;
                     *total_written += 1;
                     // }
@@ -1070,14 +1063,13 @@ fn compute_dir_node(
             let err_msg = format!("compute_dir_node No entries found for directory {path:?}");
             return Err(OxenError::basic_str(err_msg));
         };
-        // log::debug!(
-        //     "Aggregating dir {:?} child {:?} with {} vnodes",
-        //     path,
-        //     child,
-        //     vnodes.len()
-        // );
         for vnode in vnodes.iter() {
-            // log::debug!("Aggregating vnode entries {:?}", vnode.entries.len());
+            // Include VNode hashes in the directory hash so that when a VNode
+            // gets a new UUID-based hash (because it has modified entries), the
+            // parent directory hash changes too. Without this, two commits can
+            // produce the same directory hash even though their VNode children
+            // differ, causing stale node data to be read from shared storage.
+            hasher.update(&vnode.id.to_le_bytes());
             for entry in vnode.entries.iter() {
                 // log::debug!("Aggregating entry {}", entry.node);
                 match &entry.node.node {

--- a/crates/lib/src/repositories/workspaces/files.rs
+++ b/crates/lib/src/repositories/workspaces/files.rs
@@ -23,6 +23,17 @@ pub async fn add(workspace: &Workspace, path: impl AsRef<Path>) -> Result<PathBu
     }
 }
 
+pub async fn add_with_opts(
+    workspace: &Workspace,
+    path: impl AsRef<Path>,
+    force_update: bool,
+) -> Result<PathBuf, OxenError> {
+    match workspace.base_repo.min_version() {
+        MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
+        _ => core::v_latest::workspaces::files::add_with_opts(workspace, path, force_update).await,
+    }
+}
+
 pub async fn rm(
     workspace: &Workspace,
     path: impl AsRef<Path>,
@@ -46,12 +57,20 @@ pub async fn import(
     directory: PathBuf,
     filename: Option<String>,
     workspace: &Workspace,
+    force_update: bool,
 ) -> Result<(), OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => {
-            core::v_latest::workspaces::files::import(url, auth, directory, filename, workspace)
-                .await?;
+            core::v_latest::workspaces::files::import(
+                url,
+                auth,
+                directory,
+                filename,
+                workspace,
+                force_update,
+            )
+            .await?;
             Ok(())
         }
     }
@@ -266,6 +285,7 @@ mod tests {
                     std::path::PathBuf::from("data"),
                     None,
                     &workspace,
+                    false,
                 )
                 .await;
                 assert!(result.is_err(), "should reject {label}");

--- a/crates/lib/src/repositories/workspaces/files.rs
+++ b/crates/lib/src/repositories/workspaces/files.rs
@@ -26,11 +26,14 @@ pub async fn add(workspace: &Workspace, path: impl AsRef<Path>) -> Result<PathBu
 pub async fn add_with_opts(
     workspace: &Workspace,
     path: impl AsRef<Path>,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<PathBuf, OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::workspaces::files::add_with_opts(workspace, path, force_update).await,
+        _ => {
+            core::v_latest::workspaces::files::add_with_opts(workspace, path, update_timestamp)
+                .await
+        }
     }
 }
 
@@ -57,7 +60,7 @@ pub async fn import(
     directory: PathBuf,
     filename: Option<String>,
     workspace: &Workspace,
-    force_update: bool,
+    update_timestamp: bool,
 ) -> Result<(), OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
@@ -68,7 +71,7 @@ pub async fn import(
                 directory,
                 filename,
                 workspace,
-                force_update,
+                update_timestamp,
             )
             .await?;
             Ok(())

--- a/crates/lib/src/view/versions.rs
+++ b/crates/lib/src/view/versions.rs
@@ -55,6 +55,8 @@ pub struct CompleteVersionUploadRequest {
     // If the workspace_id is provided, we will add the file to the workspace
     // otherwise, we will just add the file to the versions store
     pub workspace_id: Option<String>,
+    #[serde(default)]
+    pub force_update: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/lib/src/view/versions.rs
+++ b/crates/lib/src/view/versions.rs
@@ -56,7 +56,7 @@ pub struct CompleteVersionUploadRequest {
     // otherwise, we will just add the file to the versions store
     pub workspace_id: Option<String>,
     #[serde(default)]
-    pub force_update: bool,
+    pub update_timestamp: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/server/src/controllers/import.rs
+++ b/crates/server/src/controllers/import.rs
@@ -180,10 +180,14 @@ pub async fn import(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let force_update = body
-        .get("force_update")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let update_timestamp = match body.get("update_timestamp") {
+        Some(value) => value.as_bool().ok_or_else(|| {
+            OxenHttpError::BadRequest(
+                "Invalid type for `update_timestamp`, expected boolean".into(),
+            )
+        })?,
+        None => false,
+    };
 
     // download and save the file into the workspace
     repositories::workspaces::files::import(
@@ -192,7 +196,7 @@ pub async fn import(
         directory,
         filename,
         &workspace,
-        force_update,
+        update_timestamp,
     )
     .await?;
 

--- a/crates/server/src/controllers/import.rs
+++ b/crates/server/src/controllers/import.rs
@@ -180,9 +180,21 @@ pub async fn import(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
+    let force_update = body
+        .get("force_update")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
     // download and save the file into the workspace
-    repositories::workspaces::files::import(download_url, auth, directory, filename, &workspace)
-        .await?;
+    repositories::workspaces::files::import(
+        download_url,
+        auth,
+        directory,
+        filename,
+        &workspace,
+        force_update,
+    )
+    .await?;
 
     // Commit workspace
     let commit_body = NewCommitBody {

--- a/crates/server/src/controllers/versions/chunks.rs
+++ b/crates/server/src/controllers/versions/chunks.rs
@@ -135,7 +135,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
                 &version_path,
                 &dst_path,
                 &version_id,
-                false,
+                request.force_update,
             )?;
         }
 

--- a/crates/server/src/controllers/versions/chunks.rs
+++ b/crates/server/src/controllers/versions/chunks.rs
@@ -135,6 +135,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
                 &version_path,
                 &dst_path,
                 &version_id,
+                false,
             )?;
         }
 

--- a/crates/server/src/controllers/versions/chunks.rs
+++ b/crates/server/src/controllers/versions/chunks.rs
@@ -135,7 +135,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
                 &version_path,
                 &dst_path,
                 &version_id,
-                request.force_update,
+                request.update_timestamp,
             )?;
         }
 

--- a/crates/server/src/controllers/workspaces/files.rs
+++ b/crates/server/src/controllers/workspaces/files.rs
@@ -38,7 +38,7 @@ pub struct FileUpload {
 /// Query parameters for staging operations
 #[derive(Deserialize, Debug, Default)]
 pub struct StagingQueryParams {
-    pub force_update: Option<bool>,
+    pub update_timestamp: Option<bool>,
 }
 
 /// Combined query parameters for workspace file operations (image resize and video thumbnail)
@@ -215,12 +215,12 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
 
     let version_store = repo.version_store()?;
 
-    let (upload_files, err_files, force_update) = save_parts(payload, &repo).await?;
+    let (upload_files, err_files, update_timestamp) = save_parts(payload, &repo).await?;
     log::debug!("Save multiparts found {} err_files", err_files.len());
     log::debug!(
-        "Calling add version files from the core workspace logic with {} files (force_update: {})",
+        "Calling add version files from the core workspace logic with {} files (update_timestamp: {})",
         upload_files.len(),
-        force_update,
+        update_timestamp,
     );
 
     let mut ret_files = vec![];
@@ -234,7 +234,7 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
             &version_path,
             &dst_path,
             &upload_file.hash,
-            force_update,
+            update_timestamp,
         ) {
             Ok(ret_file) => ret_file,
             Err(e) => {
@@ -264,7 +264,7 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
         ("repo_name" = String, Path, description = "The name of the repository", example = "ImageNet-1k"),
         ("workspace_id" = String, Path, description = "The UUID of the workspace", example = "580c0587-c157-417b-9118-8686d63d2745"),
         ("directory" = String, Path, description = "The directory to stage the files into", example = "data/train"),
-        ("force_update" = Option<bool>, Query, description = "Force staging even if file content has not changed, updating the file timestamp", example = false)
+        ("update_timestamp" = Option<bool>, Query, description = "Force staging even if file content has not changed, updating the file timestamp", example = false)
     ),
     request_body(
         content = Vec<FileWithHash>,
@@ -292,7 +292,7 @@ pub async fn add_version_files(
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
     let directory = path_param(&req, "directory")?;
-    let force_update = query.force_update.unwrap_or(false);
+    let update_timestamp = query.update_timestamp.unwrap_or(false);
 
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -301,16 +301,16 @@ pub async fn add_version_files(
     };
     let files_with_hash: Vec<FileWithHash> = payload.into_inner();
     log::debug!(
-        "Calling add version files from the core workspace logic with {} files (force_update: {})",
+        "Calling add version files from the core workspace logic with {} files (update_timestamp: {})",
         files_with_hash.len(),
-        force_update,
+        update_timestamp,
     );
     let err_files = core::v_latest::workspaces::files::add_version_files(
         &repo,
         &workspace,
         &files_with_hash,
         &directory,
-        force_update,
+        update_timestamp,
     )
     .await?;
 
@@ -487,7 +487,7 @@ pub async fn save_parts(
 
     let mut upload_files: Vec<FileWithHash> = vec![];
     let mut err_files: Vec<ErrorFileInfo> = vec![];
-    let mut force_update = false;
+    let mut update_timestamp = false;
 
     while let Some(mut field) = payload.try_next().await? {
         let Some(content_disposition) = field.content_disposition().cloned() else {
@@ -495,14 +495,9 @@ pub async fn save_parts(
         };
 
         if let Some(name) = content_disposition.get_name()
-            && name == "force_update"
+            && name == "update_timestamp"
         {
-            let mut field_bytes = Vec::new();
-            while let Some(chunk) = field.try_next().await? {
-                field_bytes.extend_from_slice(&chunk);
-            }
-            let value = String::from_utf8_lossy(&field_bytes);
-            force_update = value == "true" || value == "1";
+            update_timestamp = parse_bool_field(&mut field).await?;
             continue;
         }
 
@@ -621,7 +616,22 @@ pub async fn save_parts(
         }
     }
 
-    Ok((upload_files, err_files, force_update))
+    Ok((upload_files, err_files, update_timestamp))
+}
+
+async fn parse_bool_field(field: &mut actix_multipart::Field) -> Result<bool, Error> {
+    let mut bytes = Vec::new();
+    while let Some(chunk) = field.try_next().await? {
+        bytes.extend_from_slice(&chunk);
+    }
+    let value = String::from_utf8_lossy(&bytes);
+    match value.as_ref() {
+        "true" | "1" => Ok(true),
+        "false" | "0" => Ok(false),
+        _ => Err(actix_web::error::ErrorBadRequest(format!(
+            "Invalid boolean value: {value}"
+        ))),
+    }
 }
 
 // Record the error file info for retry

--- a/crates/server/src/controllers/workspaces/files.rs
+++ b/crates/server/src/controllers/workspaces/files.rs
@@ -35,6 +35,12 @@ pub struct FileUpload {
     pub file: Vec<u8>,
 }
 
+/// Query parameters for staging operations
+#[derive(Deserialize, Debug, Default)]
+pub struct StagingQueryParams {
+    pub force_update: Option<bool>,
+}
+
 /// Combined query parameters for workspace file operations (image resize and video thumbnail)
 #[derive(Deserialize, Debug)]
 pub struct WorkspaceFileQueryParams {
@@ -214,11 +220,12 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
 
     let version_store = repo.version_store()?;
 
-    let (upload_files, err_files) = save_parts(payload, &repo).await?;
+    let (upload_files, err_files, force_update) = save_parts(payload, &repo).await?;
     log::debug!("Save multiparts found {} err_files", err_files.len());
     log::debug!(
-        "Calling add version files from the core workspace logic with {} files",
+        "Calling add version files from the core workspace logic with {} files (force_update: {})",
         upload_files.len(),
+        force_update,
     );
 
     let mut ret_files = vec![];
@@ -232,6 +239,7 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
             &version_path,
             &dst_path,
             &upload_file.hash,
+            force_update,
         ) {
             Ok(ret_file) => ret_file,
             Err(e) => {
@@ -260,7 +268,8 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
         ("namespace" = String, Path, description = "The namespace of the repository", example = "ox"),
         ("repo_name" = String, Path, description = "The name of the repository", example = "ImageNet-1k"),
         ("workspace_id" = String, Path, description = "The UUID of the workspace", example = "580c0587-c157-417b-9118-8686d63d2745"),
-        ("directory" = String, Path, description = "The directory to stage the files into", example = "data/train")
+        ("directory" = String, Path, description = "The directory to stage the files into", example = "data/train"),
+        ("force_update" = Option<bool>, Query, description = "Force staging even if file content has not changed, updating the file timestamp", example = false)
     ),
     request_body(
         content = Vec<FileWithHash>,
@@ -280,6 +289,7 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
 pub async fn add_version_files(
     req: HttpRequest,
     payload: web::Json<Vec<FileWithHash>>,
+    query: web::Query<StagingQueryParams>,
 ) -> Result<HttpResponse, OxenHttpError> {
     // Add file to staging
     let app_data = app_data(&req)?;
@@ -287,6 +297,7 @@ pub async fn add_version_files(
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
     let directory = path_param(&req, "directory")?;
+    let force_update = query.force_update.unwrap_or(false);
 
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -295,14 +306,16 @@ pub async fn add_version_files(
     };
     let files_with_hash: Vec<FileWithHash> = payload.into_inner();
     log::debug!(
-        "Calling add version files from the core workspace logic with {} files",
+        "Calling add version files from the core workspace logic with {} files (force_update: {})",
         files_with_hash.len(),
+        force_update,
     );
     let err_files = core::v_latest::workspaces::files::add_version_files(
         &repo,
         &workspace,
         &files_with_hash,
         &directory,
+        force_update,
     )
     .await?;
 
@@ -469,7 +482,7 @@ pub async fn mv(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttp
 pub async fn save_parts(
     mut payload: Multipart,
     repo: &LocalRepository,
-) -> Result<(Vec<FileWithHash>, Vec<ErrorFileInfo>), Error> {
+) -> Result<(Vec<FileWithHash>, Vec<ErrorFileInfo>, bool), Error> {
     // Receive a multipart request and save the files to the version store
     let version_store = repo.version_store().map_err(|oxen_err: OxenError| {
         log::error!("Failed to get version store: {oxen_err:?}");
@@ -479,11 +492,24 @@ pub async fn save_parts(
 
     let mut upload_files: Vec<FileWithHash> = vec![];
     let mut err_files: Vec<ErrorFileInfo> = vec![];
+    let mut force_update = false;
 
     while let Some(mut field) = payload.try_next().await? {
         let Some(content_disposition) = field.content_disposition().cloned() else {
             continue;
         };
+
+        if let Some(name) = content_disposition.get_name()
+            && name == "force_update"
+        {
+            let mut field_bytes = Vec::new();
+            while let Some(chunk) = field.try_next().await? {
+                field_bytes.extend_from_slice(&chunk);
+            }
+            let value = String::from_utf8_lossy(&field_bytes);
+            force_update = value == "true" || value == "1";
+            continue;
+        }
 
         if let Some(name) = content_disposition.get_name()
             && (name == "file[]" || name == "file")
@@ -600,7 +626,7 @@ pub async fn save_parts(
         }
     }
 
-    Ok((upload_files, err_files))
+    Ok((upload_files, err_files, force_update))
 }
 
 // Record the error file info for retry


### PR DESCRIPTION
We needed a way to bump a file's latest commit / timestamp, without bumping the files content. So I introduced this update_timestamp parameter. Which is similar to just a `touch` operation that updates the latest commit and timestamp.

Import from multi-part:

curl -v -X POST "http://localhost:3001/api/repos/Subaru/playground/workspaces/upload/main/uploads" \
                                                                  -H "Authorization: Bearer $API_KEY" \
                                                                  -F "commit_message=testing from cli" \
                                                                  -F "update_timestamp=true" \
                                                                  -F "file[]=@/path/to/file.png"

and import from url:

curl -X POST \                                            
    "${BASE_API_URL}/repos/${NAMESPACE}/playground/import/main/uploads" \                                                                            
    -H "Authorization: Bearer ${TOKEN}" \
    -H "Content-Type: application/json" \                                                                                                            
    -d '{                                                   
      "download_url": "https://example.com/image.jpg",
      "name": "Greg",                                                                                                                                
      "email": "greg@example.com",
      "update_timestamp": true                                                                                                                           
    }'