### PR TITLE
mut unneeded for RmOpts construction

### DIFF
--- a/crates/lib/src/api/client/diff.rs
+++ b/crates/lib/src/api/client/diff.rs
@@ -1135,8 +1135,11 @@ who won the game?,The packers beat up on the bears,packers
                 util::fs::remove_file(&repo_filepath)?;
             }
 
-            let mut rm_opts = RmOpts::from_path(Path::new("images").join("cats"));
-            rm_opts.recursive = true;
+            let rm_opts = RmOpts {
+                path: PathBuf::from("images").join("cats"),
+                staged: false,
+                recursive: true,
+            };
             repositories::rm(&repo, &rm_opts)?;
             repositories::commit(&repo, "Removing cat images")?;
 
@@ -1249,8 +1252,11 @@ who won the game?,The packers beat up on the bears,packers
             }
 
             // THIS IS THE CRUX of this test, do not remove images/cats, just remove images/
-            let mut rm_opts = RmOpts::from_path(Path::new("images"));
-            rm_opts.recursive = true;
+            let rm_opts = RmOpts {
+                path: PathBuf::from("images"),
+                staged: false,
+                recursive: true,
+            };
             repositories::rm(&repo, &rm_opts)?;
             repositories::commit(&repo, "Removing cat images")?;
 
@@ -1749,8 +1755,11 @@ who won the game?,The packers beat up on the bears,packers
                 util::fs::remove_file(&repo_filepath)?;
             }
 
-            let mut rm_opts = RmOpts::from_path("images");
-            rm_opts.recursive = true;
+            let rm_opts = RmOpts {
+                path: PathBuf::from("images"),
+                staged: false,
+                recursive: true,
+            };
             repositories::rm(&repo, &rm_opts)?;
             repositories::commit(&repo, "Removing cat images")?;
 

--- a/crates/lib/src/core/v_latest/add.rs
+++ b/crates/lib/src/core/v_latest/add.rs
@@ -153,8 +153,11 @@ pub async fn add_files(
     let gitignore = oxenignore::create(repo);
 
     let mut paths_to_remove = HashSet::new();
-    let mut rm_opts = RmOpts::new();
-    rm_opts.recursive = true;
+    let rm_opts = RmOpts {
+        path: PathBuf::from(""),
+        staged: false,
+        recursive: true,
+    };
 
     for path in paths {
         let corrected_path = match (path.is_absolute(), repo_path.is_absolute()) {

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -817,9 +817,12 @@ async fn create_merge_commit_on_branch(
     // The author in this case is the pusher - the author of the merge commit
 
     let commit = commit_writer::commit_with_parent_ids(repo, &commit_msg, parent_ids)?;
-    let mut opts = RmOpts::from_path(PathBuf::from("/"));
-    opts.staged = true;
-    opts.recursive = true;
+    let opts = RmOpts {
+        path: PathBuf::from("/"),
+        staged: true,
+        recursive: true,
+    };
+
     rm::remove_staged(repo, &HashSet::from([PathBuf::from("/")]), &opts)?;
 
     Ok(commit)

--- a/crates/lib/src/repositories/commits.rs
+++ b/crates/lib/src/repositories/commits.rs
@@ -1060,8 +1060,12 @@ mod tests {
             assert!(tree.get_by_path(PathBuf::from("empty_dir"))?.is_some());
 
             // Remove the empty dir
-            let mut rm_opts = RmOpts::from_path(PathBuf::from("empty_dir"));
-            rm_opts.recursive = true;
+            let rm_opts = RmOpts {
+                path: PathBuf::from("empty_dir"),
+                staged: false,
+                recursive: true,
+            };
+
             repositories::rm(&repo, &rm_opts)?;
             let commit_2 = repositories::commit(&repo, "removing empty dir")?;
 

--- a/crates/lib/src/repositories/push.rs
+++ b/crates/lib/src/repositories/push.rs
@@ -1088,8 +1088,12 @@ mod tests {
             util::fs::rename(&train_images, &new_path)?;
 
             repositories::add(&local_repo, new_path).await?;
-            let mut rm_opts = RmOpts::from_path("train");
-            rm_opts.recursive = true;
+            let rm_opts = RmOpts {
+                path: PathBuf::from("train"),
+                staged: false,
+                recursive: true,
+            };
+
             repositories::rm(&local_repo, &rm_opts)?;
             let commit =
                 repositories::commit(&local_repo, "Moved all the train image files to images/")?;

--- a/crates/lib/src/repositories/rm.rs
+++ b/crates/lib/src/repositories/rm.rs
@@ -241,8 +241,12 @@ mod tests {
                 let cloned_repo =
                     repositories::clone_url(&cloned_remote_repo.remote.url, &new_repo_dir).await?;
 
-                let mut rm_opts = RmOpts::from_path(Path::new("phi-4"));
-                rm_opts.recursive = true;
+                let rm_opts = RmOpts {
+                    path: PathBuf::from("phi-4"),
+                    staged: false,
+                    recursive: true,
+                };
+
                 repositories::rm(&cloned_repo, &rm_opts)?;
                 repositories::commit(&cloned_repo, "Removing phi-4")?;
 
@@ -292,8 +296,11 @@ mod tests {
                 util::fs::remove_file(&repo_filepath)?;
             }
 
-            let mut rm_opts = RmOpts::from_path(Path::new("images"));
-            rm_opts.recursive = true;
+            let rm_opts = RmOpts {
+                path: PathBuf::from("images"),
+                staged: false,
+                recursive: true,
+            };
             repositories::rm(&repo, &rm_opts)?;
             let commit = repositories::commit(&repo, "Removing cat images")?;
 
@@ -403,8 +410,12 @@ mod tests {
             repositories::branches::create_checkout(&repo, branch_name)?;
 
             // Remove all the cat images and subdirectories
-            let mut rm_opts = RmOpts::from_path(Path::new("images"));
-            rm_opts.recursive = true;
+            let rm_opts = RmOpts {
+                path: PathBuf::from("images"),
+                staged: false,
+                recursive: true,
+            };
+
             repositories::rm(&repo, &rm_opts)?;
             let commit = repositories::commit(&repo, "Removing cat images and sub_directories")?;
 

--- a/crates/lib/src/repositories/tree.rs
+++ b/crates/lib/src/repositories/tree.rs
@@ -1504,8 +1504,12 @@ mod tests {
             // Remove the deeply nested dir
             util::fs::remove_dir_all(&dir_path)?;
 
-            let mut opts = RmOpts::from_path(dir_path);
-            opts.recursive = true;
+            let opts = RmOpts {
+                path: dir_path,
+                staged: false,
+                recursive: true,
+            };
+
             repositories::rm(&repo, &opts)?;
             let commit = repositories::commit(&repo, "Removing dir")?;
 


### PR DESCRIPTION
`RmOpts` allows for setting all fields at construction time. Several
places in the code were unnecessarily creating a `mut RmOpts` to set
fields right after construction time instead of directly setting the
`struct` directly during construction and using a non-`mut` declaration.