### PR TITLE
Replace env_logger with tracing and add Prometheus metrics infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4572,6 +4572,7 @@ dependencies = [
  "log",
  "lru 0.14.0",
  "metrics",
+ "metrics-exporter-prometheus",
  "minus",
  "mockito",
  "mp4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,22 +380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -414,15 +399,6 @@ name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -2088,7 +2064,7 @@ version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -3022,29 +2998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream 1.0.0",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -4261,30 +4214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4547,7 +4476,6 @@ dependencies = [
  "dirs",
  "duckdb",
  "dunce",
- "env_logger",
  "fd-lock",
  "filetime",
  "flate2",
@@ -4572,7 +4500,6 @@ dependencies = [
  "log",
  "lru 0.14.0",
  "metrics",
- "metrics-exporter-prometheus",
  "minus",
  "mockito",
  "mp4",
@@ -5377,7 +5304,6 @@ version = "0.46.10"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
- "env_logger",
  "glob",
  "liboxen",
  "log",
@@ -5387,6 +5313,8 @@ dependencies = [
  "pyo3-polars",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-appender",
  "uuid",
 ]
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,53 @@ pre-commit install
 ```
 
 
+## Logging
+
+Oxen uses structured logging via the [`tracing`](https://docs.rs/tracing) crate. All log output goes to **stderr** by default in a human-readable format. This applies to the CLI (`oxen`), the server (`oxen-server`), and any code using `liboxen` (including the Python bindings).
+
+### Controlling Log Level
+
+Set the `RUST_LOG` environment variable to control verbosity.
+
+```bash
+# Show debug logs from the oxen library
+RUST_LOG=debug oxen push origin main
+
+# Show only warnings and errors
+RUST_LOG=warn oxen-server start
+
+# Fine-grained: debug for liboxen, warn for everything else
+RUST_LOG=warn,liboxen=debug oxen-server start
+```
+
+### File Logging with `OXEN_LOG_DIR`
+
+Set `OXEN_LOG_DIR` to enable file-based logging in addition to stderr. This env var is a directory where rotating log files are written. Log files are written as **newline-delimited JSON** (one JSON object per line), rotated daily. Each line includes the timestamp, level, target, thread ID, source file, and line number.
+
+```bash
+OXEN_LOG_DIR=./logs/ RUST_LOG=warn oxen clone https://hub.oxen.ai/ox/CatDogBBox
+OXEN_LOG_DIR=/var/log/oxen oxen-server start
+```
+
+Log files are named `{app_name}.{date}` (e.g. `oxen-server.2026-04-06`) inside the configured directory.
+
+To ingest these logs with standard tooling:
+
+- **Promtail / Grafana Loki** -- point a `file_sd` or static target at the log directory; Loki handles newline-delimited JSON natively.
+- **Filebeat / Elasticsearch** -- configure a `filebeat.inputs` entry with `type: filestream` and `parsers: [{ ndjson: {} }]`.
+- **Vector** -- use a `file` source with `decoding.codec = "json"`.
+- **`jq`** -- for ad-hoc inspection:
+
+```bash
+# Stream logs, filter for errors
+tail -f ~/.oxen/logs/oxen-server.2026-04-06 | jq 'select(.level == "ERROR")'
+```
+
+## Prometheus Metrics
+
+`oxen-server` exposes a Prometheus-compatible metrics endpoint.
+See [Prometheus Metrics](crates/server/README.md#prometheus-metrics) for details.
+
 ## Why build Oxen?
 
 Oxen was build by a team of machine learning engineers, who have spent countless hours in their careers managing datasets. We have used many different tools, but none of them were as easy to use and as ergonomic as we would like.

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -1,1 +1,31 @@
-../lib/README.md
+# oxen-cli
+The client for interacting with `oxen` repositories, both locally and remote.
+
+## Build
+
+See the [prerequisites](../../README.md#prerequisites) section of the main readme before developing.
+Use the standard `cargo ... --workspace` commands and `cargo ... -p oxen-cli` commands.
+
+## Run
+
+Initialize a new repository or clone an existing one:
+```bash
+oxen init
+oxen clone https://hub.oxen.ai/namespace/repository
+```
+
+This will create the `.oxen` dir in your current directory and allow you to run Oxen CLI commands:
+```bash
+oxen status
+oxen add images/
+oxen commit -m "added images"
+oxen push origin main
+```
+
+## Logging
+
+Oxen uses structured logging.
+It outputs to STDERR by default but can be configured with rotating log files.
+See [Logging](../../README.md#logging) for details.
+
+By default, the `oxen` CLI does not perform any logging. Set `RUST_LOG` to change.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,6 +7,7 @@ use crate::cmd::WorkspaceCmd;
 use clap::Command;
 use liboxen::model::LocalRepository;
 use liboxen::util;
+use tracing::level_filters::LevelFilter;
 // use env_logger::Env;
 
 pub mod cli_error;
@@ -44,7 +45,14 @@ fn main() -> ExitCode {
 }
 
 async fn async_main() -> ExitCode {
-    util::logging::init_logging();
+    // NOTE: if we fail to initialze logging, we do not crash here
+    let _tracing_guard = match util::telemetry::init_tracing("oxen", LevelFilter::OFF) {
+        Ok(guard) => guard,
+        Err(e) => {
+            eprintln!("[ERROR] Failed to initialize tracing for oxen:\n{e}");
+            None
+        }
+    };
 
     let cmds: Vec<Box<dyn cmd::RunCmd>> = vec![
         Box::new(cmd::AddCmd),

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -55,7 +55,6 @@ difference = { workspace = true }
 dirs = { workspace = true }
 duckdb = { workspace = true, optional = true }
 dunce = { workspace = true }
-env_logger = { workspace = true }
 fd-lock = { workspace = true }
 filetime = { workspace = true }
 flate2 = { workspace = true }

--- a/crates/lib/README.md
+++ b/crates/lib/README.md
@@ -179,9 +179,18 @@ Then run the server like this
 bacon server
 ```
 
+## Logging
+Oxen uses structured logging.
+It outputs to STDERR by default but can be configured with rotating log files.
+See [Logging](../../README.md#logging) for details.
+
+Only main applications can initialize logging and set log levels.
+
+## Prometheus Metrics
+`oxen-server` exposes a Prometheus-compatible metrics endpoint.
+See [Prometheus Metrics](../server/README.md#prometheus-metrics) for details.
 
 ## Nix Flake
-
 If you have [Nix installed](https://github.com/DeterminateSystems/nix-installer)
 you can use the flake to build and run the server. This will automatically
 install and configure the required build toolchain dependencies for Linux & macOS.

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Mutex;
 use tokio::time::sleep;
+use tracing::level_filters::LevelFilter;
 
 pub const DEFAULT_TEST_HOST: &str = "localhost:3000";
 
@@ -74,14 +75,25 @@ pub fn repo_remote_url_from(name: &str) -> String {
 
 static ENV_LOCK: LazyLock<Arc<Mutex<bool>>> = LazyLock::new(|| Arc::new(Mutex::new(false)));
 
-pub fn init_test_env() {
-    // check if logger is already initialized
-    util::logging::init_logging();
+/// Process-global owner of the tracing `WorkerGuard`. Stored here so the
+/// file-logging writer stays alive for the entire test run instead of being
+/// dropped at the end of the `init_test_env` call.
+static WORKER_GUARD: LazyLock<Mutex<Option<tracing_appender::non_blocking::WorkerGuard>>> =
+    LazyLock::new(|| Mutex::new(None));
 
+pub fn init_test_env() {
     match ENV_LOCK.lock() {
         Ok(mut logging_setup) => {
             if !*logging_setup {
-                util::logging::init_logging();
+                // fail fast if we can't initialize logging -- find the error in tests & fix!
+                let guard = util::telemetry::init_tracing("oxen-test", LevelFilter::ERROR)
+                    .expect("Failed to initialize tracing for test environment!");
+
+                // Store the guard globally so it outlives this block.
+                if let Ok(mut slot) = WORKER_GUARD.lock() {
+                    *slot = guard;
+                }
+
                 *logging_setup = true;
             }
 

--- a/crates/lib/src/util.rs
+++ b/crates/lib/src/util.rs
@@ -13,6 +13,7 @@ pub mod perf;
 pub mod progress_bar;
 pub mod read_progress;
 pub mod str;
+pub mod telemetry;
 
 pub use crate::util::read_progress::ReadProgress;
 pub use paginate::{paginate, paginate_with_total};

--- a/crates/lib/src/util/logging.rs
+++ b/crates/lib/src/util/logging.rs
@@ -1,6 +1,4 @@
-use env_logger::Env;
-use std::io::Write;
-
+/// Gets the name of the function that this macro is called from.
 #[macro_export]
 macro_rules! current_function {
     () => {{
@@ -13,63 +11,4 @@ macro_rules! current_function {
             .find(|&part| part != "f" && part != "{{closure}}")
             .expect("Failed to find function name")
     }};
-}
-
-pub fn init_logging() {
-    let mut builder = env_logger::Builder::new();
-    // ignore noisy http logs
-    builder.filter_module("h2", log::LevelFilter::Warn);
-    builder.filter_module("hyper_util", log::LevelFilter::Warn);
-    builder.filter_module("reqwest", log::LevelFilter::Warn);
-
-    builder.parse_env(Env::default());
-    match builder
-        .format(|buf, record| {
-            use crate::request_context::get_request_id;
-
-            // Split string on a character and take the last part
-            fn take_last(s: &str, c: char) -> &str {
-                s.split(c).next_back().unwrap_or("")
-            }
-
-            // Format the target to remove "liboxen::" prefix and replace "::" with "/"
-            fn format_target(target: &str) -> String {
-                target
-                    .strip_prefix("liboxen::")
-                    .unwrap_or(target)
-                    .rsplit_once("::")
-                    .map(|(path, _)| path.replace("::", "/"))
-                    .unwrap_or_else(|| target.replace("::", "/"))
-            }
-
-            let formatted_target = format_target(record.target());
-            let file_name = take_last(record.file().unwrap_or("unknown"), '/');
-            let line_number = record.line().unwrap_or(0);
-
-            // Add request ID if available
-            let request_id_str = if let Some(request_id) = get_request_id() {
-                format!(" [request_id={request_id}]")
-            } else {
-                String::new()
-            };
-
-            writeln!(
-                buf,
-                "[{}] {} - {}/{}:{}{}  {}",
-                record.level(),
-                chrono::Local::now().format("%Y-%m-%dT%H:%M:%S%.3f"),
-                formatted_target,
-                file_name,
-                line_number,
-                request_id_str,
-                record.args()
-            )
-        })
-        .try_init()
-    {
-        Ok(_) => (),
-        Err(_) => {
-            // We already initialized the logger in tests
-        }
-    }
 }

--- a/crates/lib/src/util/telemetry.rs
+++ b/crates/lib/src/util/telemetry.rs
@@ -1,0 +1,117 @@
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+use tracing::level_filters::LevelFilter;
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::{SubscriberInitExt, TryInitError};
+use tracing_subscriber::{EnvFilter, Layer, Registry};
+
+/// An error that can occur during logging or metrics initialization.
+#[derive(Debug, Error)]
+pub enum TelemetryError {
+    #[error("OXEN_LOG_DIR set but is empty, cannot enable JSON file logging.")]
+    EmptyLogDir,
+    #[error("Requested JSON file logging cannot be enabled because OXEN_LOG_DIR is a file: {0}")]
+    LogDirIsFile(PathBuf),
+    #[error("Failed to create log directory ({0}): {1}")]
+    CreateLogDir(PathBuf, std::io::Error),
+    #[error("Failed to initialize tracing: {0}")]
+    InitFail(#[from] TryInitError),
+}
+
+/// Initialize tracing with the `tracing-log` bridge.
+///
+/// **Stderr** (always): human-readable formatted output, like `env_logger`.
+///
+/// **File** (opt-in via `OXEN_LOG_DIR`): JSON-per-line output to a rolling
+/// daily log file. The env var accepts a directory path — rolling files are
+/// written there (e.g. `/var/log/oxen`).
+///
+/// Filter level is controlled by `RUST_LOG`. The filter applies to both stderr
+/// and file output.
+///
+/// Returns `Some(WorkerGuard)` when file logging is active. The caller
+/// **must** hold the guard in a named binding for the lifetime of the
+/// application — dropping it flushes the non-blocking writer. When file
+/// logging is not enabled, returns `None`.
+pub fn init_tracing(
+    app_name: &str,
+    default: LevelFilter,
+) -> Result<Option<WorkerGuard>, TelemetryError> {
+    let log_level = log_env_filter(default);
+
+    // Always: human-readable stderr output
+    let stderr_layer = tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_target(true);
+
+    let maybe_log_dir = match std::env::var("OXEN_LOG_DIR").ok() {
+        Some(log_dir) => {
+            let created_log_dir = create_log_dir(&log_dir)?;
+            Some(created_log_dir)
+        }
+        None => None,
+    };
+
+    let (maybe_json_layer, maybe_worker_guard) = if let Some(log_dir) = maybe_log_dir {
+        let (jl, wg) = json_file_logging(app_name, &log_dir);
+        (Some(jl), Some(wg))
+    } else {
+        (None, None)
+    };
+
+    // .try_init() also installs the tracing-log bridge (forwarding log::* calls into tracing)
+    // when the `tracing-log` feature is enabled.
+    tracing_subscriber::registry()
+        .with(maybe_json_layer)
+        .with(stderr_layer)
+        .with(log_level)
+        .try_init()?;
+
+    Ok(maybe_worker_guard)
+}
+
+/// Create an [`EnvFilter`] from `RUST_LOG`, falling back to the default log level if not set.
+fn log_env_filter(default: LevelFilter) -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::builder()
+            .with_default_directive(default.into())
+            .parse_lossy("")
+    })
+}
+
+/// Accepts the OXEN_LOG_DIR's value and ensures it is a valid directory.
+/// Returns None if it shouldn't be enabled. Panics on error!
+fn create_log_dir(oxen_log_dir: &str) -> Result<PathBuf, TelemetryError> {
+    let oxen_log_dir = oxen_log_dir.trim();
+    if oxen_log_dir.is_empty() {
+        Err(TelemetryError::EmptyLogDir)
+    } else {
+        let log_dir = PathBuf::from(oxen_log_dir);
+        if log_dir.is_file() {
+            Err(TelemetryError::LogDirIsFile(log_dir))
+        } else {
+            match std::fs::create_dir_all(&log_dir) {
+                Ok(()) => Ok(log_dir),
+                Err(e) => Err(TelemetryError::CreateLogDir(log_dir, e)),
+            }
+        }
+    }
+}
+
+/// Configure ND-JSON file logging with daily log rotation in the given log directory.
+fn json_file_logging(app_name: &str, log_dir: &Path) -> (impl Layer<Registry>, WorkerGuard) {
+    let file_appender = tracing_appender::rolling::daily(log_dir, app_name);
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+    let layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_writer(non_blocking)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_file(true)
+        .with_line_number(true);
+
+    (layer, guard)
+}

--- a/crates/oxen-py/Cargo.toml
+++ b/crates/oxen-py/Cargo.toml
@@ -15,7 +15,6 @@ name = "oxen_py" # The native extension module. Users still `import oxen` via th
 crate-type = ["cdylib"] # PyO3 needs this crate to be a cdylib so it can link against it.
 
 [dependencies]
-env_logger = { workspace = true }
 liboxen = { path = "../lib" }
 log = { workspace = true }
 pyo3 = { workspace = true }
@@ -23,6 +22,8 @@ pyo3-async-runtimes = { workspace = true }
 pyo3-polars = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
 uuid = { workspace = true }
 
 [build-dependencies]

--- a/crates/oxen-py/README.md
+++ b/crates/oxen-py/README.md
@@ -1,0 +1,11 @@
+# oxen-py
+
+Python bindings for `liboxen` generated with [pyO3](https://crates.io/crates/pyo3).
+
+Exclusively used by the `oxen` Python package that lives in [`oxen-python`](../../oxen-python).
+See [`oxen-python`'s README](../../oxen-python/README.md) for documentation.
+
+## Build
+
+See the [prerequisites](../../README.md#prerequisites) section of the main readme before developing.
+Use the standard `cargo ... --workspace` commands and `cargo ... -p oxen-py` commands.

--- a/crates/oxen-py/src/lib.rs
+++ b/crates/oxen-py/src/lib.rs
@@ -1,5 +1,14 @@
+use std::sync::{LazyLock, Mutex};
+
 use liboxen::config::RuntimeConfig;
 use pyo3::prelude::*;
+use tracing::level_filters::LevelFilter;
+use tracing_appender::non_blocking::WorkerGuard;
+
+/// Process-global owner of the tracing file-logging guard. Stored here so the
+/// tracing subscriber stays alive for the entire Python process instead of
+/// being dropped when `oxen_py()` returns.
+static TRACING_GUARD: LazyLock<Mutex<Option<WorkerGuard>>> = LazyLock::new(|| Mutex::new(None));
 
 pub mod auth;
 pub mod df_utils;
@@ -42,9 +51,22 @@ fn oxen_py(m: Bound<'_, PyModule>) -> PyResult<()> {
     builder.enable_all();
     pyo3_async_runtimes::tokio::init(builder);
 
-    // Initialize env_logger so that RUST_LOG is respected.
-    // We use env_logger instead of pyo3_log to avoid GIL deadlocks.
-    let _ = env_logger::try_init();
+    // Initialize tracing so that RUST_LOG is respected.
+    // We use tracing (via liboxen) instead of pyo3_log to avoid GIL deadlocks.
+    // The guard is stored in TRACING_GUARD so it outlives this function;
+    // dropping it would tear down the tracing subscriber.
+    if let Ok(mut slot) = TRACING_GUARD.lock()
+        && slot.is_none()
+    {
+        match liboxen::util::telemetry::init_tracing("oxen-py", LevelFilter::OFF) {
+            Ok(guard) => {
+                *slot = guard;
+            }
+            Err(e) => {
+                eprintln!("[ERROR] Failed to initialize tracing for oxen-py:\n{e}");
+            }
+        }
+    }
 
     m.add_class::<diff::py_tabular_diff::PyTabularDiff>()?;
     m.add_class::<diff::py_text_diff::PyChangeType>()?;

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -1,1 +1,167 @@
-../lib/README.md
+# oxen-server
+The server for remote `oxen` repositories.
+
+Remote repositories have the same internal structure as local ones, with the caveat that all the data is in the `.oxen/` dir and not duplicated into a "local workspace".
+
+**Notable configuration sections**:
+- [Prometheus Metrics](#prometheus-metrics)
+
+## Build
+
+See the [prerequisites](../../README.md#prerequisites) section of the main readme before developing.
+Use the standard `cargo ... --workspace` commands and `cargo ... -p oxen-server` commands.
+
+## Run
+
+To run a local Oxen Server, generate a config file and token to authenticate the user:
+```bash
+cargo run -p oxen-server add-user --email ox@oxen.ai --name Ox --output user_config.toml
+```
+
+Copy the config to the default locations:
+```bash
+mkdir ~/.oxen
+mv user_config.toml ~/.oxen/user_config.toml
+mkdir -p data/test/config/
+cp ~/.oxen/user_config.toml data/test/config/user_config.toml
+```
+
+Set where you want the data to be synced to.
+The default sync directory is `./data/`.
+To change, set the `SYNC_DIR` environment variable to a path:
+```bash
+export SYNC_DIR=/path/to/sync/dir
+```
+
+You can also create a `.env.local` file in the `crates/server/` directory which can contain the `SYNC_DIR` variable to avoid setting it every time you run the server.
+
+Server defaults to localhost 3000:
+```bash
+set SERVER 0.0.0.0:3000
+```
+
+You can grab your auth token from the config file above (`~/.oxen/user_config.toml`):
+```bash
+set TOKEN <YOUR_TOKEN>
+```
+
+Run the server:
+```bash
+cargo run -p oxen-server start
+```
+
+Or run the compiled binary directly:
+```bash
+./target/debug/oxen-server start
+```
+
+To run the server with live reload, use `bacon`:
+```bash
+cargo install --locked bacon
+```
+
+Then run the server like this:
+```bash
+bacon server
+```
+
+### API Examples
+
+#### List Repositories
+```bash
+curl -H "Authorization: Bearer $TOKEN" "http://0.0.0.0:3000/api/repos"
+```
+
+#### Create Repository
+```bash
+curl -H "Authorization: Bearer $TOKEN" -X POST -d '{"name": "MyRepo"}' "http://0.0.0.0:3000api/repos"
+```
+
+## Logging
+
+Oxen uses structured logging.
+It outputs to STDERR by default but can be configured with rotating log files.
+See [Logging](../../README.md#logging) for details.
+
+By default, `oxen-server` logs at the `WARN` level. Set `RUST_LOG` to change.
+
+## Prometheus Metrics
+
+`oxen-server` exposes a [Prometheus](https://prometheus.io/)-compatible
+metrics endpoint. This allows you to monitor server health, track request
+counts, error rates, and other operational metrics using standard Prometheus
+tooling.
+
+### How it works
+
+On startup, `oxen-server` launches a lightweight HTTP server (separate from
+the main API) that serves metrics in the Prometheus exposition format. Any
+counters, gauges, or histograms recorded via the [`metrics`](https://docs.rs/metrics)
+crate are automatically exposed.
+
+### Configuration
+
+The metrics endpoint is **enabled by default** on port **9090**.
+
+| Variable | Description | Default |
+|---|---|---|
+| `OXEN_METRICS_PORT` | Port for the metrics HTTP server | `9090` |
+| `OXEN_METRICS_PORT=off` | Disable the metrics endpoint entirely | -- |
+
+```bash
+# Use the default port (9090)
+cargo run -p oxen-server start
+
+# Use a custom port
+OXEN_METRICS_PORT=9100 cargo run -p oxen-server start
+
+# Disable metrics entirely
+OXEN_METRICS_PORT=off cargo run -p oxen-server start
+```
+
+### Verifying with `curl`
+
+```bash
+curl http://localhost:9090/metrics
+```
+
+This returns all registered metrics in Prometheus text format, e.g.:
+
+```
+# TYPE oxen_errors_total counter
+oxen_errors_total{module="commits",error="not_found"} 3
+```
+
+### Integrating with Prometheus
+
+Add a scrape target to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: oxen-server
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["localhost:9090"]
+```
+
+If you run multiple `oxen-server` instances, list each one (or use service
+discovery):
+
+```yaml
+scrape_configs:
+  - job_name: oxen-server
+    static_configs:
+      - targets:
+          - "oxen-1.internal:9090"
+          - "oxen-2.internal:9090"
+```
+
+### Integrating with Grafana
+
+Once Prometheus is scraping the endpoint, add it as a data source in
+[Grafana](https://grafana.com/) and build dashboards using PromQL queries.
+For example:
+
+```
+rate(oxen_errors_total[5m])
+```

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -21,12 +21,15 @@ pub mod services;
 #[cfg(test)]
 pub(crate) mod test;
 
+pub(crate) mod telemetry;
+
 extern crate log;
 extern crate lru;
 
 use actix_web::middleware::{Condition, DefaultHeaders, Logger};
 use actix_web::{App, HttpServer, web};
 use actix_web_httpauth::middleware::HttpAuthentication;
+use metrics_exporter_prometheus::BuildError;
 use thiserror::Error;
 
 use middleware::RequestIdMiddleware;
@@ -65,6 +68,7 @@ use liboxen::view::{
     ParseResourceResponse, RepositoryResponse, RepositoryView, RootCommitResponse, StatusMessage,
 };
 
+use tracing::level_filters::LevelFilter;
 use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 use utoipa_swagger_ui::SwaggerUi;
@@ -72,7 +76,11 @@ use utoipa_swagger_ui::SwaggerUi;
 use clap::{Parser, Subcommand};
 
 use std::env;
+use std::num::ParseIntError;
 use std::path::{Path, PathBuf};
+
+use crate::telemetry::MetricsGuard;
+use crate::telemetry::init_metrics_prometheus;
 
 const VERSION: &str = liboxen::constants::OXEN_VERSION;
 
@@ -348,16 +356,32 @@ enum ServerCommand {
     },
 }
 
+#[actix_web::main]
+async fn main() {
+    // fail-fast if we cannot initialize logging
+    let _tracing_guard = util::telemetry::init_tracing("oxen-server", LevelFilter::WARN)
+        .expect("Failed to initialize tracing & logging for oxen-server.");
+    // We want to show the error's display(), not the debug() representation.
+    // actix_web::main() will show the error's debug() representation.
+    if let Err(e) = server().await {
+        log::error!("{e}");
+    }
+}
+
 #[derive(Debug, Error)]
 enum ServerError {
     #[error("{0}")]
     Io(#[from] std::io::Error),
     #[error("{0}")]
     Oxen(#[from] OxenError),
+    #[error("Invalid OXEN_METRICS_PORT value: {0} (parsing error: {1})")]
+    InvalidPort(String, ParseIntError),
+    #[error("Failed to start Prometheus metrics server: {0}")]
+    Metrics(#[from] BuildError),
 }
 
-#[actix_web::main]
-async fn main() -> Result<(), ServerError> {
+/// The actual main oxen-server loop.
+async fn server() -> Result<(), ServerError> {
     dotenv().ok();
 
     match from_filename(Path::new("src").join("server").join("env.local")) {
@@ -365,7 +389,6 @@ async fn main() -> Result<(), ServerError> {
         Err(e) => log::debug!("Failed to load .env file: {e}"),
     }
 
-    util::logging::init_logging();
     util::perf::init_perf_logging();
 
     let sync_dir = match env::var("SYNC_DIR") {
@@ -375,6 +398,9 @@ async fn main() -> Result<(), ServerError> {
 
     match ServerCli::parse().command {
         ServerCommand::Start { ip, port, auth } => {
+            let _metrics_guard = init_metrics()?;
+
+            // KEEP as println! -- do not log!
             println!("🐂 v{VERSION}");
             println!("{SUPPORT}");
 
@@ -399,11 +425,48 @@ async fn main() -> Result<(), ServerError> {
         } => {
             log::debug!("Saving to sync dir: {sync_dir:?}");
             let token = add_user(&email, &name, output.as_path(), &sync_dir)?;
+            // KEEP as println! -- do not log!
             println!(
                 "User access token created:\n\n{token}\n\nTo give user access have them run the command `oxen config --auth <HOST> <TOKEN>`"
             );
             Ok(())
         }
+    }
+}
+
+/// Initialize the Prometheus metrics server on `OXEN_METRICS_PORT`, defaulting to port 9090.
+/// Returns `Ok(None)` if `OXEN_METRICS_PORT='off'`.
+///
+/// # Errors
+///   - `OXEN_METRICS_PORT` is set to a value that cannot be parsed as a `u16`
+///   - The port is already bound by another process
+///   - The Prometheus exporter fails to start
+///
+/// Callers should propagate or handle the returned error.
+fn init_metrics() -> Result<Option<MetricsGuard>, ServerError> {
+    let enable_metrics = match env::var("OXEN_METRICS_PORT").as_deref() {
+        Ok(val) if val.to_lowercase() == "off" => {
+            log::info!("Prometheus metrics disabled.");
+            None
+        }
+        Ok(val) => {
+            let port: u16 = val
+                .parse()
+                .map_err(|e| ServerError::InvalidPort(val.to_string(), e))?;
+            Some(port)
+        }
+        Err(_) => Some(9090),
+    };
+
+    if let Some(port) = enable_metrics {
+        let guard = init_metrics_prometheus(port)?;
+        log::info!(
+            "Prometheus metrics at http://0.0.0.0:{port}/metrics \
+             (set OXEN_METRICS_PORT to change, OXEN_METRICS_PORT='off' to disable)"
+        );
+        Ok(Some(guard))
+    } else {
+        Ok(None)
     }
 }
 
@@ -438,8 +501,12 @@ async fn start(
 
     let data = app_data::OxenAppData::new(PathBuf::from(sync_dir));
 
-    println!("Running on {host}:{port}");
-    println!("Syncing to directory: {}", sync_dir.display());
+    {
+        let running = format!("Running on {host}:{port}");
+        eprintln!("{running}");
+        log::info!("{running}");
+    }
+    log::info!("Syncing to directory: {}", sync_dir.display());
 
     HttpServer::new(move || {
         App::new()

--- a/crates/server/src/telemetry.rs
+++ b/crates/server/src/telemetry.rs
@@ -1,0 +1,55 @@
+use metrics_exporter_prometheus::{BuildError, PrometheusBuilder};
+
+/// Guard for the Prometheus metrics exporter. Dropping this aborts the
+/// background HTTP server that serves the `/metrics` endpoint.
+///
+/// Use `init_metrics_prometheus` to create an instance.
+pub(crate) struct MetricsGuard {
+    handle: tokio::task::JoinHandle<Result<(), String>>,
+}
+
+impl Drop for MetricsGuard {
+    /// Aborts the background HTTP server that serves the `/metrics` endpoint.
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+/// Install the Prometheus metrics exporter, listening on the given port.
+///
+/// Metrics are available at `http://0.0.0.0:{port}/metrics`.
+///
+/// Returns a [`MetricsGuard`] that keeps the exporter alive. The HTTP server
+/// is shut down when the guard is dropped. The HTTP server runs in its own Tokio
+/// background task.
+///
+/// # Errors
+///
+/// Returns an error if the port is already in use or if the Prometheus recorder
+/// or exporter cannot be initialized.
+pub(crate) fn init_metrics_prometheus(port: u16) -> Result<MetricsGuard, BuildError> {
+    // Verify the port is free before committing to the recorder and spawning
+    // the background task. The listener is dropped immediately so the exporter
+    // can bind to the same port.
+    std::net::TcpListener::bind(("0.0.0.0", port)).map_err(|_| {
+        BuildError::FailedToCreateHTTPListener(format!(
+            "Metrics port {port} is already in use. Change the port with OXEN_METRICS_PORT="
+        ))
+    })?;
+
+    let (prom_recorder, prom_exporter_fut) = PrometheusBuilder::new()
+        .with_http_listener(([0, 0, 0, 0], port))
+        .build()?;
+
+    metrics::set_global_recorder(prom_recorder)?;
+
+    let handle = tokio::spawn(async move {
+        prom_exporter_fut.await.map_err(|e| {
+            let msg = format!("{e:?}");
+            tracing::error!("Prometheus metrics exporter failed: {msg}");
+            msg
+        })
+    });
+
+    Ok(MetricsGuard { handle })
+}

--- a/oxen-python/README.md
+++ b/oxen-python/README.md
@@ -2,12 +2,12 @@
 
 The Oxen python interface makes it easy to integrate Oxen datasets directly into machine learning dataloaders or other data pipelines.
 
+
 ## Repositories
 
 There are two types of repositories one can interact with, a `Repo` and a `RemoteRepo`.
 
-
-## Local Repo
+### Local Repo
 
 To fully clone all the data to your local machine, you can use the `Repo` class.
 
@@ -36,7 +36,7 @@ repo.clone("https://hub.oxen.ai/ox/CatDogBBox")
 repo.checkout()
 ```
 
-## Remote Repo
+### Remote Repo
 
 If you don't want to download the data locally, you can use the `RemoteRepo` class to interact with a remote repository on OxenHub.
 
@@ -65,14 +65,7 @@ Note that no "push" command is required here, since the above code creates a com
 
 ## Build 🔨
 
-### Pre-Requistes
-
-If you're developing the Python interface, you'll need to:
-1. [Install the Rust toolchain](../README.md#build-)
-2. [Install `uv`](https://docs.astral.sh/uv/getting-started/installation/)
-3. Install the [pre-commit hooks](../README.md#pre-commit-hooks) to ensure your code is consistent
-
-### Development Cycle
+**See the [prerequisites](../../README.md#prerequisites) section of the main readme before developing.**
 
 To get and build dependencies, as well as the `oxen-python` code, run:
 ```bash
@@ -83,6 +76,7 @@ To build the PyO3 oxen wrappers only, use [`maturin`](https://github.com/PyO3/ma
 ```bash
 uv run --no-sync maturin develop
 ```
+
 
 ## Test
 
@@ -104,3 +98,12 @@ Format and lint code with:
 uvx ruff check .
 uvx ruff format .
 ```
+
+
+## Logging
+
+Oxen uses structured logging.
+It outputs to STDERR by default but can be configured with rotating log files.
+See [Logging](../../README.md#logging) for details.
+
+By default, the `oxen-python` does not perform any logging. Set `RUST_LOG` to change.


### PR DESCRIPTION
Create new `liboxen::util::telemetry::init_tracing()` to configure structured
logging with tracing crate. Enables support for file-based logging with new
`OXEN_LOG_DIR` env var: location of daily-rotated newline-delimited JSON logfiles.

Removes and replaces `env_logger` with this tracing crate based logging.

Add Prometheus metrics exporter to `oxen-server` (`OXEN_METRICS_PORT`):
  - `OXEN_METRICS_PORT` defaults to 9090, can set to another port value
  - `OXEN_METRICS_PORT="off"` means "no oxen metrics"
  - invalid value results in fail-fast
  - starting is all in `oxen_server::telemetry::init_metrics_prometheus()`
    + server does `OXEN_METRICS_PORT` logic in `init_metrics()`

README includes new documentation about `OXEN_LOG_DIR`. The server's README
includes documentation on `OXEN_METRICS_PORT` and how to `curl` the endpoint.

Re-wrote server's and client's README to be independent of liboxen's README.
Added minimal oxen-py README and updated oxen-python's README.