### PR TITLE
disable debug logging for h2, reqwest, hyper_util libraries + request id in cli logs

### DIFF
--- a/crates/lib/src/api/client.rs
+++ b/crates/lib/src/api/client.rs
@@ -128,7 +128,7 @@ fn builder_for_host(host: String, should_add_user_agent: bool) -> Result<ClientB
         }
     };
     if let Some(auth_token) = config.auth_token_for_host(host.as_str()) {
-        log::debug!("Setting auth token for host: {}", host);
+        log::trace!("Setting auth token for host: {}", host);
         let auth_header = format!("Bearer {auth_token}");
         let mut auth_value = match header::HeaderValue::from_str(auth_header.as_str()) {
             Ok(header) => header,
@@ -181,6 +181,15 @@ pub async fn parse_json_body(url: &str, res: reqwest::Response) -> Result<String
     parse_json_body_with_err_msg(url, res, Some(type_override), Some(err_msg)).await
 }
 
+/// Extract the request ID from an oxen server response.
+pub fn get_request_id(response: &reqwest::Response) -> &str {
+    response
+        .headers()
+        .get("x-oxen-request-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("-")
+}
+
 /// Used to override error message when parsing json body
 async fn parse_json_body_with_err_msg(
     url: &str,
@@ -189,9 +198,9 @@ async fn parse_json_body_with_err_msg(
     response_msg_override: Option<&str>,
 ) -> Result<String, OxenError> {
     let status = res.status();
+    let request_id = get_request_id(&res);
+    log::debug!("url: {url}\nstatus: {status} request_id: {request_id}");
     let body = res.text().await?;
-
-    log::debug!("url: {url}\nstatus: {status}");
 
     let response: Result<OxenResponse, serde_json::Error> = serde_json::from_str(&body);
     log::debug!("response: {response:?}");
@@ -262,6 +271,12 @@ pub async fn handle_non_json_response(
     url: &str,
     res: reqwest::Response,
 ) -> Result<reqwest::Response, OxenError> {
+    let request_id = get_request_id(&res);
+    log::debug!(
+        "url: {url}\nstatus: {} request_id: {request_id}",
+        res.status()
+    );
+
     if res.status().is_success() || res.status().is_redirection() {
         // If the response is successful, return it as-is. We don't want to do any parsing here.
         return Ok(res);

--- a/crates/lib/src/api/client/entries.rs
+++ b/crates/lib/src/api/client/entries.rs
@@ -501,14 +501,15 @@ async fn pull_entry_chunk(
 
     let client = client::new_for_url(&url)?;
     let response = client.get(&url).send().await?;
-
+    let request_id = client::get_request_id(&response);
     let status = response.status();
     log::debug!(
-        "pull_entry_chunk response status={} for path={:?} chunk_start={} chunk_size={}",
+        "pull_entry_chunk status={} path={:?} chunk_start={} chunk_size={} request_id: {}",
         status,
         remote_path,
         chunk_start,
-        chunk_size
+        chunk_size,
+        request_id
     );
 
     match status {

--- a/crates/lib/src/config/auth_config.rs
+++ b/crates/lib/src/config/auth_config.rs
@@ -74,7 +74,7 @@ impl AuthConfig {
             Err(_) => config_dir.join(Path::new(AUTH_CONFIG_FILENAME)),
         };
 
-        log::debug!("looking for config file in...{config_file:?}");
+        log::trace!("looking for config file in...{config_file:?}");
         if config_file.exists() {
             Ok(AuthConfig::new(&config_file))
         } else {

--- a/crates/lib/src/util/logging.rs
+++ b/crates/lib/src/util/logging.rs
@@ -16,10 +16,14 @@ macro_rules! current_function {
 }
 
 pub fn init_logging() {
-    match env_logger::Builder::from_env(Env::default())
-        .filter_module("h2", log::LevelFilter::Warn)
-        .filter_module("hyper_util", log::LevelFilter::Warn)
-        .filter_module("reqwest", log::LevelFilter::Warn)
+    let mut builder = env_logger::Builder::new();
+    // ignore noisy http logs
+    builder.filter_module("h2", log::LevelFilter::Warn);
+    builder.filter_module("hyper_util", log::LevelFilter::Warn);
+    builder.filter_module("reqwest", log::LevelFilter::Warn);
+
+    builder.parse_env(Env::default());
+    match builder
         .format(|buf, record| {
             use crate::request_context::get_request_id;
 

--- a/crates/lib/src/util/logging.rs
+++ b/crates/lib/src/util/logging.rs
@@ -18,6 +18,8 @@ macro_rules! current_function {
 pub fn init_logging() {
     match env_logger::Builder::from_env(Env::default())
         .filter_module("h2", log::LevelFilter::Warn)
+        .filter_module("hyper_util", log::LevelFilter::Warn)
+        .filter_module("reqwest", log::LevelFilter::Warn)
         .format(|buf, record| {
             use crate::request_context::get_request_id;
 

--- a/crates/lib/src/util/logging.rs
+++ b/crates/lib/src/util/logging.rs
@@ -17,6 +17,7 @@ macro_rules! current_function {
 
 pub fn init_logging() {
     match env_logger::Builder::from_env(Env::default())
+        .filter_module("h2", log::LevelFilter::Warn)
         .format(|buf, record| {
             use crate::request_context::get_request_id;
 


### PR DESCRIPTION
client side logs are very noisy when run with, `RUST_LOG=debug` because of logs from h2 library. this PR turns off debug logs from h2.

this can still be enabled by `RUST_LOG=debug,h2=debug`

- removes logs from, `h2`, `reqwest` and `hyper_util`.
- also makes the `requestId` visible in the client side