### PR TITLE
Make clippy pre-commit hook also run on test code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
 
       - id: cargo-clippy
         name: cargo clippy
-        entry: bash -c 'cargo clippy --workspace --no-deps -- -D warnings'
+        entry: bash -c 'cargo clippy --workspace --all-targets --no-deps -- -D warnings'
         language: system
         files: \.rs$
         pass_filenames: false

--- a/crates/lib/src/api/client/tree.rs
+++ b/crates/lib/src/api/client/tree.rs
@@ -535,10 +535,10 @@ mod tests {
             let dir_count = entries
                 .filter_map(|entry| match entry {
                     Ok(e) => {
-                        if let Ok(file_type) = e.file_type() {
-                            if file_type.is_dir() {
-                                return Some(1);
-                            }
+                        if let Ok(file_type) = e.file_type()
+                            && file_type.is_dir()
+                        {
+                            return Some(1);
                         }
                         None
                     }
@@ -562,10 +562,10 @@ mod tests {
             let dir_count = entries
                 .filter_map(|entry| match entry {
                     Ok(e) => {
-                        if let Ok(file_type) = e.file_type() {
-                            if file_type.is_dir() {
-                                return Some(1);
-                            }
+                        if let Ok(file_type) = e.file_type()
+                            && file_type.is_dir()
+                        {
+                            return Some(1);
                         }
                         None
                     }
@@ -604,10 +604,10 @@ mod tests {
             let dir_count = entries
                 .filter_map(|entry| match entry {
                     Ok(e) => {
-                        if let Ok(file_type) = e.file_type() {
-                            if file_type.is_dir() {
-                                return Some(1);
-                            }
+                        if let Ok(file_type) = e.file_type()
+                            && file_type.is_dir()
+                        {
+                            return Some(1);
                         }
                         None
                     }
@@ -642,10 +642,10 @@ mod tests {
             let dir_count = entries
                 .filter_map(|entry| match entry {
                     Ok(e) => {
-                        if let Ok(file_type) = e.file_type() {
-                            if file_type.is_dir() {
-                                return Some(1);
-                            }
+                        if let Ok(file_type) = e.file_type()
+                            && file_type.is_dir()
+                        {
+                            return Some(1);
                         }
                         None
                     }

--- a/crates/lib/src/api/client/workspaces/data_frames/columns.rs
+++ b/crates/lib/src/api/client/workspaces/data_frames/columns.rs
@@ -326,14 +326,12 @@ mod tests {
                 .iter()
                 .enumerate()
                 .find(|(_index, field)| field.name == column.name)
-            {
-                if <std::option::Option<Changes> as Clone>::clone(&field.changes)
+                && <std::option::Option<Changes> as Clone>::clone(&field.changes)
                     .unwrap()
                     .status
                     != "deleted"
-                {
-                    panic!("Column {} still exists in the data frame", column.name);
-                }
+            {
+                panic!("Column {} still exists in the data frame", column.name);
             }
 
             Ok(remote_repo)

--- a/crates/lib/src/repositories/add.rs
+++ b/crates/lib/src/repositories/add.rs
@@ -476,7 +476,7 @@ A: Oxen.ai
                 status
                     .untracked_dirs
                     .iter()
-                    .any(|(path, _)| *path == PathBuf::from("empty_dir"))
+                    .any(|(path, _)| *path == Path::new("empty_dir"))
             );
 
             // Add the empty dir

--- a/crates/lib/src/repositories/checkout.rs
+++ b/crates/lib/src/repositories/checkout.rs
@@ -1482,7 +1482,7 @@ mod tests {
 
             // -- Simulate user manually replacing "data/" dir with a file --
             std::fs::remove_dir_all(&dir)?;
-            util::fs::write_to_path(&repo.path.join("data"), "I am a plain file, not a dir")?;
+            util::fs::write_to_path(repo.path.join("data"), "I am a plain file, not a dir")?;
 
             // Sanity: "data" is now a regular file on disk
             let data_path = repo.path.join("data");

--- a/crates/lib/src/repositories/commits.rs
+++ b/crates/lib/src/repositories/commits.rs
@@ -1044,7 +1044,7 @@ mod tests {
                 status
                     .untracked_dirs
                     .iter()
-                    .any(|(path, _)| *path == PathBuf::from("empty_dir"))
+                    .any(|(path, _)| *path == Path::new("empty_dir"))
             );
 
             // Add the empty dir
@@ -1224,7 +1224,7 @@ A: Oxen.ai
             let head_commit = repositories::commits::head_commit(&repo)?;
             assert_eq!(head_commit.id, commit_e.id);
 
-            let expected_commits = vec![commit_e.clone(), commit_c.clone(), commit_a.clone()];
+            let expected_commits = [commit_e.clone(), commit_c.clone(), commit_a.clone()];
 
             let pagination_opts = PaginateOpts::default();
             let paginated_result = repositories::commits::list_by_path_from_paginated(

--- a/crates/lib/src/repositories/remote_mode/add.rs
+++ b/crates/lib/src/repositories/remote_mode/add.rs
@@ -36,7 +36,7 @@ mod tests {
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
                 let directory = ".".to_string();
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -114,7 +114,7 @@ mod tests {
 
                 // Get status, should show staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -168,7 +168,7 @@ mod tests {
 
                 // Get status, should show staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -216,7 +216,7 @@ mod tests {
 
                 // Status displays only the untracked file and dirs
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let directory = String::from(".");
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
@@ -246,7 +246,7 @@ mod tests {
 
                 // Status displays only the staged file and dirs
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -280,7 +280,7 @@ mod tests {
 
                 // Status now displays the modified as well as the staged entries
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -313,7 +313,7 @@ mod tests {
 
                 // Status again displays only the staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -366,7 +366,7 @@ mod tests {
 
                 // Get status, should show untracked files
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -454,7 +454,7 @@ mod tests {
 
                 // Status should now show the files as staged
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -505,7 +505,7 @@ mod tests {
 
                 // Verify new paths were added
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -573,7 +573,7 @@ mod tests {
 
                 // Check status for all staged files
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -643,7 +643,7 @@ mod tests {
 
                 // Verify repo is still clean
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,

--- a/crates/lib/src/repositories/remote_mode/commit.rs
+++ b/crates/lib/src/repositories/remote_mode/commit.rs
@@ -96,7 +96,7 @@ mod tests {
 
                 // Verify repo is clean
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -163,8 +163,9 @@ mod tests {
                     )
                     .await?;
 
-                    let status_opts =
-                        StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    let status_opts = StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(
+                        &cloned_repo.path,
+                    ));
                     let status = repositories::remote_mode::status(
                         &cloned_repo,
                         &remote_repo,
@@ -240,7 +241,7 @@ mod tests {
                 let annotations_dir = PathBuf::from("annotations");
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[annotations_dir.clone()],
+                    std::slice::from_ref(&annotations_dir),
                     &head_commit.id,
                 )
                 .await?;
@@ -249,7 +250,7 @@ mod tests {
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
                 let directory = ".".to_string();
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,

--- a/crates/lib/src/repositories/remote_mode/restore.rs
+++ b/crates/lib/src/repositories/remote_mode/restore.rs
@@ -81,7 +81,7 @@ mod tests {
                 let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[readme_path.clone()],
+                    std::slice::from_ref(&readme_path),
                     &head_commit.id,
                 )
                 .await?;
@@ -130,7 +130,7 @@ mod tests {
                 let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[full_path.clone()],
+                    std::slice::from_ref(&full_path),
                     &head_commit.id,
                 )
                 .await?;
@@ -180,7 +180,7 @@ mod tests {
                     let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                     repositories::remote_mode::restore(
                         &cloned_repo,
-                        &[file_path.clone()],
+                        std::slice::from_ref(&file_path),
                         &head_commit.id,
                     )
                     .await?;
@@ -240,12 +240,13 @@ mod tests {
                 let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[annotations_path.clone()],
+                    std::slice::from_ref(&annotations_path),
                     &head_commit.id,
                 )
                 .await?;
 
-                let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path.clone()]);
+                let status_opts =
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&repo_path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,

--- a/crates/lib/src/repositories/remote_mode/rm.rs
+++ b/crates/lib/src/repositories/remote_mode/rm.rs
@@ -35,7 +35,7 @@ mod tests {
                 let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[file_path.clone()],
+                    std::slice::from_ref(&file_path),
                     &head_commit.id,
                 )
                 .await?;
@@ -53,7 +53,7 @@ mod tests {
 
                 // Get status, should show staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -104,7 +104,7 @@ mod tests {
 
                 // Get status, should show staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -157,7 +157,7 @@ mod tests {
 
                 // Get status, should show staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -209,7 +209,7 @@ mod tests {
 
                 // Get status, should show staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -299,7 +299,7 @@ mod tests {
 
                 // Check status to confirm it's staged
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -407,7 +407,7 @@ mod tests {
 
                 // Check status: only one file should be staged for removal
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -485,7 +485,7 @@ mod tests {
 
                 // Check status to verify files are staged for removal
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -555,7 +555,7 @@ mod tests {
 
                 // Check status to verify files are staged for removal
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,

--- a/crates/lib/src/repositories/remote_mode/status.rs
+++ b/crates/lib/src/repositories/remote_mode/status.rs
@@ -172,7 +172,8 @@ mod tests {
                 let repo_path = cloned_repo.path.clone();
 
                 let directory = ".".to_string();
-                let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path.clone()]);
+                let status_opts =
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&repo_path));
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
@@ -197,19 +198,19 @@ mod tests {
                 let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[one_shot_path.clone()],
+                    std::slice::from_ref(&one_shot_path),
                     &head_commit.id,
                 )
                 .await?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[two_shot_path.clone()],
+                    std::slice::from_ref(&two_shot_path),
                     &head_commit.id,
                 )
                 .await?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[bounding_box_path.clone()],
+                    std::slice::from_ref(&bounding_box_path),
                     &head_commit.id,
                 )
                 .await?;
@@ -241,7 +242,8 @@ mod tests {
 
                 // Check status for corresponding changes
                 let directory = ".".to_string();
-                let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path.clone()]);
+                let status_opts =
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&repo_path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -275,7 +277,8 @@ mod tests {
 
                 // Re-check status
                 let directory = ".".to_string();
-                let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path.clone()]);
+                let status_opts =
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&repo_path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
@@ -334,7 +337,7 @@ mod tests {
                 util::fs::rename(&og_file, &new_file)?;
 
                 // Status before adding should show 4 unsynced files (README.md,  LICENSE, prompts.jsonl, labels.txt) and an untracked file
-                let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path.clone()]);
+                let status_opts = StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&repo_path));
                 let status = repositories::remote_mode::status(&cloned_repo, &remote_repo, &workspace_identifier, &directory, &status_opts).await?;
                 status.print();
                 assert_eq!(status.moved_files.len(), 0);
@@ -343,7 +346,7 @@ mod tests {
 
                 // Remove the previous file
                 api::client::workspaces::files::rm_files(&cloned_repo, &remote_repo, &workspace_identifier, vec![og_basename.clone()]).await?;
-                let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path.clone()]);
+                let status_opts = StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&repo_path));
                 let status = repositories::remote_mode::status(&cloned_repo, &remote_repo, &workspace_identifier, &directory, &status_opts).await?;
                 status.print();
                 assert_eq!(status.moved_files.len(), 0);

--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -790,12 +790,11 @@ mod tests {
         let derived_data = b"fake resized image bytes for hash bbbbbbbbbbbbbbbb";
 
         // Should not exist before store
-        assert_eq!(
-            store
+        assert!(
+            !store
                 .derived_version_exists(orig_hash, derived_filename)
                 .await
-                .unwrap(),
-            false
+                .unwrap()
         );
 
         // Store and check again
@@ -803,12 +802,11 @@ mod tests {
             .store_version_derived(orig_hash, derived_filename, derived_data)
             .await
             .unwrap();
-        assert_eq!(
+        assert!(
             store
                 .derived_version_exists(orig_hash, derived_filename)
                 .await
-                .unwrap(),
-            true
+                .unwrap()
         );
     }
 }

--- a/crates/server/src/helpers.rs
+++ b/crates/server/src/helpers.rs
@@ -89,7 +89,6 @@ mod tests {
         let values: Vec<&str> = response
             .headers()
             .get_all(header::ACCESS_CONTROL_EXPOSE_HEADERS)
-            .into_iter()
             .map(|value| value.to_str().unwrap())
             .collect();
 

--- a/data/test/config/user_config.toml
+++ b/data/test/config/user_config.toml
@@ -1,2 +1,2 @@
-name = "Ox"
+name = "ox"
 email = "ox@oxen.ai"


### PR DESCRIPTION
Makes the pre-commit hooks for `cargo clippy` run on all targets: crates, tests,
and benchmarking code are all included now.

Applies all suggestions from `cargo clippy` on the rest of the codebase.

Also makes the test user config have the same name that bin/test-rust produces.