### PR TITLE
Fix conflicting names between the cli and the oxen-py crates

### DIFF
--- a/crates/oxen-py/Cargo.toml
+++ b/crates/oxen-py/Cargo.toml
@@ -11,7 +11,7 @@ keywords = { workspace = true }
 publish = false
 
 [lib]
-name = "_oxen" # The native extension module. Users still `import oxen` via the Python package wrapper.
+name = "oxen_py" # The native extension module. Users still `import oxen` via the Python package wrapper.
 crate-type = ["cdylib"] # PyO3 needs this crate to be a cdylib so it can link against it.
 
 [dependencies]

--- a/crates/oxen-py/Cargo.toml
+++ b/crates/oxen-py/Cargo.toml
@@ -11,7 +11,7 @@ keywords = { workspace = true }
 publish = false
 
 [lib]
-name = "oxen" # Necessary so that we can import the crate as `import oxen` in Python.
+name = "_oxen" # The native extension module. Users still `import oxen` via the Python package wrapper.
 crate-type = ["cdylib"] # PyO3 needs this crate to be a cdylib so it can link against it.
 
 [dependencies]

--- a/crates/oxen-py/src/lib.rs
+++ b/crates/oxen-py/src/lib.rs
@@ -28,7 +28,7 @@ pub mod util;
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn _oxen(m: Bound<'_, PyModule>) -> PyResult<()> {
+fn oxen_py(m: Bound<'_, PyModule>) -> PyResult<()> {
     let py_version = Python::version_info(m.py());
     let _ = RuntimeConfig::set(
         String::from("Python"),

--- a/crates/oxen-py/src/lib.rs
+++ b/crates/oxen-py/src/lib.rs
@@ -28,7 +28,7 @@ pub mod util;
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn oxen(m: Bound<'_, PyModule>) -> PyResult<()> {
+fn _oxen(m: Bound<'_, PyModule>) -> PyResult<()> {
     let py_version = Python::version_info(m.py());
     let _ = RuntimeConfig::set(
         String::from("Python"),

--- a/oxen-python/pyproject.toml
+++ b/oxen-python/pyproject.toml
@@ -40,5 +40,6 @@ build-backend = "maturin"
 
 [tool.maturin]
 manifest-path = "../crates/oxen-py/Cargo.toml"
+module-name = "oxen._oxen"
 python-source = "python"
 features = ["pyo3/extension-module"]

--- a/oxen-python/pyproject.toml
+++ b/oxen-python/pyproject.toml
@@ -40,6 +40,6 @@ build-backend = "maturin"
 
 [tool.maturin]
 manifest-path = "../crates/oxen-py/Cargo.toml"
-module-name = "oxen._oxen"
+module-name = "oxen.oxen_py"
 python-source = "python"
 features = ["pyo3/extension-module"]

--- a/oxen-python/python/oxen/__init__.py
+++ b/oxen-python/python/oxen/__init__.py
@@ -1,7 +1,7 @@
 """Core Oxen Functionality"""
 
 # Rust wrappers
-from .oxen import (
+from ._oxen import (
     PyRepo,
     PyStagedData,
     PyCommit,
@@ -13,7 +13,7 @@ from .oxen import (
     PyColumn,
     __version__,
 )
-from .oxen import util
+from ._oxen import util
 
 # Python classes
 from oxen.repo import Repo

--- a/oxen-python/python/oxen/__init__.py
+++ b/oxen-python/python/oxen/__init__.py
@@ -1,7 +1,7 @@
 """Core Oxen Functionality"""
 
 # Rust wrappers
-from ._oxen import (
+from .oxen_py import (
     PyRepo,
     PyStagedData,
     PyCommit,
@@ -13,7 +13,7 @@ from ._oxen import (
     PyColumn,
     __version__,
 )
-from ._oxen import util
+from .oxen_py import util
 
 # Python classes
 from oxen.repo import Repo

--- a/oxen-python/python/oxen/auth.py
+++ b/oxen-python/python/oxen/auth.py
@@ -1,4 +1,4 @@
-from .oxen import auth, util
+from ._oxen import auth, util
 from oxen.user import config_user
 from typing import Optional
 import os

--- a/oxen-python/python/oxen/auth.py
+++ b/oxen-python/python/oxen/auth.py
@@ -1,4 +1,4 @@
-from ._oxen import auth, util
+from .oxen_py import auth, util
 from oxen.user import config_user
 from typing import Optional
 import os

--- a/oxen-python/python/oxen/config.py
+++ b/oxen-python/python/oxen/config.py
@@ -1,4 +1,4 @@
-from ._oxen import util
+from .oxen_py import util
 import os
 
 

--- a/oxen-python/python/oxen/config.py
+++ b/oxen-python/python/oxen/config.py
@@ -1,4 +1,4 @@
-from .oxen import util
+from ._oxen import util
 import os
 
 

--- a/oxen-python/python/oxen/data_frame.py
+++ b/oxen-python/python/oxen/data_frame.py
@@ -1,6 +1,6 @@
 from oxen.workspace import Workspace
 from oxen.remote_repo import RemoteRepo
-from .oxen import PyWorkspaceDataFrame, PyColumn
+from ._oxen import PyWorkspaceDataFrame, PyColumn
 import json
 from typing import List, Union, Optional
 import os

--- a/oxen-python/python/oxen/data_frame.py
+++ b/oxen-python/python/oxen/data_frame.py
@@ -1,6 +1,6 @@
 from oxen.workspace import Workspace
 from oxen.remote_repo import RemoteRepo
-from ._oxen import PyWorkspaceDataFrame, PyColumn
+from .oxen_py import PyWorkspaceDataFrame, PyColumn
 import json
 from typing import List, Union, Optional
 import os

--- a/oxen-python/python/oxen/df_utils.py
+++ b/oxen-python/python/oxen/df_utils.py
@@ -17,7 +17,7 @@ df_utils.save(df, "path/to/save.csv")
 ```
 """
 
-from ._oxen import df_utils
+from .oxen_py import df_utils
 
 import os
 from polars import DataFrame

--- a/oxen-python/python/oxen/df_utils.py
+++ b/oxen-python/python/oxen/df_utils.py
@@ -17,7 +17,7 @@ df_utils.save(df, "path/to/save.csv")
 ```
 """
 
-from .oxen import df_utils
+from ._oxen import df_utils
 
 import os
 from polars import DataFrame

--- a/oxen-python/python/oxen/diff/diff.py
+++ b/oxen-python/python/oxen/diff/diff.py
@@ -36,15 +36,15 @@ print(result.get())
 
 """
 
-from ..oxen import PyDiff
-from ..oxen import diff as py_diff
+import os
+from typing import Optional
 
 from oxen import df_utils
 from oxen.diff.tabular_diff import TabularDiff
 from oxen.diff.text_diff import TextDiff
 
-import os
-from typing import Optional
+from ..oxen_py import PyDiff
+from ..oxen_py import diff as py_diff
 
 
 def diff(

--- a/oxen-python/python/oxen/diff/line_diff.py
+++ b/oxen-python/python/oxen/diff/line_diff.py
@@ -1,6 +1,6 @@
-from ..oxen import PyLineDiff, PyChangeType
-
 from oxen.diff.change_type import ChangeType
+
+from ..oxen_py import PyChangeType, PyLineDiff
 
 
 class LineDiff:

--- a/oxen-python/python/oxen/diff/tabular_diff.py
+++ b/oxen-python/python/oxen/diff/tabular_diff.py
@@ -1,6 +1,6 @@
-from ..oxen import PyTabularDiff
-
 from polars import DataFrame
+
+from ..oxen_py import PyTabularDiff
 
 
 class TabularDiff:

--- a/oxen-python/python/oxen/diff/text_diff.py
+++ b/oxen-python/python/oxen/diff/text_diff.py
@@ -1,6 +1,6 @@
-from ..oxen import PyTextDiff, PyChangeType
-
 from oxen.diff.line_diff import LineDiff
+
+from ..oxen_py import PyChangeType, PyTextDiff
 
 
 class TextDiff:

--- a/oxen-python/python/oxen/oxen_fs.py
+++ b/oxen-python/python/oxen/oxen_fs.py
@@ -9,7 +9,7 @@ import fsspec
 from fsspec.utils import infer_storage_options
 
 from .remote_repo import RemoteRepo
-from .oxen import PyEntry
+from ._oxen import PyEntry
 
 logger = logging.getLogger(__name__)
 

--- a/oxen-python/python/oxen/oxen_fs.py
+++ b/oxen-python/python/oxen/oxen_fs.py
@@ -9,7 +9,7 @@ import fsspec
 from fsspec.utils import infer_storage_options
 
 from .remote_repo import RemoteRepo
-from ._oxen import PyEntry
+from .oxen_py import PyEntry
 
 logger = logging.getLogger(__name__)
 

--- a/oxen-python/python/oxen/remote_repo.py
+++ b/oxen-python/python/oxen/remote_repo.py
@@ -2,7 +2,7 @@ import os
 
 from typing import Optional
 from typing import List, Tuple
-from ._oxen import PyRemoteRepo, remote, PyCommit
+from .oxen_py import PyRemoteRepo, remote, PyCommit
 from . import user as oxen_user
 from .workspace import Workspace
 

--- a/oxen-python/python/oxen/remote_repo.py
+++ b/oxen-python/python/oxen/remote_repo.py
@@ -2,7 +2,7 @@ import os
 
 from typing import Optional
 from typing import List, Tuple
-from .oxen import PyRemoteRepo, remote, PyCommit
+from ._oxen import PyRemoteRepo, remote, PyCommit
 from . import user as oxen_user
 from .workspace import Workspace
 

--- a/oxen-python/python/oxen/user.py
+++ b/oxen-python/python/oxen/user.py
@@ -1,4 +1,4 @@
-from .oxen import user, util
+from ._oxen import user, util
 from typing import Optional
 import os
 

--- a/oxen-python/python/oxen/user.py
+++ b/oxen-python/python/oxen/user.py
@@ -1,4 +1,4 @@
-from ._oxen import user, util
+from .oxen_py import user, util
 from typing import Optional
 import os
 

--- a/oxen-python/python/oxen/workspace.py
+++ b/oxen-python/python/oxen/workspace.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Iterator, Optional
 
-from ._oxen import PyCommit, PyErrorFileInfo, PyWorkspace
+from .oxen_py import PyCommit, PyErrorFileInfo, PyWorkspace
 
 # Use TYPE_CHECKING for type hints to avoid runtime circular imports
 if TYPE_CHECKING:

--- a/oxen-python/python/oxen/workspace.py
+++ b/oxen-python/python/oxen/workspace.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Iterator, Optional
 
-from .oxen import PyCommit, PyErrorFileInfo, PyWorkspace
+from ._oxen import PyCommit, PyErrorFileInfo, PyWorkspace
 
 # Use TYPE_CHECKING for type hints to avoid runtime circular imports
 if TYPE_CHECKING:

--- a/oxen-python/tests/test_data_frame.py
+++ b/oxen-python/tests/test_data_frame.py
@@ -14,10 +14,8 @@ def test_data_frame_crud(celeba_remote_repo_fully_pushed):
 
     train_path = str(PurePath("annotations", "train.csv"))
     df = DataFrame(
-        remote_repo.identifier,
+        remote_repo,
         train_path,
-        host="localhost:3000",
-        scheme="http",
     )
     _width, og_height = df.size()
 
@@ -51,10 +49,8 @@ def test_data_frame_create_on_insert(celeba_remote_repo_fully_pushed):
     }
 
     df = DataFrame(
-        remote_repo.identifier,
+        remote_repo,
         new_file,
-        host="localhost:3000",
-        scheme="http",
     )
 
     # Add a row and commit
@@ -94,10 +90,8 @@ def test_data_frame_create_on_insert_on_branch(celeba_remote_repo_fully_pushed):
     }
 
     df = DataFrame(
-        remote_repo.identifier,
+        remote_repo,
         new_file,
-        host="localhost:3000",
-        scheme="http",
         branch="test-branch",
     )
 
@@ -177,10 +171,8 @@ def test_data_frame_commit(celeba_remote_repo_fully_pushed):
 
     train_path = str(PurePath("annotations", "train.csv"))
     df = DataFrame(
-        remote_repo.identifier,
+        remote_repo,
         train_path,
-        host="localhost:3000",
-        scheme="http",
     )
 
     # List commits before


### PR DESCRIPTION
Use a unique name for the `oxen-py` crate library to fix the warning from Cargo that `cli` and `oxen-py` produce artifacts with the same name that will become a hard error in the future.

This doesn't change anything from a Python user's perspective. They will still do `import oxen`, as the python module is named `oxen`, then under-the-hood it will access the Rust python interface through `oxen_py`.