### PR TITLE
sort dir by date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,7 +2908,7 @@ dependencies = [
  "rust_decimal",
  "serde_json",
  "smallvec",
- "strum",
+ "strum 0.25.0",
 ]
 
 [[package]]
@@ -4513,6 +4513,7 @@ dependencies = [
  "simdutf8",
  "sql_query_builder",
  "sqlparser",
+ "strum 0.26.3",
  "sysinfo",
  "tar",
  "tempfile",
@@ -7735,6 +7736,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
  "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ sha2 = "0.10.8"
 simdutf8 = "0.1.4"
 sql_query_builder = { version = "2.1.0", features = ["postgresql"] }
 sqlparser = "0.53.0"
+strum = { version = "0.26.3", features = ["derive"] }
 sysinfo = "0.33.0"
 tar = "0.4.44"
 # TODO: Replace all tempfile use with async-tempfile

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -102,6 +102,7 @@ sha2 = { workspace = true }
 simdutf8 = { workspace = true }
 sql_query_builder = { workspace = true }
 sqlparser = { workspace = true }
+strum = { workspace = true, features = ["derive"] }
 sysinfo = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/lib/src/api/client/dir.rs
+++ b/crates/lib/src/api/client/dir.rs
@@ -38,7 +38,7 @@ pub async fn list_with_opts(
     page: usize,
     page_size: usize,
     sort_opts: Option<&SortOpts>,
-    depth: Option<usize>,
+    depth: Option<isize>,
 ) -> Result<PaginatedDirEntries, OxenError> {
     let revision = revision.as_ref();
     let path = path.as_ref().to_string_lossy();

--- a/crates/lib/src/api/client/dir.rs
+++ b/crates/lib/src/api/client/dir.rs
@@ -5,6 +5,7 @@ use crate::error::OxenError;
 use crate::model::RemoteRepository;
 use crate::model::metadata::MetadataDir;
 use crate::model::metadata::generic_metadata::GenericMetadata;
+use crate::opts::SortOpts;
 use crate::view::entries::EMetadataEntry;
 use crate::view::{PaginatedDirEntries, PaginatedDirEntriesResponse};
 use crate::{api, constants};
@@ -27,9 +28,31 @@ pub async fn list(
     page: usize,
     page_size: usize,
 ) -> Result<PaginatedDirEntries, OxenError> {
+    list_with_opts(remote_repo, revision, path, page, page_size, None, None).await
+}
+
+pub async fn list_with_opts(
+    remote_repo: &RemoteRepository,
+    revision: impl AsRef<str>,
+    path: impl AsRef<Path>,
+    page: usize,
+    page_size: usize,
+    sort_opts: Option<&SortOpts>,
+    depth: Option<usize>,
+) -> Result<PaginatedDirEntries, OxenError> {
     let revision = revision.as_ref();
     let path = path.as_ref().to_string_lossy();
-    let uri = format!("/dir/{revision}/{path}?page={page}&page_size={page_size}");
+    let mut query_params = vec![format!("page={page}"), format!("page_size={page_size}")];
+    if let Some(sort_opts) = sort_opts {
+        query_params.push(format!("sort_by={}", sort_opts.sort_by));
+        if sort_opts.reverse {
+            query_params.push("reverse=true".to_string());
+        }
+    }
+    if let Some(depth) = depth {
+        query_params.push(format!("depth={depth}"));
+    }
+    let uri = format!("/dir/{revision}/{path}?{}", query_params.join("&"));
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
     let client = client::new_for_url(&url)?;
@@ -101,10 +124,12 @@ mod tests {
     use crate::constants::DEFAULT_BRANCH_NAME;
     use crate::error::OxenError;
     use crate::model::StagedEntryStatus;
+    use crate::opts::{SortBy, SortOpts};
     use crate::repositories;
     use crate::test;
     use crate::util;
     use crate::view::entries::EMetadataEntry;
+    use tokio::time::sleep;
 
     use std::path::Path;
     use std::path::PathBuf;
@@ -488,6 +513,129 @@ mod tests {
                 }
             }
             Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_sort_opts() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|local_repo| async move {
+            let mut local_repo = local_repo;
+
+            let name = local_repo.dirname();
+            let remote = test::repo_remote_url_from(&name);
+            command::config::set_remote(&mut local_repo, constants::DEFAULT_REMOTE_NAME, &remote)?;
+
+            let remote_repo = test::create_remote_repo(&local_repo).await?;
+
+            let file_a = local_repo.path.join("a_file.txt");
+            util::fs::write_to_path(&file_a, "content a")?;
+            repositories::add(&local_repo, &file_a).await?;
+            repositories::commit(&local_repo, "adding a_file")?;
+            repositories::push(&local_repo).await?;
+
+            sleep(std::time::Duration::from_millis(1100)).await;
+
+            let file_b = local_repo.path.join("b_file.txt");
+            util::fs::write_to_path(&file_b, "content b")?;
+            repositories::add(&local_repo, &file_b).await?;
+            repositories::commit(&local_repo, "adding b_file")?;
+            repositories::push(&local_repo).await?;
+
+            let root_entries = api::client::dir::list_with_opts(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                Path::new(""),
+                1,
+                10,
+                Some(&SortOpts {
+                    sort_by: SortBy::Date,
+                    reverse: true,
+                }),
+                None,
+            )
+            .await?;
+
+            let filenames: Vec<&str> = root_entries.entries.iter().map(|e| e.filename()).collect();
+            assert_eq!(filenames, vec!["b_file.txt", "a_file.txt"]);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_depth_and_nested_sort_opts() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|local_repo| async move {
+            let mut local_repo = local_repo;
+
+            let name = local_repo.dirname();
+            let remote = test::repo_remote_url_from(&name);
+            command::config::set_remote(&mut local_repo, constants::DEFAULT_REMOTE_NAME, &remote)?;
+
+            let remote_repo = test::create_remote_repo(&local_repo).await?;
+
+            let dir_a = local_repo.path.join("dir_a");
+            let dir_a_subdir = dir_a.join("subdir");
+            let dir_b = local_repo.path.join("dir_b");
+
+            util::fs::create_dir_all(&dir_a)?;
+            util::fs::create_dir_all(&dir_a_subdir)?;
+            util::fs::create_dir_all(&dir_b)?;
+
+            util::fs::write(local_repo.path.join("root_file.txt"), "root content")?;
+            util::fs::write(dir_a.join("file_a1.txt"), "a1 content")?;
+            util::fs::write(dir_a_subdir.join("file_sub.txt"), "sub content")?;
+            util::fs::write(dir_b.join("file_b1.txt"), "b1 content")?;
+
+            repositories::add(&local_repo, &local_repo.path).await?;
+            repositories::commit(&local_repo, "Adding nested structure")?;
+            repositories::push(&local_repo).await?;
+
+            sleep(std::time::Duration::from_millis(1100)).await;
+
+            let newer_nested_file = dir_a.join("file_a2.txt");
+            util::fs::write(newer_nested_file.clone(), "a2 content")?;
+            repositories::add(&local_repo, newer_nested_file).await?;
+            repositories::commit(&local_repo, "Adding newer nested file")?;
+            repositories::push(&local_repo).await?;
+
+            let paginated = api::client::dir::list_with_opts(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                Path::new(""),
+                1,
+                100,
+                Some(&SortOpts {
+                    sort_by: SortBy::Date,
+                    reverse: true,
+                }),
+                Some(1),
+            )
+            .await?;
+
+            let dir_a_entry = paginated
+                .entries
+                .iter()
+                .find(|e| e.filename() == "dir_a")
+                .expect("dir_a entry not found");
+
+            let EMetadataEntry::MetadataEntry(dir_a) = dir_a_entry else {
+                panic!("Expected dir_a to be a MetadataEntry");
+            };
+
+            let children = dir_a
+                .children
+                .as_ref()
+                .expect("dir_a children not populated");
+            let child_names: Vec<&str> = children
+                .iter()
+                .map(|child| child.filename.as_str())
+                .collect();
+            assert_eq!(child_names, vec!["subdir", "file_a2.txt", "file_a1.txt"]);
+            assert!(children[0].children.is_none());
+
+            Ok(())
         })
         .await
     }

--- a/crates/lib/src/api/client/dir.rs
+++ b/crates/lib/src/api/client/dir.rs
@@ -129,7 +129,6 @@ mod tests {
     use crate::test;
     use crate::util;
     use crate::view::entries::EMetadataEntry;
-    use tokio::time::sleep;
 
     use std::path::Path;
     use std::path::PathBuf;
@@ -534,8 +533,6 @@ mod tests {
             repositories::commit(&local_repo, "adding a_file")?;
             repositories::push(&local_repo).await?;
 
-            sleep(std::time::Duration::from_millis(1100)).await;
-
             let file_b = local_repo.path.join("b_file.txt");
             util::fs::write_to_path(&file_b, "content b")?;
             repositories::add(&local_repo, &file_b).await?;
@@ -591,8 +588,6 @@ mod tests {
             repositories::add(&local_repo, &local_repo.path).await?;
             repositories::commit(&local_repo, "Adding nested structure")?;
             repositories::push(&local_repo).await?;
-
-            sleep(std::time::Duration::from_millis(1100)).await;
 
             let newer_nested_file = dir_a.join("file_a2.txt");
             util::fs::write(newer_nested_file.clone(), "a2 content")?;

--- a/crates/lib/src/command/ls.rs
+++ b/crates/lib/src/command/ls.rs
@@ -26,7 +26,7 @@ pub async fn ls_with_opts(
     directory: &Path,
     opts: &PaginateOpts,
     sort_opts: Option<&SortOpts>,
-    depth: Option<usize>,
+    depth: Option<isize>,
 ) -> Result<PaginatedDirEntries, OxenError> {
     api::client::dir::list_with_opts(
         remote_repo,

--- a/crates/lib/src/command/ls.rs
+++ b/crates/lib/src/command/ls.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use crate::api;
 use crate::error::OxenError;
 use crate::model::{Branch, RemoteRepository};
-use crate::opts::PaginateOpts;
+use crate::opts::{PaginateOpts, SortOpts};
 use crate::view::PaginatedDirEntries;
 
 pub async fn ls(
@@ -17,12 +17,25 @@ pub async fn ls(
     directory: &Path,
     opts: &PaginateOpts,
 ) -> Result<PaginatedDirEntries, OxenError> {
-    api::client::dir::list(
+    ls_with_opts(remote_repo, branch, directory, opts, None, None).await
+}
+
+pub async fn ls_with_opts(
+    remote_repo: &RemoteRepository,
+    branch: &Branch,
+    directory: &Path,
+    opts: &PaginateOpts,
+    sort_opts: Option<&SortOpts>,
+    depth: Option<usize>,
+) -> Result<PaginatedDirEntries, OxenError> {
+    api::client::dir::list_with_opts(
         remote_repo,
         &branch.name,
         directory,
         opts.page_num,
         opts.page_size,
+        sort_opts,
+        depth,
     )
     .await
 }

--- a/crates/lib/src/core/v_latest/entries.rs
+++ b/crates/lib/src/core/v_latest/entries.rs
@@ -249,6 +249,7 @@ pub fn dir_entries_with_depth(
         parsed_resource,
         found_commits,
         &mut entries,
+        sort_opts,
         depth,
     )?;
     drop(_perf_recurse);
@@ -407,6 +408,7 @@ fn p_dir_entries(
     parsed_resource: &ParsedResource,
     found_commits: &mut HashMap<MerkleHash, Commit>,
     entries: &mut Vec<MetadataEntry>,
+    sort_opts: &SortOpts,
     depth: usize,
 ) -> Result<(), OxenError> {
     let search_directory = search_directory.as_ref();
@@ -423,6 +425,7 @@ fn p_dir_entries(
                     parsed_resource,
                     found_commits,
                     entries,
+                    sort_opts,
                     depth,
                 )?;
             }
@@ -464,15 +467,11 @@ fn p_dir_entries(
                                 &sub_resource,
                                 found_commits,
                                 &mut children,
+                                sort_opts,
                                 depth - 1,
                             )?;
 
-                            // Sort children
-                            children.sort_by(|a, b| {
-                                b.is_dir
-                                    .cmp(&a.is_dir)
-                                    .then_with(|| a.filename.cmp(&b.filename))
-                            });
+                            sort_entries(&mut children, sort_opts);
 
                             if !children.is_empty() {
                                 metadata.children = Some(children);
@@ -491,6 +490,7 @@ fn p_dir_entries(
                     parsed_resource,
                     found_commits,
                     entries,
+                    sort_opts,
                     depth,
                 )?;
             }

--- a/crates/lib/src/core/v_latest/entries.rs
+++ b/crates/lib/src/core/v_latest/entries.rs
@@ -8,7 +8,8 @@ use crate::model::metadata::generic_metadata::GenericMetadata;
 use crate::model::{
     Commit, CommitEntry, EntryDataType, LocalRepository, MerkleHash, MetadataEntry, ParsedResource,
 };
-use crate::opts::PaginateOpts;
+use crate::opts::{PaginateOpts, SortBy, SortOpts};
+
 use crate::repositories;
 use crate::util;
 use crate::view::PaginatedDirEntries;
@@ -45,7 +46,14 @@ pub fn list_directory(
     parsed_resource: &ParsedResource,
     paginate_opts: &PaginateOpts,
 ) -> Result<PaginatedDirEntries, OxenError> {
-    list_directory_with_depth(repo, directory, parsed_resource, paginate_opts, 0)
+    list_directory_with_depth(
+        repo,
+        directory,
+        parsed_resource,
+        paginate_opts,
+        &SortOpts::default(),
+        0,
+    )
 }
 
 pub fn list_directory_with_depth(
@@ -53,6 +61,7 @@ pub fn list_directory_with_depth(
     directory: impl AsRef<Path>,
     parsed_resource: &ParsedResource,
     paginate_opts: &PaginateOpts,
+    sort_opts: &SortOpts,
     depth: usize,
 ) -> Result<PaginatedDirEntries, OxenError> {
     let _perf = crate::perf_guard!("core::entries::list_directory");
@@ -112,6 +121,7 @@ pub fn list_directory_with_depth(
         directory,
         parsed_resource,
         &mut found_commits,
+        sort_opts,
         depth,
     )?;
     log::debug!("list_directory got {} entries", entries.len());
@@ -199,41 +209,15 @@ pub fn dir_entries(
     parsed_resource: &ParsedResource,
     found_commits: &mut HashMap<MerkleHash, Commit>,
 ) -> Result<Vec<MetadataEntry>, OxenError> {
-    let _perf = crate::perf_guard!("core::entries::dir_entries");
-
-    log::debug!(
-        "dir_entries search_directory {:?} dir {}",
-        search_directory.as_ref(),
-        dir
-    );
-    let mut entries: Vec<MetadataEntry> = Vec::new();
-    let current_directory = search_directory.as_ref();
-
-    let _perf_recurse = crate::perf_guard!("core::entries::p_dir_entries_recurse");
-    p_dir_entries(
+    dir_entries_with_depth(
         repo,
         dir,
-        &search_directory,
-        current_directory,
+        search_directory,
         parsed_resource,
         found_commits,
-        &mut entries,
+        &SortOpts::default(),
         0,
-    )?;
-    drop(_perf_recurse);
-
-    log::debug!("dir_entries got {} entries", entries.len());
-
-    let _perf_sort = crate::perf_guard!("core::entries::sort_entries");
-    // Sort entries by is_dir first, then by filename
-    entries.sort_by(|a, b| {
-        b.is_dir
-            .cmp(&a.is_dir)
-            .then_with(|| a.filename.cmp(&b.filename))
-    });
-    drop(_perf_sort);
-
-    Ok(entries)
+    )
 }
 
 pub fn dir_entries_with_depth(
@@ -242,6 +226,7 @@ pub fn dir_entries_with_depth(
     search_directory: impl AsRef<Path>,
     parsed_resource: &ParsedResource,
     found_commits: &mut HashMap<MerkleHash, Commit>,
+    sort_opts: &SortOpts,
     depth: usize,
 ) -> Result<Vec<MetadataEntry>, OxenError> {
     let _perf = crate::perf_guard!("core::entries::dir_entries");
@@ -271,15 +256,37 @@ pub fn dir_entries_with_depth(
     log::debug!("dir_entries got {} entries", entries.len());
 
     let _perf_sort = crate::perf_guard!("core::entries::sort_entries");
-    // Sort entries by is_dir first, then by filename
-    entries.sort_by(|a, b| {
-        b.is_dir
-            .cmp(&a.is_dir)
-            .then_with(|| a.filename.cmp(&b.filename))
-    });
+    sort_entries(&mut entries, sort_opts);
     drop(_perf_sort);
 
     Ok(entries)
+}
+
+fn sort_entries(entries: &mut [MetadataEntry], sort_opts: &SortOpts) {
+    use std::cmp::Ordering;
+
+    entries.sort_by(|a, b| {
+        // Directories always come first
+        let dir_cmp = b.is_dir.cmp(&a.is_dir);
+        if dir_cmp != Ordering::Equal {
+            return dir_cmp;
+        }
+
+        let field_cmp = match sort_opts.sort_by {
+            SortBy::Name => a.filename.cmp(&b.filename),
+            SortBy::Date => {
+                let a_ts = a.latest_commit.as_ref().map(|c| c.timestamp);
+                let b_ts = b.latest_commit.as_ref().map(|c| c.timestamp);
+                a_ts.cmp(&b_ts)
+            }
+        };
+
+        if sort_opts.reverse {
+            field_cmp.reverse()
+        } else {
+            field_cmp
+        }
+    });
 }
 
 fn dir_node_to_metadata_entry(

--- a/crates/lib/src/opts.rs
+++ b/crates/lib/src/opts.rs
@@ -20,6 +20,7 @@ pub mod push_opts;
 pub mod restore_opts;
 pub mod rm_opts;
 pub mod s3_opts;
+pub mod sort_opts;
 pub mod storage_opts;
 pub mod upload_opts;
 
@@ -40,5 +41,6 @@ pub use crate::opts::push_opts::PushOpts;
 pub use crate::opts::restore_opts::RestoreOpts;
 pub use crate::opts::rm_opts::RmOpts;
 pub use crate::opts::s3_opts::S3Opts;
+pub use crate::opts::sort_opts::{SortBy, SortOpts};
 pub use crate::opts::storage_opts::StorageOpts;
 pub use crate::opts::upload_opts::UploadOpts;

--- a/crates/lib/src/opts/sort_opts.rs
+++ b/crates/lib/src/opts/sort_opts.rs
@@ -1,33 +1,73 @@
+use derive_more::Display;
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::str::FromStr;
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+use crate::error::OxenError;
+
+#[derive(Clone, Debug, Default, Display, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+// TODO: When we upgrade to derive_more 2.0.0, use #[display(rename_all = "lowercase")]
 pub enum SortBy {
+    #[default]
+    #[display("name")]
     Name,
+    #[display("date")]
     Date,
 }
 
-impl fmt::Display for SortBy {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl SortBy {
+    const ALL: [SortBy; 2] = [SortBy::Name, SortBy::Date];
+
+    pub fn values() -> Vec<&'static str> {
+        Self::ALL.iter().map(SortBy::as_str).collect()
+    }
+
+    pub fn as_str(&self) -> &'static str {
         match self {
-            SortBy::Name => write!(f, "name"),
-            SortBy::Date => write!(f, "date"),
+            SortBy::Name => "name",
+            SortBy::Date => "date",
         }
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+impl FromStr for SortBy {
+    type Err = OxenError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let value = value.trim().to_lowercase();
+        SortBy::ALL
+            .iter()
+            .find(|sort_by| sort_by.as_str() == value)
+            .cloned()
+            .ok_or_else(|| {
+                let options = SortBy::values()
+                    .into_iter()
+                    .map(|value| format!("'{value}'"))
+                    .collect::<Vec<String>>()
+                    .join(" or ");
+                OxenError::basic_str(format!("Invalid sort_by: {value}. Expected {options}."))
+            })
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct SortOpts {
     pub sort_by: SortBy,
     pub reverse: bool,
 }
 
-impl Default for SortOpts {
-    fn default() -> Self {
-        SortOpts {
-            sort_by: SortBy::Name,
-            reverse: false,
-        }
+impl SortOpts {
+    pub fn from_query(sort_by: Option<&str>, reverse: bool) -> Result<Option<Self>, OxenError> {
+        let parsed = sort_by
+            .map(SortBy::from_str)
+            .transpose()?
+            .map(|sort_by| Self { sort_by, reverse });
+
+        Ok(parsed.or_else(|| {
+            reverse.then_some(Self {
+                sort_by: SortBy::Name,
+                reverse: true,
+            })
+        }))
     }
 }

--- a/crates/lib/src/opts/sort_opts.rs
+++ b/crates/lib/src/opts/sort_opts.rs
@@ -1,10 +1,12 @@
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+use strum::EnumIter;
+use strum::IntoEnumIterator;
 
 use crate::error::OxenError;
 
-#[derive(Clone, Debug, Default, Display, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Display, Serialize, Deserialize, PartialEq, Eq, EnumIter)]
 #[serde(rename_all = "lowercase")]
 // TODO: When we upgrade to derive_more 2.0.0, use #[display(rename_all = "lowercase")]
 pub enum SortBy {
@@ -16,10 +18,8 @@ pub enum SortBy {
 }
 
 impl SortBy {
-    const ALL: [SortBy; 2] = [SortBy::Name, SortBy::Date];
-
     pub fn values() -> Vec<&'static str> {
-        Self::ALL.iter().map(SortBy::as_str).collect()
+        Self::iter().map(|sort_by| sort_by.as_str()).collect()
     }
 
     pub fn as_str(&self) -> &'static str {
@@ -35,10 +35,8 @@ impl FromStr for SortBy {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let value = value.trim().to_lowercase();
-        SortBy::ALL
-            .iter()
+        SortBy::iter()
             .find(|sort_by| sort_by.as_str() == value)
-            .cloned()
             .ok_or_else(|| {
                 let options = SortBy::values()
                     .into_iter()

--- a/crates/lib/src/opts/sort_opts.rs
+++ b/crates/lib/src/opts/sort_opts.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SortBy {
+    Name,
+    Date,
+}
+
+impl fmt::Display for SortBy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SortBy::Name => write!(f, "name"),
+            SortBy::Date => write!(f, "date"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SortOpts {
+    pub sort_by: SortBy,
+    pub reverse: bool,
+}
+
+impl Default for SortOpts {
+    fn default() -> Self {
+        SortOpts {
+            sort_by: SortBy::Name,
+            reverse: false,
+        }
+    }
+}

--- a/crates/lib/src/repositories/entries.rs
+++ b/crates/lib/src/repositories/entries.rs
@@ -1208,6 +1208,9 @@ mod tests {
             )?;
 
             assert_eq!(paginated.total_entries, 3);
+            assert_eq!(paginated.entries[0].filename(), "dir_a");
+            assert_eq!(paginated.entries[1].filename(), "dir_b");
+            assert_eq!(paginated.entries[2].filename(), "root_file.txt");
 
             // Find dir_a and check it has children
             let dir_a_entry = paginated.entries.iter().find(|e| e.filename() == "dir_a");
@@ -1218,6 +1221,10 @@ mod tests {
                 let children = e.children.as_ref().unwrap();
                 // dir_a should have: file_a1.txt, file_a2.txt, and subdir
                 assert_eq!(children.len(), 3);
+                // Default sort is name asc with directories first
+                assert_eq!(children[0].filename, "subdir");
+                assert_eq!(children[1].filename, "file_a1.txt");
+                assert_eq!(children[2].filename, "file_a2.txt");
 
                 // With depth=1, subdir's children should NOT be populated
                 let subdir = children.iter().find(|c| c.filename == "subdir");

--- a/crates/lib/src/repositories/entries.rs
+++ b/crates/lib/src/repositories/entries.rs
@@ -6,7 +6,7 @@ use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::entry::commit_entry::{Entry, SchemaEntry};
 use crate::model::merkle_tree::node::{DirNode, FileNode};
-use crate::opts::PaginateOpts;
+use crate::opts::{PaginateOpts, SortOpts};
 use crate::repositories;
 use crate::util::concurrency;
 use rayon::prelude::*;
@@ -110,17 +110,20 @@ pub fn list_directory_w_workspace(
         revision,
         workspace,
         paginate_opts,
+        &SortOpts::default(),
         version,
         0,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn list_directory_w_workspace_depth(
     repo: &LocalRepository,
     directory: impl AsRef<Path>,
     revision: impl AsRef<str>,
     workspace: Option<Workspace>,
     paginate_opts: &PaginateOpts,
+    sort_opts: &SortOpts,
     version: MinOxenVersion,
     depth: usize,
 ) -> Result<PaginatedDirEntries, OxenError> {
@@ -154,6 +157,7 @@ pub fn list_directory_w_workspace_depth(
                 directory,
                 &parsed_resource,
                 paginate_opts,
+                sort_opts,
                 depth,
             )
         }
@@ -397,7 +401,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::error::OxenError;
-    use crate::opts::PaginateOpts;
+    use crate::opts::{PaginateOpts, SortOpts};
     use crate::repositories;
     use crate::test;
     use crate::util;
@@ -1164,6 +1168,7 @@ mod tests {
                 &commit.id,
                 None,
                 &paginate_opts,
+                &SortOpts::default(),
                 repo.min_version(),
                 0,
             )?;
@@ -1189,6 +1194,7 @@ mod tests {
                 &commit.id,
                 None,
                 &paginate_opts,
+                &SortOpts::default(),
                 repo.min_version(),
                 1,
             )?;
@@ -1218,6 +1224,7 @@ mod tests {
                 &commit.id,
                 None,
                 &paginate_opts,
+                &SortOpts::default(),
                 repo.min_version(),
                 2,
             )?;

--- a/crates/lib/src/repositories/entries.rs
+++ b/crates/lib/src/repositories/entries.rs
@@ -401,10 +401,11 @@ mod tests {
     use uuid::Uuid;
 
     use crate::error::OxenError;
-    use crate::opts::{PaginateOpts, SortOpts};
+    use crate::opts::{PaginateOpts, SortBy, SortOpts};
     use crate::repositories;
     use crate::test;
     use crate::util;
+    use tokio::time::sleep;
 
     #[tokio::test]
     async fn test_api_local_entries_list_all() -> Result<(), OxenError> {
@@ -1134,6 +1135,7 @@ mod tests {
             // root/
             //   dir_a/
             //     file_a1.txt
+            //     file_a2.txt
             //     subdir/
             //       file_sub.txt
             //   dir_b/
@@ -1154,7 +1156,13 @@ mod tests {
             util::fs::write(dir_b.join("file_b1.txt"), "b1 content")?;
 
             repositories::add(&repo, &repo.path).await?;
-            let commit = repositories::commit(&repo, "Adding nested structure")?;
+            let _first_commit = repositories::commit(&repo, "Adding nested structure")?;
+
+            sleep(std::time::Duration::from_millis(1100)).await;
+
+            util::fs::write(dir_a.join("file_a2.txt"), "a2 content")?;
+            repositories::add(&repo, dir_a.join("file_a2.txt")).await?;
+            let commit = repositories::commit(&repo, "Adding newer nested file")?;
 
             let paginate_opts = PaginateOpts {
                 page_num: 1,
@@ -1208,13 +1216,36 @@ mod tests {
             if let Some(crate::view::entries::EMetadataEntry::MetadataEntry(e)) = dir_a_entry {
                 assert!(e.children.is_some());
                 let children = e.children.as_ref().unwrap();
-                // dir_a should have: file_a1.txt and subdir
-                assert_eq!(children.len(), 2);
+                // dir_a should have: file_a1.txt, file_a2.txt, and subdir
+                assert_eq!(children.len(), 3);
 
                 // With depth=1, subdir's children should NOT be populated
                 let subdir = children.iter().find(|c| c.filename == "subdir");
                 assert!(subdir.is_some());
                 assert!(subdir.unwrap().children.is_none());
+            }
+
+            // Test non-default sorting is applied to nested children as well
+            let paginated = repositories::entries::list_directory_w_workspace_depth(
+                &repo,
+                Path::new(""),
+                &commit.id,
+                None,
+                &paginate_opts,
+                &SortOpts {
+                    sort_by: SortBy::Date,
+                    reverse: true,
+                },
+                repo.min_version(),
+                1,
+            )?;
+
+            let dir_a_entry = paginated.entries.iter().find(|e| e.filename() == "dir_a");
+            if let Some(crate::view::entries::EMetadataEntry::MetadataEntry(e)) = dir_a_entry {
+                let children = e.children.as_ref().unwrap();
+                assert_eq!(children[0].filename, "subdir");
+                assert_eq!(children[1].filename, "file_a2.txt");
+                assert_eq!(children[2].filename, "file_a1.txt");
             }
 
             // Test depth=2 - nested children populated

--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -365,7 +365,7 @@ impl PyRemoteRepo {
         page_size: usize,
         sort_by: Option<&str>,
         reverse: bool,
-        depth: Option<usize>,
+        depth: Option<isize>,
     ) -> Result<PyPaginatedDirEntries, PyOxenError> {
         let Some(revision) = &self.revision else {
             return Ok(PyPaginatedDirEntries::empty());

--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -6,8 +6,8 @@ use liboxen::error::OxenError;
 use liboxen::model::commit::NewCommitBody;
 use liboxen::model::file::{FileContents, FileNew};
 use liboxen::model::{Remote, RemoteRepository, RepoNew};
-use liboxen::opts::PaginateOpts;
 use liboxen::opts::StorageOpts;
+use liboxen::opts::{PaginateOpts, SortOpts};
 use liboxen::{api, repositories};
 
 use std::borrow::Cow;
@@ -357,18 +357,33 @@ impl PyRemoteRepo {
             .collect())
     }
 
+    #[pyo3(signature = (path, page_num=1, page_size=10, sort_by=None, reverse=false, depth=None))]
     fn ls(
         &self,
         path: PathBuf,
         page_num: usize,
         page_size: usize,
+        sort_by: Option<&str>,
+        reverse: bool,
+        depth: Option<usize>,
     ) -> Result<PyPaginatedDirEntries, PyOxenError> {
         let Some(revision) = &self.revision else {
             return Ok(PyPaginatedDirEntries::empty());
         };
 
+        let sort_opts = SortOpts::from_query(sort_by, reverse)?;
+
         let result = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::dir::list(&self.repo, &revision, &path, page_num, page_size).await
+            api::client::dir::list_with_opts(
+                &self.repo,
+                revision,
+                &path,
+                page_num,
+                page_size,
+                sort_opts.as_ref(),
+                depth,
+            )
+            .await
         })?;
 
         // Convert remote status to a PyStagedData using the from method

--- a/crates/server/src/controllers/dir.rs
+++ b/crates/server/src/controllers/dir.rs
@@ -3,7 +3,7 @@ use crate::helpers::get_repo;
 use crate::params::{PageNumVersionQuery, app_data, parse_resource, path_param};
 
 use liboxen::core::versions::MinOxenVersion;
-use liboxen::opts::{PaginateOpts, SortBy, SortOpts};
+use liboxen::opts::{PaginateOpts, SortOpts};
 use liboxen::perf_guard;
 use liboxen::view::PaginatedDirEntriesResponse;
 use liboxen::{constants, repositories};
@@ -49,14 +49,13 @@ pub async fn get(
         d if d < 0 => usize::MAX,
         d => d as usize,
     };
-    let sort_by = match query.sort_by.as_deref() {
-        Some("date") => SortBy::Date,
-        _ => SortBy::Name,
-    };
-    let sort_opts = SortOpts {
-        sort_by,
-        reverse: query.reverse.unwrap_or(false),
-    };
+    let sort_opts = SortOpts::from_query(query.sort_by.as_deref(), query.reverse.unwrap_or(false))
+        .map_err(|_| {
+            OxenHttpError::BadRequest(
+                "Invalid value for sort_by, valid options include: `name`, `date`.".into(),
+            )
+        })?
+        .unwrap_or_default();
     drop(_perf_parse);
 
     log::debug!(

--- a/crates/server/src/controllers/dir.rs
+++ b/crates/server/src/controllers/dir.rs
@@ -3,7 +3,7 @@ use crate::helpers::get_repo;
 use crate::params::{PageNumVersionQuery, app_data, parse_resource, path_param};
 
 use liboxen::core::versions::MinOxenVersion;
-use liboxen::opts::PaginateOpts;
+use liboxen::opts::{PaginateOpts, SortBy, SortOpts};
 use liboxen::perf_guard;
 use liboxen::view::PaginatedDirEntriesResponse;
 use liboxen::{constants, repositories};
@@ -49,6 +49,14 @@ pub async fn get(
         d if d < 0 => usize::MAX,
         d => d as usize,
     };
+    let sort_by = match query.sort_by.as_deref() {
+        Some("date") => SortBy::Date,
+        _ => SortBy::Name,
+    };
+    let sort_opts = SortOpts {
+        sort_by,
+        reverse: query.reverse.unwrap_or(false),
+    };
     drop(_perf_parse);
 
     log::debug!(
@@ -72,6 +80,7 @@ pub async fn get(
             page_num: page,
             page_size,
         },
+        &sort_opts,
         api_version,
         depth,
     )?;
@@ -138,6 +147,91 @@ mod tests {
 
         // Make sure we can fetch all the entries
         assert_eq!(entries_resp.total_entries, num_entries);
+
+        // cleanup
+        test::cleanup_sync_dir(&sync_dir)?;
+
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_controllers_dir_sort_by_date() -> Result<(), OxenError> {
+        liboxen::test::init_test_env();
+
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let name = "Testing-Name";
+        let repo = test::create_local_repo(&sync_dir, namespace, name)?;
+
+        // Create files in separate commits so they have different timestamps
+        let file_a = repo.path.join("a_file.txt");
+        util::fs::write_to_path(&file_a, "content a")?;
+        repositories::add(&repo, &file_a).await?;
+        repositories::commit(&repo, "adding a_file")?;
+
+        let file_b = repo.path.join("b_file.txt");
+        util::fs::write_to_path(&file_b, "content b")?;
+        repositories::add(&repo, &file_b).await?;
+        let commit = repositories::commit(&repo, "adding b_file")?;
+
+        let app = actix_web::test::init_service(
+            App::new()
+                .app_data(OxenAppData::new(sync_dir.clone()))
+                .route(
+                    "/oxen/{namespace}/{repo_name}/dir/{resource:.*}",
+                    web::get().to(controllers::dir::get),
+                ),
+        )
+        .await;
+
+        // Default sort (name ascending)
+        let uri = format!("/oxen/{}/{}/dir/{}/", namespace, name, commit.id);
+        let req = actix_web::test::TestRequest::get().uri(&uri).to_request();
+        let resp = actix_web::test::call_service(&app, req).await;
+        let bytes = actix_http::body::to_bytes(resp.into_body()).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        let entries_resp: PaginatedDirEntries = serde_json::from_str(body)?;
+        let filenames: Vec<&str> = entries_resp.entries.iter().map(|e| e.filename()).collect();
+        assert_eq!(filenames, vec!["a_file.txt", "b_file.txt"]);
+
+        // Sort by date ascending (a_file committed first, b_file second)
+        let uri = format!(
+            "/oxen/{}/{}/dir/{}/?sort_by=date",
+            namespace, name, commit.id
+        );
+        let req = actix_web::test::TestRequest::get().uri(&uri).to_request();
+        let resp = actix_web::test::call_service(&app, req).await;
+        let bytes = actix_http::body::to_bytes(resp.into_body()).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        let entries_resp: PaginatedDirEntries = serde_json::from_str(body)?;
+        let filenames: Vec<&str> = entries_resp.entries.iter().map(|e| e.filename()).collect();
+        assert_eq!(filenames, vec!["a_file.txt", "b_file.txt"]);
+
+        // Sort by date descending (reverse)
+        let uri = format!(
+            "/oxen/{}/{}/dir/{}/?sort_by=date&reverse=true",
+            namespace, name, commit.id
+        );
+        let req = actix_web::test::TestRequest::get().uri(&uri).to_request();
+        let resp = actix_web::test::call_service(&app, req).await;
+        let bytes = actix_http::body::to_bytes(resp.into_body()).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        let entries_resp: PaginatedDirEntries = serde_json::from_str(body)?;
+        let filenames: Vec<&str> = entries_resp.entries.iter().map(|e| e.filename()).collect();
+        assert_eq!(filenames, vec!["b_file.txt", "a_file.txt"]);
+
+        // Sort by name reversed
+        let uri = format!(
+            "/oxen/{}/{}/dir/{}/?sort_by=name&reverse=true",
+            namespace, name, commit.id
+        );
+        let req = actix_web::test::TestRequest::get().uri(&uri).to_request();
+        let resp = actix_web::test::call_service(&app, req).await;
+        let bytes = actix_http::body::to_bytes(resp.into_body()).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        let entries_resp: PaginatedDirEntries = serde_json::from_str(body)?;
+        let filenames: Vec<&str> = entries_resp.entries.iter().map(|e| e.filename()).collect();
+        assert_eq!(filenames, vec!["b_file.txt", "a_file.txt"]);
 
         // cleanup
         test::cleanup_sync_dir(&sync_dir)?;

--- a/crates/server/src/params/page_num_query.rs
+++ b/crates/server/src/params/page_num_query.rs
@@ -14,4 +14,8 @@ pub struct PageNumVersionQuery {
     pub api_version: Option<String>,
     /// Depth of nested directory traversal. 0 = current directory only (default), 1 = include immediate children, -1 = unlimited.
     pub depth: Option<isize>,
+    /// Sort entries by "name" (default) or "date" (latest commit timestamp).
+    pub sort_by: Option<String>,
+    /// Reverse the sort order. Default is false (ascending).
+    pub reverse: Option<bool>,
 }


### PR DESCRIPTION
 New: Sort parameters on the directory listing endpoint
 
GET /api/repos/{namespace}/{repo_name}/dir/{resource} now accepts two new optional query parameters:
    - sort_by — "name" (default) or "date" (sorts by the entry's latest commit timestamp)
    - reverse — true or false (default false, which is ascending)
 
Examples:
    ?sort_by=date                  # oldest first
    ?sort_by=date&reverse=true     # newest first
    ?sort_by=name&reverse=true     # Z-A
