### PR TITLE
Fix nested directory bug in rm

### DIFF
--- a/crates/lib/src/core/v_latest/rm.rs
+++ b/crates/lib/src/core/v_latest/rm.rs
@@ -727,10 +727,16 @@ fn r_process_remove_dir(
     match &node.node {
         // if node is a Directory, stage it for removal
         EMerkleTreeNode::Directory(_) => {
-            // node has the correct relative path to the dir, so no need for updates
+            // Update the dir node name to the full relative path so that
+            // split_into_vnodes and cleanup_rm_dirs can match it against
+            // existing children (which use full relative paths).
+            let mut updated_node = node.clone();
+            if let EMerkleTreeNode::Directory(ref mut dir_node) = updated_node.node {
+                dir_node.set_name(path.to_str().unwrap());
+            }
             let staged_entry = StagedMerkleTreeNode {
                 status: StagedEntryStatus::Removed,
-                node: node.clone(),
+                node: updated_node,
             };
 
             // Write removed node to staged db

--- a/crates/lib/src/repositories/rm.rs
+++ b/crates/lib/src/repositories/rm.rs
@@ -1146,4 +1146,136 @@ mod tests {
         })
         .await
     }
+
+    /// Regression: `oxen rm -r` on a nested directory that was already deleted
+    /// from disk should stage the removal and commit it successfully.
+    ///
+    /// mkdir -p 1/2/3 && echo content > 1/2/3/file.txt
+    /// oxen add . && oxen commit -m "init"
+    /// rm -rf 1/2/3
+    /// oxen rm -r 1/2/3
+    /// oxen commit -m "remove dir"
+    /// oxen status   # should be clean
+    #[tokio::test]
+    async fn test_rm_r_already_deleted_nested_dir() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            // Create nested directory with a file
+            let nested_dir = repo.path.join("1/2/3");
+            std::fs::create_dir_all(&nested_dir)?;
+            let file_path = nested_dir.join("file.txt");
+            util::fs::write(&file_path, "content")?;
+
+            // Add and commit
+            repositories::add(&repo, &repo.path).await?;
+            repositories::commit(&repo, "init")?;
+
+            // Physically delete the directory (simulating `rm -rf 1/2/3`)
+            util::fs::remove_dir_all(&nested_dir)?;
+            assert!(!nested_dir.exists());
+
+            // oxen rm -r 1/2/3 — stage the removal
+            let rm_opts = RmOpts {
+                path: PathBuf::from("1/2/3"),
+                recursive: true,
+                staged: false,
+            };
+            repositories::rm(&repo, &rm_opts)?;
+
+            // Should have staged the file for removal
+            let status = repositories::status(&repo)?;
+            let has_staged_removal = status
+                .staged_files
+                .iter()
+                .any(|(_, entry)| entry.status == StagedEntryStatus::Removed);
+            assert!(has_staged_removal, "file should be staged for removal");
+
+            // Commit the removal
+            repositories::commit(&repo, "remove dir")?;
+
+            // Status should be clean — no removed files
+            let status = repositories::status(&repo)?;
+            assert!(
+                status.removed_files.is_empty(),
+                "status should be clean after committing removal, but got removed_files: {:?}",
+                status.removed_files
+            );
+            assert!(
+                status.staged_files.is_empty(),
+                "no staged files should remain"
+            );
+
+            // Verify the directory is gone from the committed tree
+            let head = repositories::commits::head_commit(&repo)?;
+            let dir_node = repositories::tree::get_dir_without_children(
+                &repo,
+                &head,
+                Path::new("1/2/3"),
+                None,
+            )?;
+            assert!(
+                dir_node.is_none(),
+                "directory 1/2/3 should not exist in the committed tree"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    /// Regression: `oxen add .` should detect and stage a nested directory
+    /// that was physically deleted from disk.
+    ///
+    /// mkdir -p 1/2/3 && echo content > 1/2/3/file.txt
+    /// oxen add . && oxen commit -m "init"
+    /// rm -rf 1/2/3
+    /// oxen add .
+    /// oxen commit -m "remove dir"
+    /// oxen status   # should be clean
+    #[tokio::test]
+    async fn test_add_dot_stages_deleted_nested_dir() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            // Create nested directory with a file
+            let nested_dir = repo.path.join("1/2/3");
+            std::fs::create_dir_all(&nested_dir)?;
+            let file_path = nested_dir.join("file.txt");
+            util::fs::write(&file_path, "content")?;
+
+            // Add and commit
+            repositories::add(&repo, &repo.path).await?;
+            repositories::commit(&repo, "init")?;
+
+            // Physically delete only the leaf directory (1/ and 1/2/ remain)
+            util::fs::remove_dir_all(&nested_dir)?;
+            assert!(!nested_dir.exists());
+            assert!(repo.path.join("1/2").exists());
+
+            // oxen add . — should detect and stage the removal
+            repositories::add(&repo, &repo.path).await?;
+
+            // Should have staged the file for removal
+            let status = repositories::status(&repo)?;
+            let has_staged_removal = status
+                .staged_files
+                .iter()
+                .any(|(_, entry)| entry.status == StagedEntryStatus::Removed);
+            assert!(
+                has_staged_removal,
+                "file should be staged for removal after `oxen add .`"
+            );
+
+            // Commit the removal
+            repositories::commit(&repo, "remove dir")?;
+
+            // Status should be clean
+            let status = repositories::status(&repo)?;
+            assert!(
+                status.removed_files.is_empty(),
+                "status should be clean after committing removal, but got removed_files: {:?}",
+                status.removed_files
+            );
+
+            Ok(())
+        })
+        .await
+    }
 }

--- a/crates/lib/src/util/glob.rs
+++ b/crates/lib/src/util/glob.rs
@@ -417,17 +417,22 @@ pub fn r_collect_removed_paths(
     if dir_path.is_dir() {
         let glob_path = util::fs::path_relative_to_dir(dir_path, &repo_path)?.join("*");
 
-        // Search the merkle tree for all paths in the directory
-        search_merkle_tree(removed_paths, repo, &glob_path)?;
-        let paths = removed_paths.clone();
+        // Search the merkle tree for immediate children of this directory
+        let mut new_paths = HashSet::new();
+        search_merkle_tree(&mut new_paths, repo, &glob_path)?;
 
-        // Recurse into present directories to find removed subdirs and files
-        for path in paths.iter() {
-            if repo_path.join(path).is_dir() {
-                let dir_path = dir_path.join(path);
-                r_collect_removed_paths(repo, &dir_path, removed_paths)?;
+        // Recurse into child directories that still exist on disk to find
+        // removed entries deeper in the tree. Use repo_path.join(path) since
+        // paths returned by search_merkle_tree are full relative paths from
+        // the repo root (e.g., "1/2"), not just the child name.
+        for path in new_paths.iter() {
+            let full_path = repo_path.join(path);
+            if full_path.is_dir() {
+                r_collect_removed_paths(repo, &full_path, removed_paths)?;
             }
         }
+
+        removed_paths.extend(new_paths);
     }
 
     Ok(())


### PR DESCRIPTION
This PR Fixes a bug where nested directory removal was not being staged/track during a commit.

