### PR TITLE
Unify crate's `liboxen` features

### DIFF
--- a/crates/oxen-py/Cargo.toml
+++ b/crates/oxen-py/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"] # PyO3 needs this crate to be a cdylib so it can link ag
 
 [dependencies]
 env_logger = { workspace = true }
-liboxen = { path = "../lib", features = ["perf-logging"] }
+liboxen = { path = "../lib" }
 log = { workspace = true }
 pyo3 = { workspace = true }
 pyo3-async-runtimes = { workspace = true }


### PR DESCRIPTION
Improve workspace compilation time by unifying the `liboxen` features that
all `crates/` use. The `oxen-py` crate no longer requests the `perf-logging`
feature: it uses default features like the other crates. This means `liboxen`
doesn't need to be compiled twice during `cargo build`.