### PR TITLE
Add a way to automatically test python

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -108,7 +108,7 @@ oxen push origin main               # Push to remote
 - When altering the `OxenError` enum, consider whether a hint needs to be added or updated in the `hint` method.
 - After changing any Rust code, verify that tests pass with the `bin/test-rust` script (not `cargo`). The script is documented in a comment at the top of its file.
 - The Python project calls into the Rust project. Whenever changing the Rust code, check to see if the Python code needs to be updated.
-- After changing any Rust or Python code, verify that Rust tests pass with `bin/test-rust` and Python tests pass with `/bin/test-rust -p`
+- After changing any Rust or Python code, verify that Rust tests pass with `bin/test-rust` and Python tests pass with `bin/test-rust -p`
 
 # Testing Rules
 - Use the test helpers in `crates/lib/src/test.rs` (e.g., `run_empty_local_repo_test`) for unit tests in the lib code.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -107,6 +107,8 @@ oxen push origin main               # Push to remote
 - When calling `get_staged_db_manager`, follow the doc comment on that function: drop the returned `StagedDBManager` as soon as possible (via a block scope or explicit `drop()`) to avoid holding the shared database handle longer than necessary.
 - When altering the `OxenError` enum, consider whether a hint needs to be added or updated in the `hint` method.
 - After changing any Rust code, verify that tests pass with the `bin/test-rust` script (not `cargo`). The script is documented in a comment at the top of its file.
+- The Python project calls into the Rust project. Whenever changing the Rust code, check to see if the Python code needs to be updated.
+- After changing any Rust or Python code, verify that Rust tests pass with `bin/test-rust` and Python tests pass with `/bin/test-rust -p`
 
 # Testing Rules
 - Use the test helpers in `crates/lib/src/test.rs` (e.g., `run_empty_local_repo_test`) for unit tests in the lib code.

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -2,20 +2,30 @@
 #
 # Build, configure, and run the Oxen test suite.
 #
-# Usage: test-rust [--ffmpeg] [--keep] [nextest args...]
+# Usage: test-rust [--ffmpeg] [--keep] [-p|--python] [extra args...]
 #
-#   --ffmpeg    Enable the "ffmpeg" cargo feature for build and test commands.
-#   --keep      Do not remove test data (in data/ox and data/test/runs)on cleanup--useful for
-#               debugging failed tests
-#   All subsequent arguments are forwarded to `cargo nextest run`.
+#   --ffmpeg      Enable the "ffmpeg" cargo feature for build and test commands.
+#   --keep        Do not remove test data (in data/ox and data/test/runs) on cleanup — useful for
+#                 debugging failed tests.
+#   -p|--python   Run the oxen-python test suite (via pytest) instead of the Rust test suite.
+#                 Builds the native extension with maturin.
+#   All remaining arguments are forwarded to `cargo nextest run` or `pytest` (with -p).
+#
+# Examples:
+#   test-rust                       # Run all Rust tests
+#   test-rust test_name             # Run Rust tests matching test_name
+#   test-rust -p                    # Run all Python tests
+#   test-rust -p -k test_init      # Run Python tests matching test_init
 
-# Check for --ffmpeg and --keep flags
+# Check for flags
 FEATURE_ARGS=""
 KEEP_DATA=false
+RUN_PYTHON=false
 while true; do
     case "${1:-}" in
-        --ffmpeg) FEATURE_ARGS="-F ffmpeg"; shift ;;
-        --keep)   KEEP_DATA=true; shift ;;
+        --ffmpeg)        FEATURE_ARGS="-F ffmpeg"; shift ;;
+        --keep)          KEEP_DATA=true; shift ;;
+        -p|--python)     RUN_PYTHON=true; shift ;;
         *) break ;;
     esac
 done
@@ -137,9 +147,28 @@ wait_for_server() {
 echo "==> Waiting for oxen-server health check to pass..."
 wait_for_server
 
-# Run tests
-echo "==> Running tests with 'cargo nextest run $FEATURE_ARGS $*' ..."
-# shellcheck disable=SC2086
-cargo nextest run $FEATURE_ARGS "$@"
+if [ "$RUN_PYTHON" = true ]; then
+    # Configure oxen CLI user for the Python tests
+    echo "==> Configuring oxen CLI user..."
+    ./target/debug/oxen config --name "Bessie Testington" --email "bessie@yourcompany.com"
+
+    # Set up Python environment and build the extension
+    echo "==> Setting up Python environment..."
+    cd oxen-python
+    uv sync --no-install-project
+    # shellcheck disable=SC1091
+    source .venv/bin/activate
+    echo "==> Building Python extension with maturin..."
+    maturin develop
+
+    # Run tests
+    echo "==> Running pytest $* ..."
+    pytest -s tests "$@"
+else
+    # Run Rust tests
+    echo "==> Running tests with 'cargo nextest run $FEATURE_ARGS $*' ..."
+    # shellcheck disable=SC2086
+    cargo nextest run $FEATURE_ARGS "$@"
+fi
 
 # cleanup handled via the trapped cleanup function

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -152,18 +152,21 @@ if [ "$RUN_PYTHON" = true ]; then
     echo "==> Configuring oxen CLI user..."
     ./target/debug/oxen config --name "Bessie Testington" --email "bessie@yourcompany.com"
 
-    # Set up Python environment and build the extension
+    # Set up Python environment and build the extension (in a subshell to avoid
+    # changing the working directory, so cleanup's relative paths still work)
     echo "==> Setting up Python environment..."
-    cd oxen-python
-    uv sync --no-install-project
-    # shellcheck disable=SC1091
-    source .venv/bin/activate
-    echo "==> Building Python extension with maturin..."
-    maturin develop
+    (
+        cd oxen-python
+        uv sync --no-install-project
+        # shellcheck disable=SC1091
+        source .venv/bin/activate
+        echo "==> Building Python extension with maturin..."
+        maturin develop
 
-    # Run tests
-    echo "==> Running pytest $* ..."
-    pytest -s tests "$@"
+        # Run tests
+        echo "==> Running pytest $* ..."
+        pytest -s tests "$@"
+    )
 else
     # Run Rust tests
     echo "==> Running tests with 'cargo nextest run $FEATURE_ARGS $*' ..."


### PR DESCRIPTION
- Test Python with a script, so we don't have to manually do all the steps (which was driving me crazy while working on #399)
- Testing python requires installing prereqs, building and running the server, and cleaning up afterwards just like the Rust tests do, so I elected to add this to the `test-rust` script. I intend to rename the script `test` in the future, now that it tests everything, but I thought it might make the PR more difficult to read if it considered it a whole new file, so I left the filename for now.