### PR TITLE
production compilation feature flag + CI OTel test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,8 @@ jobs:
     if: github.event.pull_request.draft != true
     name: Test Suite
     uses: ./.github/workflows/ci_test.yml
+
+  build-production:
+    if: github.event.pull_request.draft != true
+    name: Production Build
+    uses: ./.github/workflows/ci_build_production.yml

--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -1,4 +1,4 @@
-name: 🐂🏭 Continuous integration - Production Build
+name: 🐂🏭 Continuous integration - Production Build & Telemetry
 
 on:
   workflow_call:
@@ -9,7 +9,7 @@ defaults:
 
 jobs:
   build-production:
-    name: Build (production features)
+    name: Build & verify production features
     runs-on: ubuntu-latest
 
     steps:
@@ -32,11 +32,14 @@ jobs:
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.11"
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          # Only cache builds from main. Otherwise our caches will be too big and start to churn. (10 GB limit in GitHub Actions)
-          # Other branches will still use the cache but won't save it.
           save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: "."
 
@@ -46,5 +49,183 @@ jobs:
           sudo apt-get install -y clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev pkg-config
 
       - name: Build with production features
+        run: cargo build --workspace --features production
+
+      # ── Test 1: Log file writing (OXEN_LOG_DIR + NDJSON) ──────────────
+      - name: Test log file writing
         run: |
-          cargo build --workspace --features production
+          set -euo pipefail
+          OXEN="$GITHUB_WORKSPACE/target/debug/oxen"
+
+          mkdir -p /tmp/oxen-logs /tmp/test-logfile
+          cd /tmp/test-logfile
+          OXEN_LOG_DIR=/tmp/oxen-logs RUST_LOG=debug "$OXEN" init
+
+          LOG_FILE=$(ls /tmp/oxen-logs/oxen.* 2>/dev/null | head -1)
+          if [ -z "$LOG_FILE" ]; then
+            echo "FAIL: No log file created in /tmp/oxen-logs/"
+            ls -la /tmp/oxen-logs/
+            exit 1
+          fi
+
+          LINE_COUNT=$(wc -l < "$LOG_FILE")
+          if [ "$LINE_COUNT" -eq 0 ]; then
+            echo "FAIL: Log file is empty"
+            exit 1
+          fi
+
+          # Verify first line is valid JSON (NDJSON format)
+          if ! head -1 "$LOG_FILE" | jq . > /dev/null 2>&1; then
+            echo "FAIL: Log output is not valid JSON"
+            head -3 "$LOG_FILE"
+            exit 1
+          fi
+
+          echo "PASS: Log file writing works ($LINE_COUNT NDJSON lines in $LOG_FILE)"
+
+      # ── Test 2: FmtSpan events (OXEN_FMT_SPAN=CLOSE) ─────────────────
+      - name: Test FmtSpan span events
+        run: |
+          set -euo pipefail
+          SERVER="$GITHUB_WORKSPACE/target/debug/oxen-server"
+
+          # Start server with span-close events on stderr
+          mkdir -p "$GITHUB_WORKSPACE/data/test/config"
+          OXEN_FMT_SPAN=CLOSE RUST_LOG=info "$SERVER" start 2>/tmp/span-stderr.txt &
+          SERVER_PID=$!
+          sleep 2
+
+          # Hit an endpoint so TracingLogger creates (and closes) a span
+          curl -sf http://localhost:3000/api/health > /dev/null || true
+          sleep 1
+
+          kill "$SERVER_PID" 2>/dev/null || true
+          wait "$SERVER_PID" 2>/dev/null || true
+
+          # Span CLOSE events include "time.busy" / "time.idle"
+          if grep -q "time.busy" /tmp/span-stderr.txt; then
+            echo "PASS: FmtSpan CLOSE events detected"
+            grep "time.busy" /tmp/span-stderr.txt | head -3
+          else
+            echo "FAIL: No span close events found in stderr output"
+            echo "--- stderr output ---"
+            cat /tmp/span-stderr.txt
+            exit 1
+          fi
+
+      # ── Test 3: OTel telemetry (Jaeger + full push/pull workflow) ─────
+      - name: Test OTel telemetry with Jaeger
+        run: |
+          set -euo pipefail
+          OXEN="$GITHUB_WORKSPACE/target/debug/oxen"
+          SERVER="$GITHUB_WORKSPACE/target/debug/oxen-server"
+
+          # ── Start Jaeger all-in-one ──
+          docker run -d --name jaeger \
+            -p 4317:4317 -p 16686:16686 \
+            jaegertracing/all-in-one:latest
+
+          # Wait for Jaeger query API to be ready
+          echo "Waiting for Jaeger..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:16686/api/services > /dev/null 2>&1; then
+              echo "Jaeger is ready"
+              break
+            fi
+            sleep 1
+          done
+
+          # ── Setup oxen-server ──
+          cd "$GITHUB_WORKSPACE"
+          mkdir -p data/test/config ~/.oxen
+
+          ADD_USER_OUTPUT=$("$SERVER" add-user \
+            --email ci@test.com --name CI --output /tmp/ci-user.toml)
+
+          cp /tmp/ci-user.toml ~/.oxen/user_config.toml
+          cp /tmp/ci-user.toml data/test/config/user_config.toml
+
+          # Token is on the 3rd line of the add-user output
+          TOKEN=$(echo "$ADD_USER_OUTPUT" | sed -n '3p' | tr -d '[:space:]')
+          echo "Auth token: ${TOKEN:0:8}..."
+
+          # Configure CLI identity and auth
+          "$OXEN" config --name "CI Test" --email "ci@test.com"
+          "$OXEN" config --auth localhost:3000 "$TOKEN"
+
+          # ── Start oxen-server with OTel export ──
+          OXEN_OTEL_ENDPOINT=http://localhost:4317 \
+          RUST_LOG=info \
+          "$SERVER" start &
+          SERVER_PID=$!
+          sleep 3
+
+          # ── Full push / clone / modify / push / pull workflow ──
+
+          # Create remote repository (namespace "ox", name "otel-test")
+          curl -sf -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -X POST -d '{"namespace":"ox","name":"otel-test"}' \
+            http://localhost:3000/api/repos
+
+          # Repo A: init, commit, push
+          mkdir -p /tmp/repo-a && cd /tmp/repo-a
+          "$OXEN" init
+          "$OXEN" config --set-remote origin http://localhost:3000/ox/otel-test
+          echo "hello from CI" > test-file.txt
+          "$OXEN" add test-file.txt
+          "$OXEN" commit -m "initial commit"
+          "$OXEN" push origin main
+
+          # Clone to Repo B
+          cd /tmp
+          "$OXEN" clone http://localhost:3000/ox/otel-test /tmp/repo-b
+
+          # Repo B: modify, commit, push
+          cd /tmp/repo-b
+          echo "modified in repo-b" >> test-file.txt
+          "$OXEN" add test-file.txt
+          "$OXEN" commit -m "modify from repo-b"
+          "$OXEN" push origin main
+
+          # Repo A: pull (with client-side OTel too)
+          cd /tmp/repo-a
+          OXEN_OTEL_ENDPOINT=http://localhost:4317 \
+          RUST_LOG=info \
+          "$OXEN" pull
+
+          # Wait for OTel batch exporter to flush
+          sleep 10
+
+          # ── Verify traces in Jaeger ──
+
+          SERVICES=$(curl -sf http://localhost:16686/api/services)
+          echo "Jaeger services: $SERVICES"
+
+          if ! echo "$SERVICES" | jq -e '.data | index("oxen-server")' > /dev/null 2>&1; then
+            echo "FAIL: 'oxen-server' not found in Jaeger services"
+            exit 1
+          fi
+          echo "PASS: oxen-server service registered in Jaeger"
+
+          TRACES=$(curl -sf "http://localhost:16686/api/traces?service=oxen-server&limit=5")
+          TRACE_COUNT=$(echo "$TRACES" | jq '.data | length')
+
+          if [ "$TRACE_COUNT" -gt 0 ]; then
+            echo "PASS: OTel traces exported to Jaeger ($TRACE_COUNT traces)"
+          else
+            echo "FAIL: No traces found for oxen-server"
+            exit 1
+          fi
+
+          # Check for client traces too
+          if echo "$SERVICES" | jq -e '.data | index("oxen")' > /dev/null 2>&1; then
+            echo "PASS: oxen client traces also found in Jaeger"
+          else
+            echo "INFO: oxen client traces not found (client OTel export may not have flushed)"
+          fi
+
+          # ── Cleanup ──
+          kill "$SERVER_PID" 2>/dev/null || true
+          docker stop jaeger 2>/dev/null || true
+          docker rm jaeger 2>/dev/null || true

--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -40,6 +40,11 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: "."
 
+      - name: Install FFmpeg dev libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev pkg-config
+
       - name: Build with production features
         run: |
           cargo build --workspace --features production

--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -121,10 +121,6 @@ jobs:
           SERVER="$GITHUB_WORKSPACE/target/debug/oxen-server"
 
           # ── Start Jaeger all-in-one ──
-          docker run -d --name jaeger \
-            -p 4317:4317 -p 16686:16686 \
-            jaegertracing/all-in-one:latest
-
           docker run --rm --name jaeger \
             -p 16686:16686 \
             -p 4317:4317 \

--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -125,9 +125,17 @@ jobs:
             -p 4317:4317 -p 16686:16686 \
             jaegertracing/all-in-one:latest
 
+          docker run --rm --name jaeger \
+            -p 16686:16686 \
+            -p 4317:4317 \
+            -p 4318:4318 \
+            -p 5778:5778 \
+            -p 9411:9411 \
+            cr.jaegertracing.io/jaegertracing/jaeger:2.17.0
+
           # Wait for Jaeger query API to be ready
           echo "Waiting for Jaeger..."
-          for i in $(seq 1 30); do
+          for i in $(seq 1 60); do
             if curl -sf http://localhost:16686/api/services > /dev/null 2>&1; then
               echo "Jaeger is ready"
               break
@@ -159,6 +167,8 @@ jobs:
           "$SERVER" start &
           SERVER_PID=$!
           sleep 3
+
+          # TODO: add server health check
 
           # ── Full push / clone / modify / push / pull workflow ──
 
@@ -202,9 +212,11 @@ jobs:
           SERVICES=$(curl -sf http://localhost:16686/api/services)
           echo "Jaeger services: $SERVICES"
 
+          local did_fail=false
+
           if ! echo "$SERVICES" | jq -e '.data | index("oxen-server")' > /dev/null 2>&1; then
             echo "FAIL: 'oxen-server' not found in Jaeger services"
-            exit 1
+            did_fail=true
           fi
           echo "PASS: oxen-server service registered in Jaeger"
 
@@ -215,15 +227,21 @@ jobs:
             echo "PASS: OTel traces exported to Jaeger ($TRACE_COUNT traces)"
           else
             echo "FAIL: No traces found for oxen-server"
-            exit 1
+            did_fail=true
           fi
 
           # Check for client traces too
           if echo "$SERVICES" | jq -e '.data | index("oxen")' > /dev/null 2>&1; then
             echo "PASS: oxen client traces also found in Jaeger"
           else
-            echo "INFO: oxen client traces not found (client OTel export may not have flushed)"
+            echo "FAIL: oxen client traces not found (client OTel export may not have flushed)"
+            did_fail=true
           fi
+
+          if [ "$did_fail" = true ]; then
+            exit 1
+          fi
+
 
           # ── Cleanup ──
           kill "$SERVER_PID" 2>/dev/null || true

--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -177,9 +177,9 @@ jobs:
           "$OXEN" commit -m "initial commit"
           "$OXEN" push origin main
 
-          # Clone to Repo B
+          # Clone to Repo B (oxen clone rejects absolute paths)
           cd /tmp
-          "$OXEN" clone http://localhost:3000/ox/otel-test /tmp/repo-b
+          "$OXEN" clone http://localhost:3000/ox/otel-test repo-b
 
           # Repo B: modify, commit, push
           cd /tmp/repo-b

--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -1,0 +1,45 @@
+name: 🐂🏭 Continuous integration - Production Build
+
+on:
+  workflow_call:
+
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
+jobs:
+  build-production:
+    name: Build (production features)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Free up disk space
+        run: |
+          echo "=== Before cleanup ==="
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo apt-get clean
+          echo "=== After cleanup ==="
+          df -h
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Only cache builds from main. Otherwise our caches will be too big and start to churn. (10 GB limit in GitHub Actions)
+          # Other branches will still use the cache but won't save it.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: "."
+
+      - name: Build with production features
+        run: |
+          cargo build --workspace --features production

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,6 +2268,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,6 +3852,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4500,11 +4525,13 @@ dependencies = [
  "log",
  "lru 0.14.0",
  "metrics",
- "metrics-exporter-prometheus",
  "minus",
  "mockito",
  "mp4",
  "num_cpus",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "os_path",
  "par-stream",
  "parking_lot",
@@ -4544,7 +4571,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-appender",
- "tracing-log",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "urlencoding",
@@ -5001,6 +5028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutually_exclusive_features"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94e1e6445d314f972ff7395df2de295fe51b71821694f0b0e1e79c4f12c8577"
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5252,6 +5285,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.12.28",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "base64",
+ "const-hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "serde_json",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5292,9 +5406,6 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "tracing-appender",
- "tracing-log",
- "tracing-subscriber",
  "url",
  "uuid",
 ]
@@ -5358,9 +5469,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-appender",
- "tracing-log",
- "tracing-subscriber",
+ "tracing-actix-web",
  "url",
  "utoipa",
  "utoipa-swagger-ui",
@@ -6290,6 +6399,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6664,6 +6811,15 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -8498,6 +8654,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8505,11 +8698,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.13.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -8557,6 +8754,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-actix-web"
+version = "0.7.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca6b15407f9bfcb35f82d0e79e603e1629ece4e91cc6d9e58f890c184dd20af"
+dependencies = [
+ "actix-web",
+ "mutually_exclusive_features",
+ "pin-project",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -8611,6 +8821,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -8675,6 +8901,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,9 @@ minus = { version = "5.4.0", features = ["static_output", "search"] }
 mockito = "1.1.0"
 mp4 = "0.14.0"
 num_cpus = "1.16.0"
+opentelemetry = "0.31"
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "http-json", "trace"] }
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 os_path = "0.8.0"
 par-stream = { version = "0.10.2", features = ["runtime-tokio"] }
 parking_lot = "0.12.1"
@@ -140,8 +143,10 @@ tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.8", features = ["compat"] }
 toml = "0.8.19"
 tracing = "0.1"
+tracing-actix-web = "0.7"
 tracing-appender = "0.2"
 tracing-log = "0.2"
+tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "registry"] }
 url = "2.4.1"
 urlencoding = "2.1.3"

--- a/README.md
+++ b/README.md
@@ -202,6 +202,20 @@ Install `Oxen`'s pre-commit hooks locally using:
 pre-commit install
 ```
 
+### Production Release Build
+
+For deployment, build with the `production` feature flag and `--release`:
+
+```bash
+cargo build --workspace --release --features production
+```
+
+This enables:
+- **OpenTelemetry tracing** (`otel`) -- export spans to any OTLP-compatible collector (Jaeger, Tempo, Datadog, etc.). See [OpenTelemetry Tracing](crates/server/README.md#opentelemetry-tracing) for runtime configuration.
+- **FFmpeg thumbnails** (`ffmpeg`) -- generate video/image thumbnails via FFmpeg (requires FFmpeg libraries installed on the host).
+- **Performance logging** (`perf-logging`) -- additional timing instrumentation for internal operations.
+
+Without `--features production`, the default build excludes OTel dependencies and FFmpeg support, keeping the binary smaller for local development.
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,17 @@ tail -f ~/.oxen/logs/oxen-server.2026-04-06 | jq 'select(.level == "ERROR")'
 `oxen-server` exposes a Prometheus-compatible metrics endpoint.
 See [Prometheus Metrics](crates/server/README.md#prometheus-metrics) for details.
 
+## OpenTelemetry Tracing
+
+`oxen-server` can export tracing spans to any OTLP-compatible collector (Jaeger, Tempo, etc.).
+Requires building with the `otel` feature flag.
+See [OpenTelemetry Tracing](crates/server/README.md#opentelemetry-tracing) for details.
+
+## FmtSpan Events
+
+Span lifecycle events can be emitted as log lines on stderr for lightweight tracing.
+See [FmtSpan Events](crates/server/README.md#fmtspan-events) for details.
+
 ## Why build Oxen?
 
 Oxen was build by a team of machine learning engineers, who have spent countless hours in their careers managing datasets. We have used many different tools, but none of them were as easy to use and as ergonomic as we would like.

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -35,8 +35,5 @@ tempfile = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-tracing-appender = { workspace = true }
-tracing-log = { workspace = true }
-tracing-subscriber = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,6 +19,11 @@ categories = [
 name = "oxen"
 path = "src/main.rs"
 
+[features]
+default = []
+otel = ["liboxen/otel"]
+production = ["otel", "default"]
+
 [dependencies]
 async-trait = { workspace = true }
 bytesize = { workspace = true }

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -29,3 +29,57 @@ It outputs to STDERR by default but can be configured with rotating log files.
 See [Logging](../../README.md#logging) for details.
 
 By default, the `oxen` CLI does not perform any logging. Set `RUST_LOG` to change.
+
+## OpenTelemetry Tracing
+
+The `oxen` CLI can export tracing spans to any OTLP-compatible collector
+(Jaeger, Tempo, etc.). This requires building with the `otel` feature flag:
+
+```bash
+cargo build -p oxen-cli --features otel
+```
+
+At runtime, set **both** `OXEN_OTEL_ENDPOINT` and `RUST_LOG=info`:
+
+```bash
+OXEN_OTEL_ENDPOINT=http://localhost:4317 RUST_LOG=info oxen pull
+```
+
+### Why `RUST_LOG=info` is required
+
+The CLI defaults to `LevelFilter::OFF` when `RUST_LOG` is not set. The
+`RUST_LOG` filter is global — it gates what reaches **all** tracing outputs,
+including the OpenTelemetry exporter. Since `#[tracing::instrument]` creates
+spans at `INFO` level, they are silently dropped before the OTel layer ever
+sees them unless the filter is at `INFO` or below.
+
+Setting `OXEN_OTEL_ENDPOINT` alone is not enough — you must also set
+`RUST_LOG=info` (or more targeted, e.g. `RUST_LOG=liboxen=info`) for spans
+to be exported.
+
+| Variable | Description | Default |
+|---|---|---|
+| `OXEN_OTEL_ENDPOINT` | Collector endpoint URL. Absent = disabled. | *(none)* |
+| `OXEN_OTEL_PROTOCOL` | Transport: `grpc` or `http` | `grpc` |
+| `RUST_LOG` | Must include `info` level for spans to be exported | `off` |
+
+### Quick start with Jaeger
+
+```bash
+# Start Jaeger all-in-one: https://www.jaegertracing.io/docs/2.17/
+docker run --rm --name jaeger \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -p 5778:5778 \
+  -p 9411:9411 \
+  cr.jaegertracing.io/jaegertracing/jaeger:2.17.0
+
+# Run a pull with tracing enabled
+OXEN_OTEL_ENDPOINT=http://localhost:4317 RUST_LOG=info cargo run --features otel -p oxen-cli pull
+
+# View traces at http://localhost:16686 under service "oxen"
+```
+
+When the `otel` feature is not compiled in, no OpenTelemetry dependencies
+are included and the env vars are ignored.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> ExitCode {
 async fn async_main() -> ExitCode {
     // NOTE: if we fail to initialze logging, we do not crash here
     let _tracing_guard = match util::telemetry::init_tracing("oxen", LevelFilter::OFF) {
-        Ok(guard) => guard,
+        Ok(guard) => Some(guard),
         Err(e) => {
             eprintln!("[ERROR] Failed to initialize tracing for oxen:\n{e}");
             None

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -34,6 +34,7 @@ otel = [
     "dep:tracing-opentelemetry",
 ]
 perf-logging = []
+production = ["otel", "ffmpeg", "perf-logging", "default"]
 
 [dependencies]
 approx = { workspace = true }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -27,6 +27,12 @@ path = "src/lib.rs"
 default = ["duckdb/bundled"]
 docs = ["duckdb"]
 ffmpeg = ["thumbnails"]
+otel = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+]
 perf-logging = []
 
 [dependencies]
@@ -77,10 +83,12 @@ lofty = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
 metrics = { workspace = true }
-metrics-exporter-prometheus = { workspace = true }
 minus = { workspace = true }
 mp4 = { workspace = true }
 num_cpus = { workspace = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
 os_path = { workspace = true }
 par-stream = { workspace = true }
 parking_lot = { workspace = true }
@@ -117,7 +125,7 @@ tokio-util = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
-tracing-log = { workspace = true }
+tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }

--- a/crates/lib/src/api/client/branches.rs
+++ b/crates/lib/src/api/client/branches.rs
@@ -11,6 +11,7 @@ use crate::view::{
 use serde_json::json;
 use std::path::Path;
 
+#[tracing::instrument(skip(repository, branch_name))]
 pub async fn get_by_name(
     repository: &RemoteRepository,
     branch_name: impl AsRef<str>,
@@ -103,6 +104,7 @@ pub async fn create_from_commit_id(
 }
 
 /// List all branches on the remote
+#[tracing::instrument(skip(repository))]
 pub async fn list(repository: &RemoteRepository) -> Result<Vec<Branch>, OxenError> {
     let url = api::endpoint::url_from_repo(repository, "/branches")?;
 

--- a/crates/lib/src/api/client/commits.rs
+++ b/crates/lib/src/api/client/commits.rs
@@ -336,6 +336,7 @@ pub async fn root_commit_maybe(
     }
 }
 
+#[tracing::instrument(skip(remote_repo, path), fields(commit_id))]
 pub async fn download_dir_hashes_from_commit(
     remote_repo: &RemoteRepository,
     commit_id: &str,
@@ -347,6 +348,7 @@ pub async fn download_dir_hashes_from_commit(
     download_dir_hashes_from_url(url, path).await
 }
 
+#[tracing::instrument(skip(remote_repo, path), fields(base_commit_id, head_commit_id))]
 pub async fn download_base_head_dir_hashes(
     remote_repo: &RemoteRepository,
     base_commit_id: &str,
@@ -438,6 +440,7 @@ pub async fn download_dir_hashes_from_url(
     }
 }
 
+#[tracing::instrument(skip(remote_repo, path), fields(commit_id))]
 pub async fn download_dir_hashes_db_to_path(
     remote_repo: &RemoteRepository,
     commit_id: &str,

--- a/crates/lib/src/api/client/entries.rs
+++ b/crates/lib/src/api/client/entries.rs
@@ -324,6 +324,7 @@ pub async fn download_small_entry(
 }
 
 /// Download a file from the remote repository in parallel chunks
+#[tracing::instrument(skip(repo, remote_repo, remote_path, entry))]
 pub async fn pull_large_entry(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,

--- a/crates/lib/src/api/client/repositories.rs
+++ b/crates/lib/src/api/client/repositories.rs
@@ -105,6 +105,7 @@ pub async fn get_by_url(url: &str) -> Result<RemoteRepository, OxenError> {
     get_by_remote(&remote).await
 }
 
+#[tracing::instrument(skip(remote))]
 pub async fn get_by_remote(remote: &Remote) -> Result<RemoteRepository, OxenError> {
     let url = api::endpoint::url_from_remote(remote, "")?;
     log::debug!("get_by_remote url: {url}");
@@ -476,21 +477,25 @@ pub async fn post_download(repository: &RemoteRepository) -> Result<(), OxenErro
     action_hook(repository, action_name, ActionEventState::Completed, None).await
 }
 
+#[tracing::instrument(skip(repository))]
 pub async fn pre_pull(repository: &RemoteRepository) -> Result<(), OxenError> {
     let action_name = PULL;
     action_hook(repository, action_name, ActionEventState::Started, None).await
 }
 
+#[tracing::instrument(skip(repository))]
 pub async fn post_pull(repository: &RemoteRepository) -> Result<(), OxenError> {
     let action_name = PULL;
     action_hook(repository, action_name, ActionEventState::Completed, None).await
 }
 
+#[tracing::instrument(skip(repository))]
 pub async fn pre_fetch(repository: &RemoteRepository) -> Result<(), OxenError> {
     let action_name = FETCH;
     action_hook(repository, action_name, ActionEventState::Started, None).await
 }
 
+#[tracing::instrument(skip(repository))]
 pub async fn post_fetch(repository: &RemoteRepository) -> Result<(), OxenError> {
     let action_name = FETCH;
     action_hook(repository, action_name, ActionEventState::Completed, None).await

--- a/crates/lib/src/api/client/tree.rs
+++ b/crates/lib/src/api/client/tree.rs
@@ -25,6 +25,7 @@ use crate::view::{MerkleHashesResponse, StatusMessage};
 use crate::{api, util};
 
 /// Check if a node exists in the remote repository merkle tree by hash
+#[tracing::instrument(skip(repository))]
 pub async fn has_node(
     repository: &RemoteRepository,
     node_id: MerkleHash,
@@ -159,6 +160,7 @@ pub async fn download_node_with_children(
 }
 
 /// Downloads the full merkle tree from the remote repository
+#[tracing::instrument(skip(local_repo, remote_repo))]
 pub async fn download_tree(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
@@ -176,6 +178,7 @@ pub async fn download_tree(
 }
 
 /// Downloads a tree from the remote repository merkle tree by hash
+#[tracing::instrument(skip(local_repo, remote_repo))]
 pub async fn download_tree_from(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
@@ -256,6 +259,7 @@ pub async fn download_tree_from_path(
 }
 
 /// Download ALL the trees starting from the given commit id
+#[tracing::instrument(skip(local_repo, remote_repo, commit_id, fetch_opts))]
 pub async fn download_trees_from(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
@@ -329,6 +333,7 @@ fn append_subtree_paths_and_depth_to_uri(
     uri
 }
 
+#[tracing::instrument(skip(local_repo, remote_repo, base_id, head_id, fetch_opts))]
 pub async fn download_trees_between(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,

--- a/crates/lib/src/api/client/versions.rs
+++ b/crates/lib/src/api/client/versions.rs
@@ -114,6 +114,7 @@ pub async fn parallel_large_file_upload(
     entry: Option<Entry>,                 // entry is provided for push workflow
     progress: Option<&Arc<PushProgress>>, // for push workflow
 ) -> Result<MultipartLargeFileUpload, OxenError> {
+    let timer = std::time::Instant::now();
     log::debug!("multipart_large_file_upload path: {:?}", file_path.as_ref());
 
     let mut upload =
@@ -133,14 +134,19 @@ pub async fn parallel_large_file_upload(
     .await?;
     let num_chunks = results.len();
     log::debug!("multipart_large_file_upload num_chunks: {num_chunks:?}");
-    complete_multipart_large_file_upload(
+    let result = complete_multipart_large_file_upload(
         remote_repo,
         upload,
         num_chunks,
         workspace_id,
         update_timestamp,
     )
-    .await
+    .await;
+    log::debug!(
+        "parallel_large_file_upload completed in {:?}",
+        timer.elapsed()
+    );
+    result
 }
 
 /// Creates a new multipart large file upload
@@ -200,18 +206,28 @@ async fn create_multipart_large_file_upload(
 }
 
 /// Batch download
+#[tracing::instrument(skip(remote_repo, hashes, local_repo))]
 pub async fn download_data_from_version_paths(
     remote_repo: &RemoteRepository,
     hashes: &[String],
     local_repo: &LocalRepository,
 ) -> Result<u64, OxenError> {
+    let timer = std::time::Instant::now();
     let total_retries = max_retries().try_into().unwrap_or(max_retries() as u64);
     let mut num_retries = 0;
 
     while num_retries < total_retries {
         match try_download_data_from_version_paths(remote_repo, hashes, local_repo).await {
-            Ok(val) => return Ok(val),
-            Err(OxenError::Authentication(val)) => return Err(OxenError::Authentication(val)),
+            Ok(val) => {
+                log::debug!(
+                    "download_data_from_version_paths completed in {:?}",
+                    timer.elapsed()
+                );
+                return Ok(val);
+            }
+            Err(OxenError::Authentication(val)) => {
+                return Err(OxenError::Authentication(val));
+            }
             Err(err) => {
                 num_retries += 1;
                 // Exponentially back off
@@ -230,6 +246,7 @@ pub async fn download_data_from_version_paths(
     Err(OxenError::basic_str(err))
 }
 
+#[tracing::instrument(skip(remote_repo, hashes, local_repo))]
 pub async fn try_download_data_from_version_paths(
     remote_repo: &RemoteRepository,
     hashes: &[String],
@@ -491,6 +508,7 @@ pub async fn multipart_batch_upload_with_retry(
     chunk: &Vec<Entry>,
     client: &reqwest::Client,
 ) -> Result<(), OxenError> {
+    let timer = std::time::Instant::now();
     let mut files_to_retry: Vec<ErrorFileInfo> = vec![];
     let mut first_try = true;
     let mut retry_count: usize = 0;
@@ -509,6 +527,10 @@ pub async fn multipart_batch_upload_with_retry(
         }
     }
     if files_to_retry.is_empty() {
+        log::debug!(
+            "multipart_batch_upload_with_retry completed in {:?}",
+            timer.elapsed()
+        );
         Ok(())
     } else {
         Err(OxenError::basic_str(format!(

--- a/crates/lib/src/core/v_latest/fetch.rs
+++ b/crates/lib/src/core/v_latest/fetch.rs
@@ -19,6 +19,7 @@ use crate::{api, util};
 use crate::core::progress::pull_progress::PullProgress;
 use crate::opts::fetch_opts::FetchOpts;
 
+#[tracing::instrument(skip(repo, remote_repo, fetch_opts), fields(repo_path = %repo.path.display(), branch = %fetch_opts.branch))]
 pub async fn fetch_remote_branch(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,
@@ -174,6 +175,7 @@ pub async fn fetch_remote_branch(
     Ok(remote_branch)
 }
 
+#[tracing::instrument(skip(repo, remote_repo, fetch_opts, pull_progress), fields(repo_path = %repo.path.display(), branch = %branch.name, head_commit_id = %head_commit.id))]
 async fn sync_from_head(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,
@@ -226,6 +228,7 @@ async fn sync_from_head(
 }
 
 // Sync all the commits from the commit (and their parents)
+#[tracing::instrument(skip(repo, remote_repo, commit_id, fetch_opts, pull_progress), fields(repo_path = %repo.path.display()))]
 async fn sync_tree_from_commit(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,
@@ -413,6 +416,7 @@ pub async fn fetch_tree_and_hashes_for_commit_id(
     Ok(())
 }
 
+#[tracing::instrument(skip(repo, remote_repo, pull_progress), fields(repo_path = %repo.path.display(), branch = %remote_branch.name))]
 pub async fn fetch_full_tree_and_hashes(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,
@@ -596,6 +600,7 @@ async fn r_download_entries(
 }
 
 // pull entries from remote repo to versions dir
+#[tracing::instrument(skip(repo, remote_repo, entries, progress_bar), fields(repo_path = %repo.path.display(), num_entries = entries.len()))]
 pub async fn pull_entries_to_versions_dir(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,

--- a/crates/lib/src/core/v_latest/pull.rs
+++ b/crates/lib/src/core/v_latest/pull.rs
@@ -6,6 +6,7 @@ use crate::repositories;
 use crate::core::v_latest::fetch;
 use crate::opts::fetch_opts::FetchOpts;
 
+#[tracing::instrument(skip(repo), fields(repo_path = %repo.path.display()))]
 pub async fn pull(repo: &LocalRepository) -> Result<(), OxenError> {
     let mut fetch_opts = FetchOpts::new();
     fetch_opts.depth = repo.depth();
@@ -13,6 +14,7 @@ pub async fn pull(repo: &LocalRepository) -> Result<(), OxenError> {
     pull_remote_branch(repo, &fetch_opts).await
 }
 
+#[tracing::instrument(skip(repo), fields(repo_path = %repo.path.display()))]
 pub async fn pull_all(repo: &LocalRepository) -> Result<(), OxenError> {
     let fetch_opts = FetchOpts {
         all: true,
@@ -24,6 +26,7 @@ pub async fn pull_all(repo: &LocalRepository) -> Result<(), OxenError> {
 }
 
 /// Pull a specific remote and branch
+#[tracing::instrument(skip(repo, fetch_opts), fields(repo_path = %repo.path.display()))]
 pub async fn pull_remote_branch(
     repo: &LocalRepository,
     fetch_opts: &FetchOpts,

--- a/crates/lib/src/repositories/fetch.rs
+++ b/crates/lib/src/repositories/fetch.rs
@@ -13,10 +13,12 @@ use crate::repositories;
 use futures::{StreamExt, stream};
 
 /// # Fetch the remote branches and objects
+#[tracing::instrument(skip(repo, fetch_opts), fields(repo_path = %repo.path.display()))]
 pub async fn fetch_all(
     repo: &LocalRepository,
     fetch_opts: &FetchOpts,
 ) -> Result<Vec<Branch>, OxenError> {
+    metrics::counter!("oxen_fetch_total").increment(1);
     let remote = repo
         .get_remote(&fetch_opts.remote)
         .ok_or_else(|| OxenError::RemoteNotSet(fetch_opts.remote.clone()))?;
@@ -81,10 +83,12 @@ pub async fn fetch_all(
     branches
 }
 
+#[tracing::instrument(skip(repo, fetch_opts), fields(repo_path = %repo.path.display()))]
 pub async fn fetch_branch(
     repo: &LocalRepository,
     fetch_opts: &FetchOpts,
 ) -> Result<Branch, OxenError> {
+    metrics::counter!("oxen_fetch_total").increment(1);
     let remote = repo
         .get_remote(&fetch_opts.remote)
         .ok_or_else(|| OxenError::RemoteNotSet(fetch_opts.remote.clone()))?;
@@ -96,6 +100,7 @@ pub async fn fetch_branch(
     Ok(branch)
 }
 
+#[tracing::instrument(skip(repo, remote_repo, fetch_opts), fields(repo_path = %repo.path.display()))]
 pub async fn fetch_remote_branch(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,

--- a/crates/lib/src/repositories/pull.rs
+++ b/crates/lib/src/repositories/pull.rs
@@ -12,14 +12,21 @@ use crate::opts::fetch_opts::FetchOpts;
 /// Pull a repository's data from default branches origin/main
 /// Defaults defined in
 /// `constants::DEFAULT_REMOTE_NAME` and `constants::DEFAULT_BRANCH_NAME`
+#[tracing::instrument(skip(repo), fields(repo_path = %repo.path.display()))]
 pub async fn pull(repo: &LocalRepository) -> Result<(), OxenError> {
-    match repo.min_version() {
+    metrics::counter!("oxen_pull_total").increment(1);
+    let timer = std::time::Instant::now();
+    let result = match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::pull::pull(repo).await,
-    }
+    };
+    metrics::histogram!("oxen_pull_duration_ms").record(timer.elapsed().as_millis() as f64);
+    result
 }
 
+#[tracing::instrument(skip(repo), fields(repo_path = %repo.path.display()))]
 pub async fn pull_all(repo: &LocalRepository) -> Result<(), OxenError> {
+    metrics::counter!("oxen_pull_total").increment(1);
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::pull::pull_all(repo).await,
@@ -27,6 +34,7 @@ pub async fn pull_all(repo: &LocalRepository) -> Result<(), OxenError> {
 }
 
 /// Pull a specific remote and branch
+#[tracing::instrument(skip(repo, fetch_opts), fields(repo_path = %repo.path.display()))]
 pub async fn pull_remote_branch(
     repo: &LocalRepository,
     fetch_opts: &FetchOpts,

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -19,6 +19,7 @@ use crate::model::{LocalRepository, RemoteRepository};
 use crate::opts::RmOpts;
 use crate::repositories;
 use crate::util;
+use crate::util::telemetry::TracingGuard;
 
 use rand::Rng;
 use rand::distributions::Alphanumeric;
@@ -78,8 +79,7 @@ static ENV_LOCK: LazyLock<Arc<Mutex<bool>>> = LazyLock::new(|| Arc::new(Mutex::n
 /// Process-global owner of the tracing `WorkerGuard`. Stored here so the
 /// file-logging writer stays alive for the entire test run instead of being
 /// dropped at the end of the `init_test_env` call.
-static WORKER_GUARD: LazyLock<Mutex<Option<tracing_appender::non_blocking::WorkerGuard>>> =
-    LazyLock::new(|| Mutex::new(None));
+static WORKER_GUARD: LazyLock<Mutex<Option<TracingGuard>>> = LazyLock::new(|| Mutex::new(None));
 
 pub fn init_test_env() {
     match ENV_LOCK.lock() {
@@ -91,7 +91,7 @@ pub fn init_test_env() {
 
                 // Store the guard globally so it outlives this block.
                 if let Ok(mut slot) = WORKER_GUARD.lock() {
-                    *slot = guard;
+                    *slot = Some(guard);
                 }
 
                 *logging_setup = true;

--- a/crates/lib/src/util/telemetry.rs
+++ b/crates/lib/src/util/telemetry.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::{SubscriberInitExt, TryInitError};
 use tracing_subscriber::{EnvFilter, Layer, Registry};
@@ -18,6 +19,90 @@ pub enum TelemetryError {
     CreateLogDir(PathBuf, std::io::Error),
     #[error("Failed to initialize tracing: {0}")]
     InitFail(#[from] TryInitError),
+    #[error("Unknown OXEN_OTEL_PROTOCOL value: {0}")]
+    UnknownProtocol(String),
+    #[error("Failed to parse OXEN_OTEL_ENDPOINT ({0}): {1}")]
+    InvalidEndpoint(String, url::ParseError),
+}
+
+/// Holds all tracing-related guards. Drop flushes writers and shuts down
+/// the OpenTelemetry pipeline (when enabled). The caller **must** keep this
+/// alive for the application lifetime.
+pub struct TracingGuard {
+    _file_guard: Option<WorkerGuard>,
+    #[cfg(feature = "otel")]
+    _tracer_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+}
+
+impl Drop for TracingGuard {
+    fn drop(&mut self) {
+        // The global subscriber holds an Arc clone of the tracer provider
+        // (via OpenTelemetryLayer → SdkTracer → SdkTracerProvider), so
+        // dropping _tracer_provider alone never brings the Arc refcount to
+        // zero — TracerProviderInner::drop() never fires. We call shutdown()
+        // explicitly to flush the BatchSpanProcessor's pending spans.
+        // This is idempotent: if atexit_flush already ran, the atomic
+        // is_shutdown flag causes this to no-op.
+        #[cfg(feature = "otel")]
+        if let Some(ref provider) = self._tracer_provider
+            && let Err(e) = provider.shutdown()
+        {
+            eprintln!("warning: OTel tracer provider shutdown failed: {e}");
+        }
+    }
+}
+
+/// Ensures the OTel tracer provider is shut down (and pending spans flushed)
+/// when the process exits, even if [`TracingGuard`] is stored in a static
+/// whose `Drop` impl will never run.
+///
+/// A clone of the [`SdkTracerProvider`] is stored in a process-global
+/// [`OnceLock`] and a C `atexit` callback is registered to call `shutdown()`
+/// on it. `shutdown()` is idempotent (guarded by an atomic flag), so it is
+/// safe for both [`TracingGuard::drop`] and the `atexit` handler to call it.
+#[cfg(feature = "otel")]
+mod atexit_flush {
+    use std::sync::OnceLock;
+
+    static PROVIDER: OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> = OnceLock::new();
+
+    extern "C" fn on_exit() {
+        if let Some(provider) = PROVIDER.get() {
+            let _ = provider.shutdown();
+        }
+    }
+
+    /// Store a clone of the provider and register the `atexit` callback.
+    /// Only the first call has any effect; subsequent calls are no-ops.
+    ///
+    /// # Safety
+    ///
+    /// This function declares the C standard library's `atexit` via
+    /// `unsafe extern "C"` and marks it `safe` because:
+    ///
+    /// - `atexit` is defined by ISO C (C89 / C99 / C11) and is available on
+    ///   every platform this project targets (Linux, macOS, Windows).
+    /// - The registered callback (`on_exit`) is an `extern "C" fn` with no
+    ///   captures, satisfying `atexit`'s function-pointer requirement.
+    /// - `on_exit` only accesses `PROVIDER`, a `OnceLock` that is `Sync` and
+    ///   fully initialized before the callback can ever fire.
+    /// - `SdkTracerProvider::shutdown()` is synchronous, blocking, and
+    ///   idempotent (guarded by an atomic flag), so it is safe to call from
+    ///   the single-threaded `atexit` context even if [`TracingGuard::drop`]
+    ///   already called it.
+    pub(super) fn register(provider: opentelemetry_sdk::trace::SdkTracerProvider) -> bool {
+        if PROVIDER.set(provider).is_err() {
+            return false;
+        }
+        unsafe extern "C" {
+            safe fn atexit(f: extern "C" fn()) -> core::ffi::c_int;
+        }
+        let registered = atexit(on_exit) == 0;
+        if !registered {
+            eprintln!("warning: failed to register OTel atexit flush handler");
+        }
+        registered
+    }
 }
 
 /// Initialize tracing with the `tracing-log` bridge.
@@ -28,23 +113,38 @@ pub enum TelemetryError {
 /// daily log file. The env var accepts a directory path — rolling files are
 /// written there (e.g. `/var/log/oxen`).
 ///
-/// Filter level is controlled by `RUST_LOG`. The filter applies to both stderr
-/// and file output.
+/// **FmtSpan events** (opt-in via `OXEN_FMT_SPAN`): emit span lifecycle
+/// events (creation, close, etc.) as additional log lines on stderr. Accepted
+/// values: `NEW`, `CLOSE`, `ENTER`, `EXIT`, `ACTIVE`, `FULL`, `NONE`,
+/// `1`/`true` (alias for `CLOSE`), or `|`-combined (e.g. `NEW|CLOSE`).
 ///
-/// Returns `Some(WorkerGuard)` when file logging is active. The caller
+/// **OpenTelemetry** (opt-in via `OXEN_OTEL_ENDPOINT`, requires `otel` feature):
+/// export spans to an OTLP-compatible collector. See env var documentation in
+/// the server README for configuration details. Also accepts the standard named
+/// env var `OTEL_EXPORTER_OTLP_ENDPOINT`, but checks `OXEN_OTEL_ENDPOINT` first.
+///
+/// The `OXEN_OTEL_PROTOCOL` env var is either `"http"` or `"grpc"`: it controls
+/// the protocol used for OTLP exports. If not set, defaults to `"grpc"`.
+///
+/// Filter level is controlled by `RUST_LOG`. The filter applies to all output layers.
+///
+/// Returns a [TracingGuard] when file logging is active. The caller
 /// **must** hold the guard in a named binding for the lifetime of the
-/// application — dropping it flushes the non-blocking writer. When file
-/// logging is not enabled, returns `None`.
-pub fn init_tracing(
-    app_name: &str,
-    default: LevelFilter,
-) -> Result<Option<WorkerGuard>, TelemetryError> {
+/// application — dropping it flushes the non-blocking writer.
+pub fn init_tracing(app_name: &str, default: LevelFilter) -> Result<TracingGuard, TelemetryError> {
     let log_level = log_env_filter(default);
 
-    // Always: human-readable stderr output
+    // FmtSpan configuration for stderr
+    let span_events = std::env::var("OXEN_FMT_SPAN")
+        .ok()
+        .map(|v| parse_fmt_span(&v))
+        .unwrap_or(FmtSpan::NONE);
+
+    // Always: human-readable stderr output (with optional span events)
     let stderr_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
-        .with_target(true);
+        .with_target(true)
+        .with_span_events(span_events);
 
     let maybe_log_dir = match std::env::var("OXEN_LOG_DIR").ok() {
         Some(log_dir) => {
@@ -54,22 +154,89 @@ pub fn init_tracing(
         None => None,
     };
 
-    let (maybe_json_layer, maybe_worker_guard) = if let Some(log_dir) = maybe_log_dir {
-        let (jl, wg) = json_file_logging(app_name, &log_dir);
+    let (m_json_layer, m_worker_guard) = if let Some(ref log_dir) = maybe_log_dir {
+        let (jl, wg) = json_file_logging(app_name, log_dir);
         (Some(jl), Some(wg))
     } else {
         (None, None)
     };
 
+    // Base registry with all non-OTel layers
+    let registry = tracing_subscriber::registry()
+        .with(m_json_layer)
+        .with(stderr_layer)
+        .with(log_level);
+
+    // OpenTelemetry layer (feature-gated). Composed separately because the
+    // concrete subscriber type (`S`) changes with each `.with()` call and
+    // `OpenTelemetryLayer<S, T>` must match the exact inner subscriber.
+    #[cfg(feature = "otel")]
+    let (m_otel_layer, m_tracer_provider, m_endpoint_p) = match std::env::var("OXEN_OTEL_ENDPOINT")
+        .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT"))
+        .ok()
+    {
+        Some(raw_endpoint) => {
+            let explicit_protocol = std::env::var("OXEN_OTEL_PROTOCOL")
+                .map(|x| x.to_lowercase())
+                .ok();
+
+            let endpoint = OtelEndpoint::parse(&raw_endpoint, explicit_protocol.as_deref())?;
+
+            match build_otel_layer(app_name, &endpoint) {
+                (Some(layer), Some(provider)) => {
+                    atexit_flush::register(provider.clone());
+                    (Some(layer), Some(provider), Some(endpoint.to_string()))
+                }
+                _ => (None, None, None),
+            }
+        }
+
+        None => (None, None, None),
+    };
+
+    #[cfg(not(feature = "otel"))]
+    {
+        if std::env::var("OXEN_OTEL_ENDPOINT").is_ok() {
+            eprintln!(
+                "[WARNING] OXEN_OTEL_ENDPOINT is set but otel feature is not enabled! Ignoring."
+            );
+        }
+        if std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").is_ok() {
+            eprintln!(
+                "[WARNING] OTEL_EXPORTER_OTLP_ENDPOINT is set but otel feature is not enabled! Ignoring."
+            );
+        }
+    }
+
     // .try_init() also installs the tracing-log bridge (forwarding log::* calls into tracing)
     // when the `tracing-log` feature is enabled.
-    tracing_subscriber::registry()
-        .with(maybe_json_layer)
-        .with(stderr_layer)
-        .with(log_level)
-        .try_init()?;
 
-    Ok(maybe_worker_guard)
+    #[cfg(feature = "otel")]
+    {
+        registry.with(m_otel_layer).try_init()?;
+
+        if let Some(protocol_and_endpoint) = m_endpoint_p {
+            log::info!("OpenTelemetry tracing enabled (endpoint: {protocol_and_endpoint})");
+        }
+    }
+
+    #[cfg(not(feature = "otel"))]
+    {
+        registry.try_init()?;
+    }
+
+    if let Some(ref log_dir) = maybe_log_dir {
+        log::info!(
+            "JSON file logging enabled (log directory: {})",
+            log_dir.display()
+        );
+    }
+
+    Ok(TracingGuard {
+        _file_guard: m_worker_guard,
+        #[cfg(feature = "otel")]
+        _tracer_provider: m_tracer_provider,
+    })
 }
 
 /// Create an [`EnvFilter`] from `RUST_LOG`, falling back to the default log level if not set.
@@ -114,4 +281,386 @@ fn json_file_logging(app_name: &str, log_dir: &Path) -> (impl Layer<Registry>, W
         .with_line_number(true);
 
     (layer, guard)
+}
+
+/// Parse an `OXEN_FMT_SPAN` value into a [`FmtSpan`] bitflag.
+///
+/// Accepts single names (`NEW`, `CLOSE`, `FULL`, etc.), the convenience
+/// aliases `1`/`true` (mapped to `CLOSE`), or `|`-separated combinations
+/// (e.g. `NEW|CLOSE`, `ACTIVE|FULL`).
+fn parse_fmt_span(value: &str) -> FmtSpan {
+    let upper = value.to_uppercase();
+    if !upper.contains('|') {
+        return parse_fmt_span_token(&upper);
+    }
+    let mut span = FmtSpan::NONE;
+    for part in upper.split('|') {
+        span |= parse_fmt_span_token(part.trim());
+    }
+    span
+}
+
+/// Parse a single `FmtSpan` token (already uppercased).
+fn parse_fmt_span_token(token: &str) -> FmtSpan {
+    match token {
+        "1" | "TRUE" | "CLOSE" => FmtSpan::CLOSE,
+        "NEW" => FmtSpan::NEW,
+        "ENTER" => FmtSpan::ENTER,
+        "EXIT" => FmtSpan::EXIT,
+        "ACTIVE" => FmtSpan::ACTIVE,
+        "FULL" => FmtSpan::FULL,
+        "NONE" => FmtSpan::NONE,
+        other => {
+            eprintln!("warning: unknown OXEN_FMT_SPAN component: {other:?}, ignoring");
+            FmtSpan::NONE
+        }
+    }
+}
+#[cfg(feature = "otel")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Protocol {
+    Grpc,
+    Http,
+}
+
+#[cfg(feature = "otel")]
+impl std::fmt::Display for Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Protocol::Grpc => write!(f, "grpc"),
+            Protocol::Http => write!(f, "http"),
+        }
+    }
+}
+
+/// Parsed representation of an OTLP endpoint.
+///
+/// Built from the raw `OXEN_OTEL_ENDPOINT` value and the optional
+/// `OXEN_OTEL_PROTOCOL` override via [`OtelEndpoint::parse`].
+#[cfg(feature = "otel")]
+struct OtelEndpoint {
+    /// Resolved OTLP transport protocol.
+    protocol: Protocol,
+    /// Host or IP address (no scheme, no port).
+    address: String,
+    /// Port number, if explicitly provided.
+    port: Option<u16>,
+}
+
+#[cfg(feature = "otel")]
+impl OtelEndpoint {
+    /// Parse a raw endpoint string and optional explicit protocol into a
+    /// structured [`OtelEndpoint`].
+    ///
+    /// `explicit_protocol` is the lowercased value of `OXEN_OTEL_PROTOCOL`
+    /// (if set). It accepts `"http"` or `"grpc"`. Any other value returns
+    /// [`TelemetryError::UnknownProtocol`].
+    ///
+    /// When the endpoint string has no scheme (e.g. `localhost:4317`), the
+    /// resolved protocol is used as the scheme for URL parsing.
+    fn parse(raw: &str, explicit_protocol: Option<&str>) -> Result<Self, TelemetryError> {
+        // Resolve the explicit protocol string (if any) into a Protocol.
+        let explicit = match explicit_protocol {
+            Some("http") => Some(Protocol::Http),
+            Some("grpc") => Some(Protocol::Grpc),
+            Some(unknown) => {
+                return Err(TelemetryError::UnknownProtocol(unknown.to_string()));
+            }
+            None => None,
+        };
+
+        // Detect whether the raw input has a scheme, and if so, which one.
+        // We always parse using `http://` as the scheme for URL parsing
+        // because url::Url only extracts host:port for "special" schemes
+        // (http, https, ftp, etc.) — non-special schemes like "grpc" put
+        // everything after :// into the path component.
+        let (original_scheme, to_parse) =
+            if raw.starts_with("http://") || raw.starts_with("https://") {
+                (Some(Protocol::Http), raw.to_string())
+            } else {
+                // No scheme (or non-http scheme): prepend http:// for parsing.
+                (None, format!("http://{raw}"))
+            };
+
+        let parsed = url::Url::parse(&to_parse)
+            .map_err(|e| TelemetryError::InvalidEndpoint(raw.to_string(), e))?;
+
+        // Protocol resolution priority:
+        // 1. Explicit env var (OXEN_OTEL_PROTOCOL) — always wins
+        // 2. Scheme from the endpoint string (http/https → Http)
+        // 3. Default: Grpc
+        let protocol = explicit.or(original_scheme).unwrap_or(Protocol::Grpc);
+
+        let address = parsed.host_str().unwrap_or("localhost").to_string();
+
+        let port = parsed.port();
+
+        Ok(OtelEndpoint {
+            protocol,
+            address,
+            port,
+        })
+    }
+
+    /// Build the full URL that the OTLP exporter needs.
+    ///
+    /// Always uses `http://` as the scheme — both tonic (gRPC) and the HTTP
+    /// OTLP exporter use HTTP as the underlying transport.
+    fn to_url(&self) -> String {
+        match self.port {
+            Some(port) => format!("http://{}:{port}", self.address),
+            None => format!("http://{}", self.address),
+        }
+    }
+}
+
+#[cfg(feature = "otel")]
+impl std::fmt::Display for OtelEndpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} -> {}", self.protocol, self.to_url())
+    }
+}
+
+/// Build an OpenTelemetry tracing layer that exports spans via OTLP.
+///
+/// Returns the layer (wrapped in `Option`) and the provider. When the
+/// exporter cannot be built, returns `(None, None)`.
+#[cfg(feature = "otel")]
+fn build_otel_layer<S>(
+    app_name: &str,
+    endpoint: &OtelEndpoint,
+) -> (
+    Option<tracing_opentelemetry::OpenTelemetryLayer<S, opentelemetry_sdk::trace::SdkTracer>>,
+    Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+)
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    use opentelemetry::KeyValue;
+    use opentelemetry::trace::TracerProvider;
+    use opentelemetry_otlp::WithExportConfig;
+    use opentelemetry_sdk::{Resource, trace::SdkTracerProvider};
+
+    let url = endpoint.to_url();
+
+    let exporter = match endpoint.protocol {
+        Protocol::Http => {
+            match opentelemetry_otlp::SpanExporter::builder()
+                .with_http()
+                .with_endpoint(&url)
+                .build()
+            {
+                Ok(e) => e,
+                Err(err) => {
+                    eprintln!("[ERROR] failed to build OTel HTTP exporter: {err}");
+                    return (None, None);
+                }
+            }
+        }
+        Protocol::Grpc => {
+            match opentelemetry_otlp::SpanExporter::builder()
+                .with_tonic()
+                .with_endpoint(&url)
+                .build()
+            {
+                Ok(e) => e,
+                Err(err) => {
+                    eprintln!("[ERROR] failed to build OTel gRPC exporter: {err}");
+                    return (None, None);
+                }
+            }
+        }
+    };
+
+    let resource = Resource::builder()
+        .with_attributes([KeyValue::new("service.name", app_name.to_string())])
+        .build();
+
+    let provider = SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(resource)
+        .build();
+
+    let tracer = provider.tracer("oxen");
+    let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    (Some(layer), Some(provider))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::fmt::format::FmtSpan;
+
+    #[test]
+    fn token_close() {
+        assert_eq!(parse_fmt_span_token("CLOSE"), FmtSpan::CLOSE);
+        assert_eq!(parse_fmt_span_token("1"), FmtSpan::CLOSE);
+        assert_eq!(parse_fmt_span_token("TRUE"), FmtSpan::CLOSE);
+        // case-insensitive
+        assert_eq!(parse_fmt_span("cLosE"), FmtSpan::CLOSE);
+        assert_eq!(parse_fmt_span("tRuE"), FmtSpan::CLOSE);
+    }
+
+    #[test]
+    fn token_new() {
+        assert_eq!(parse_fmt_span_token("NEW"), FmtSpan::NEW);
+        // case-insensitive
+        assert_eq!(parse_fmt_span("NeW"), FmtSpan::NEW);
+    }
+
+    #[test]
+    fn token_enter() {
+        assert_eq!(parse_fmt_span_token("ENTER"), FmtSpan::ENTER);
+        // case-insensitive
+        assert_eq!(parse_fmt_span("eNteR"), FmtSpan::ENTER);
+    }
+
+    #[test]
+    fn token_exit() {
+        assert_eq!(parse_fmt_span_token("EXIT"), FmtSpan::EXIT);
+        // case-insensitive
+        assert_eq!(parse_fmt_span("exIT"), FmtSpan::EXIT);
+    }
+
+    #[test]
+    fn token_active() {
+        assert_eq!(parse_fmt_span_token("ACTIVE"), FmtSpan::ACTIVE);
+        // case-insensitive
+        assert_eq!(parse_fmt_span("aCtIvE"), FmtSpan::ACTIVE);
+    }
+
+    #[test]
+    fn token_full() {
+        assert_eq!(parse_fmt_span_token("FULL"), FmtSpan::FULL);
+        // case-insensitive
+        assert_eq!(parse_fmt_span("FUll"), FmtSpan::FULL);
+    }
+
+    #[test]
+    fn token_none() {
+        assert_eq!(parse_fmt_span_token("NONE"), FmtSpan::NONE);
+        // case-insensitive
+        assert_eq!(parse_fmt_span("NonE"), FmtSpan::NONE);
+    }
+
+    #[test]
+    fn token_unknown_returns_none() {
+        assert_eq!(parse_fmt_span_token("BOGUS"), FmtSpan::NONE);
+        // case-insensitive
+        assert_eq!(parse_fmt_span("bogus"), FmtSpan::NONE);
+    }
+
+    #[test]
+    fn combined_new_close() {
+        assert_eq!(parse_fmt_span("NEW|CLOSE"), FmtSpan::NEW | FmtSpan::CLOSE);
+        // case-insensitive
+        assert_eq!(parse_fmt_span("new|close"), FmtSpan::NEW | FmtSpan::CLOSE);
+        // spaces around | are OK
+        assert_eq!(parse_fmt_span("NEW | CLOSE"), FmtSpan::NEW | FmtSpan::CLOSE);
+    }
+
+    #[test]
+    fn combined_active_close() {
+        assert_eq!(
+            parse_fmt_span("ACTIVE|CLOSE"),
+            FmtSpan::ACTIVE | FmtSpan::CLOSE
+        );
+    }
+
+    #[test]
+    fn combined_full_new() {
+        assert_eq!(parse_fmt_span("FULL|NEW"), FmtSpan::FULL | FmtSpan::NEW);
+    }
+
+    #[test]
+    fn combined_unknown_component_ignored() {
+        assert_eq!(parse_fmt_span("NEW|BOGUS"), FmtSpan::NEW | FmtSpan::NONE);
+    }
+
+    #[test]
+    fn combined_all_four_lifecycle() {
+        assert_eq!(
+            parse_fmt_span("NEW|ENTER|EXIT|CLOSE"),
+            FmtSpan::NEW | FmtSpan::ENTER | FmtSpan::EXIT | FmtSpan::CLOSE
+        );
+    }
+
+    #[cfg(feature = "otel")]
+    mod otel_endpoint_tests {
+        use super::super::{OtelEndpoint, Protocol};
+
+        #[test]
+        fn http_scheme_no_env_var() {
+            let ep = OtelEndpoint::parse("http://localhost:4317", None).unwrap();
+            assert_eq!(ep.protocol, Protocol::Http);
+            assert_eq!(ep.address, "localhost");
+            assert_eq!(ep.port, Some(4317));
+            assert_eq!(ep.to_url(), "http://localhost:4317");
+        }
+
+        #[test]
+        fn https_scheme_no_env_var() {
+            let ep = OtelEndpoint::parse("https://collector.example.com:443", None).unwrap();
+            assert_eq!(ep.protocol, Protocol::Http);
+            assert_eq!(ep.address, "collector.example.com");
+            // url::Url returns None for default ports (443 is default for https)
+            assert_eq!(ep.port, None);
+        }
+
+        #[test]
+        fn schemeless_no_env_var_defaults_to_grpc() {
+            let ep = OtelEndpoint::parse("localhost:4317", None).unwrap();
+            assert_eq!(ep.protocol, Protocol::Grpc);
+            assert_eq!(ep.address, "localhost");
+            assert_eq!(ep.port, Some(4317));
+            assert_eq!(ep.to_url(), "http://localhost:4317");
+        }
+
+        #[test]
+        fn schemeless_no_port_no_env_var() {
+            let ep = OtelEndpoint::parse("localhost", None).unwrap();
+            assert_eq!(ep.protocol, Protocol::Grpc);
+            assert_eq!(ep.address, "localhost");
+            assert_eq!(ep.port, None);
+            assert_eq!(ep.to_url(), "http://localhost");
+        }
+
+        #[test]
+        fn schemeless_with_http_env_var() {
+            let ep = OtelEndpoint::parse("localhost:4318", Some("http")).unwrap();
+            assert_eq!(ep.protocol, Protocol::Http);
+            assert_eq!(ep.address, "localhost");
+            assert_eq!(ep.port, Some(4318));
+        }
+
+        #[test]
+        fn schemeless_with_grpc_env_var() {
+            let ep = OtelEndpoint::parse("localhost:4317", Some("grpc")).unwrap();
+            assert_eq!(ep.protocol, Protocol::Grpc);
+            assert_eq!(ep.address, "localhost");
+            assert_eq!(ep.port, Some(4317));
+        }
+
+        #[test]
+        fn env_var_overrides_endpoint_scheme() {
+            let ep = OtelEndpoint::parse("http://localhost:4318", Some("grpc")).unwrap();
+            assert_eq!(ep.protocol, Protocol::Grpc);
+            assert_eq!(ep.address, "localhost");
+            assert_eq!(ep.port, Some(4318));
+            assert_eq!(ep.to_url(), "http://localhost:4318");
+        }
+
+        #[test]
+        fn unknown_protocol_returns_error() {
+            let result = OtelEndpoint::parse("localhost:4317", Some("mqtt"));
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn display_shows_protocol_and_url() {
+            let ep = OtelEndpoint::parse("localhost:4317", None).unwrap();
+            assert_eq!(ep.to_string(), "grpc -> http://localhost:4317");
+        }
+    }
 }

--- a/crates/oxen-py/Cargo.toml
+++ b/crates/oxen-py/Cargo.toml
@@ -14,6 +14,11 @@ publish = false
 name = "oxen_py" # The native extension module. Users still `import oxen` via the Python package wrapper.
 crate-type = ["cdylib"] # PyO3 needs this crate to be a cdylib so it can link against it.
 
+[features]
+default = []
+otel = ["liboxen/otel"]
+production = ["otel", "default"]
+
 [dependencies]
 liboxen = { path = "../lib" }
 log = { workspace = true }

--- a/crates/oxen-py/src/lib.rs
+++ b/crates/oxen-py/src/lib.rs
@@ -1,14 +1,13 @@
 use std::sync::{LazyLock, Mutex};
 
-use liboxen::config::RuntimeConfig;
+use liboxen::{config::RuntimeConfig, util::telemetry::TracingGuard};
 use pyo3::prelude::*;
 use tracing::level_filters::LevelFilter;
-use tracing_appender::non_blocking::WorkerGuard;
 
 /// Process-global owner of the tracing file-logging guard. Stored here so the
 /// tracing subscriber stays alive for the entire Python process instead of
 /// being dropped when `oxen_py()` returns.
-static TRACING_GUARD: LazyLock<Mutex<Option<WorkerGuard>>> = LazyLock::new(|| Mutex::new(None));
+static TRACING_GUARD: LazyLock<Mutex<Option<TracingGuard>>> = LazyLock::new(|| Mutex::new(None));
 
 pub mod auth;
 pub mod df_utils;
@@ -60,7 +59,7 @@ fn oxen_py(m: Bound<'_, PyModule>) -> PyResult<()> {
     {
         match liboxen::util::telemetry::init_tracing("oxen-py", LevelFilter::OFF) {
             Ok(guard) => {
-                *slot = guard;
+                *slot = Some(guard);
             }
             Err(e) => {
                 eprintln!("[ERROR] Failed to initialize tracing for oxen-py:\n{e}");

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -17,6 +17,10 @@ ignored = ["astral-tokio-tar"]
 name = "oxen-server"
 path = "src/main.rs"
 
+[features]
+default = []
+otel = ["liboxen/otel"]
+
 [dependencies]
 actix-http = { workspace = true }
 actix-multipart = { workspace = true }
@@ -52,9 +56,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
-tracing-appender = { workspace = true }
-tracing-log = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-actix-web = { workspace = true }
 url = { workspace = true }
 utoipa = { workspace = true }
 utoipa-swagger-ui = { workspace = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 [features]
 default = []
 otel = ["liboxen/otel"]
+production = ["otel", "liboxen/production", "default"]
 
 [dependencies]
 actix-http = { workspace = true }

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -5,11 +5,16 @@ Remote repositories have the same internal structure as local ones, with the cav
 
 **Notable configuration sections**:
 - [Prometheus Metrics](#prometheus-metrics)
+- [OpenTelemetry Tracing](#opentelemetry-tracing)
+- [FmtSpan Events](#fmtspan-events)
+- [Stacking Tracing Layers | Writing Spans to Logs & OTel](#stacking-tracing-layers)
+
 
 ## Build
 
 See the [prerequisites](../../README.md#prerequisites) section of the main readme before developing.
 Use the standard `cargo ... --workspace` commands and `cargo ... -p oxen-server` commands.
+
 
 ## Run
 
@@ -35,16 +40,6 @@ export SYNC_DIR=/path/to/sync/dir
 
 You can also create a `.env.local` file in the `crates/server/` directory which can contain the `SYNC_DIR` variable to avoid setting it every time you run the server.
 
-Server defaults to localhost 3000:
-```bash
-set SERVER 0.0.0.0:3000
-```
-
-You can grab your auth token from the config file above (`~/.oxen/user_config.toml`):
-```bash
-set TOKEN <YOUR_TOKEN>
-```
-
 Run the server:
 ```bash
 cargo run -p oxen-server start
@@ -67,6 +62,13 @@ bacon server
 
 ### API Examples
 
+Server defaults to localhost 3000.
+
+You can grab your auth token from the config file above (`~/.oxen/user_config.toml`):
+```bash
+export TOKEN="<YOUR_TOKEN>"
+```
+
 #### List Repositories
 ```bash
 curl -H "Authorization: Bearer $TOKEN" "http://0.0.0.0:3000/api/repos"
@@ -77,6 +79,7 @@ curl -H "Authorization: Bearer $TOKEN" "http://0.0.0.0:3000/api/repos"
 curl -H "Authorization: Bearer $TOKEN" -X POST -d '{"name": "MyRepo"}' "http://0.0.0.0:3000api/repos"
 ```
 
+
 ## Logging
 
 Oxen uses structured logging.
@@ -84,6 +87,7 @@ It outputs to STDERR by default but can be configured with rotating log files.
 See [Logging](../../README.md#logging) for details.
 
 By default, `oxen-server` logs at the `WARN` level. Set `RUST_LOG` to change.
+
 
 ## Prometheus Metrics
 
@@ -164,4 +168,124 @@ For example:
 
 ```
 rate(oxen_errors_total[5m])
+```
+
+
+## OpenTelemetry Tracing
+
+`oxen-server` can export tracing spans to any OTLP-compatible collector
+(Jaeger, Tempo, Honeycomb, Datadog, etc.). This requires building with the
+`otel` feature flag:
+
+```bash
+cargo build -p oxen-server --features otel
+```
+
+At runtime, set `OXEN_OTEL_ENDPOINT` to enable export:
+
+```bash
+# gRPC (default protocol)
+OXEN_OTEL_ENDPOINT=localhost:4317 oxen-server start
+
+# HTTP/JSON
+OXEN_OTEL_ENDPOINT=localhost:4318 OXEN_OTEL_PROTOCOL=http oxen-server start
+
+# Or include the protocol in the endpoint string directly
+OXEN_OTEL_ENDPOINT=http://localhost:4318 oxen-server start
+OXEN_OTEL_ENDPOINT=grpc://localhost:4318 oxen-server start
+```
+
+| Variable | Description | Default |
+|---|---|---|
+| `OXEN_OTEL_ENDPOINT` | Collector endpoint URL. Absent = disabled. | *(none)* |
+| `OXEN_OTEL_PROTOCOL` | Transport: `grpc` or `http` | `grpc` or whatever is listed in `OXEN_OTEL_ENDPOINT` |
+
+The standard `OTEL_EXPORTER_OTLP_ENDPOINT` variable is also respected as a
+fallback if `OXEN_OTEL_ENDPOINT` is not set.
+
+When the `otel` feature is not compiled in, no OpenTelemetry dependencies are
+included and the env vars are ignored.
+
+### `RUST_LOG` and span visibility
+
+The `RUST_LOG` filter is global — it gates what reaches **all** tracing
+outputs, including the OpenTelemetry exporter. `#[tracing::instrument]`
+creates spans at `INFO` level by default. The server defaults to
+`LevelFilter::WARN` when `RUST_LOG` is not set, which means **all
+`#[instrument]` spans are silently dropped** before the OTel layer sees
+them.
+
+To get full traces in Jaeger (or any collector), explicitly set
+`RUST_LOG=info`:
+
+```bash
+OXEN_OTEL_ENDPOINT=http://localhost:4317 RUST_LOG=info oxen-server start
+```
+
+Without `RUST_LOG=info`, the OTel exporter is active but receives no spans.
+The `TracingLogger` HTTP root span is also at `INFO` level, so it is
+similarly affected.
+
+For targeted verbosity (e.g. keep third-party crates quiet), use a
+filter directive:
+
+```bash
+RUST_LOG="warn,liboxen=info,oxen_server=info,tracing_actix_web=info"
+```
+
+### Quick Start with Jaeger
+
+```bash
+# Start Jaeger all-in-one: https://www.jaegertracing.io/docs/2.17/
+docker run --rm --name jaeger \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -p 5778:5778 \
+  -p 9411:9411 \
+  cr.jaegertracing.io/jaegertracing/jaeger:2.17.0
+
+# Start oxen-server with OTel export
+OXEN_OTEL_ENDPOINT=http://localhost:4317 RUST_LOG=info cargo run --features otel -p oxen-server start
+
+# View traces at http://localhost:16686 under service "oxen-server"
+```
+
+
+## FmtSpan Events
+
+Span lifecycle events (creation, entry, exit, close) can be emitted as
+additional log lines on stderr. This is useful for seeing timing of
+`#[instrument]`-annotated functions without a full tracing collector.
+
+Set `OXEN_FMT_SPAN` to enable:
+
+```bash
+# Log when spans close (includes elapsed time)
+OXEN_FMT_SPAN=CLOSE oxen-server start
+
+# Log all span lifecycle events
+OXEN_FMT_SPAN=FULL oxen-server start
+
+# Combine specific events
+OXEN_FMT_SPAN="NEW|CLOSE" oxen-server start
+```
+
+Accepted values: `NEW`, `CLOSE`, `ENTER`, `EXIT`, `ACTIVE` (enter+exit),
+`FULL` (all), `NONE`, `1`/`true` (alias for `CLOSE`).
+
+No feature flag or additional dependencies are required.
+
+
+## Stacking Tracing Layers
+
+All tracing outputs can be enabled simultaneously. For example, to get stderr
+output with span timing, JSON file logs, and OpenTelemetry export:
+
+```bash
+OXEN_LOG_DIR='/var/log/oxen' \
+OXEN_FMT_SPAN='CLOSE' \
+OXEN_OTEL_ENDPOINT='http://localhost:4317' \
+RUST_LOG='info' \
+oxen-server start
 ```

--- a/crates/server/src/controllers/branches.rs
+++ b/crates/server/src/controllers/branches.rs
@@ -18,6 +18,7 @@ use liboxen::view::{
 use liboxen::{constants, repositories};
 
 /// List all branches
+#[tracing::instrument(skip_all)]
 #[utoipa::path(
     get,
     path = "/api/repos/{namespace}/{repo_name}/branches",
@@ -81,6 +82,7 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
 }
 
 /// Get an existing branch
+#[tracing::instrument(skip_all)]
 #[utoipa::path(
     get,
     path = "/api/repos/{namespace}/{repo_name}/branches/{branch_name}",

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -439,6 +439,7 @@ pub async fn parents(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHt
 }
 
 /// Download commits DB
+#[tracing::instrument(skip_all)]
 #[utoipa::path(
     get,
     path = "/api/repos/{namespace}/{repo_name}/commits_db",
@@ -488,6 +489,7 @@ fn compress_commits_db(repository: &LocalRepository) -> Result<Vec<u8>, OxenErro
 }
 
 /// Download dir hashes DB
+#[tracing::instrument(skip_all)]
 #[utoipa::path(
     get,
     path = "/api/repos/{namespace}/{repo_name}/commits/{base_head}/dir_hashes_db",

--- a/crates/server/src/controllers/entries.rs
+++ b/crates/server/src/controllers/entries.rs
@@ -95,6 +95,7 @@ pub async fn download_data_from_version_paths(
 }
 
 /// Download a chunk of a larger file
+#[tracing::instrument(skip_all)]
 pub async fn download_chunk(
     req: HttpRequest,
     query: web::Query<ChunkQuery>,

--- a/crates/server/src/controllers/tree.rs
+++ b/crates/server/src/controllers/tree.rs
@@ -24,6 +24,7 @@ use crate::params::TreeDepthQuery;
 use crate::params::parse_resource;
 use crate::params::{app_data, path_param};
 
+#[tracing::instrument(skip_all)]
 pub async fn get_node_by_id(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
@@ -37,6 +38,7 @@ pub async fn get_node_by_id(req: HttpRequest) -> actix_web::Result<HttpResponse,
     node_to_json(node)
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn list_missing_node_hashes(
     req: HttpRequest,
     mut body: web::Payload,
@@ -67,6 +69,7 @@ pub async fn list_missing_node_hashes(
     }))
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn list_missing_file_hashes_from_commits(
     req: HttpRequest,
     query: web::Query<TreeDepthQuery>,
@@ -105,6 +108,7 @@ pub async fn list_missing_file_hashes_from_commits(
     }))
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn list_missing_file_hashes(
     req: HttpRequest,
 ) -> actix_web::Result<HttpResponse, OxenHttpError> {
@@ -127,6 +131,7 @@ pub async fn list_missing_file_hashes(
     }))
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn mark_nodes_as_synced(
     req: HttpRequest,
     mut body: web::Payload,
@@ -156,6 +161,7 @@ pub async fn mark_nodes_as_synced(
     }))
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn create_nodes(
     req: HttpRequest,
     mut body: web::Payload,
@@ -180,6 +186,7 @@ pub async fn create_nodes(
     Ok(HttpResponse::Ok().json(StatusMessage::resource_found()))
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn download_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
@@ -192,6 +199,7 @@ pub async fn download_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, 
     Ok(HttpResponse::Ok().body(buffer))
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn get_node_hash_by_path(
     req: HttpRequest,
 ) -> actix_web::Result<HttpResponse, OxenHttpError> {
@@ -211,6 +219,7 @@ pub async fn get_node_hash_by_path(
     }))
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn download_tree_nodes(
     req: HttpRequest,
     query: web::Query<TreeDepthQuery>,
@@ -299,6 +308,7 @@ fn get_commit_list(
     Ok(commits)
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn download_node(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;

--- a/crates/server/src/controllers/versions.rs
+++ b/crates/server/src/controllers/versions.rs
@@ -89,6 +89,7 @@ pub async fn clean(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
 
 // TODO: Refactor places that call /file/{resource:*} to use this new version store download endpoint
 /// Download version file
+#[tracing::instrument(skip_all)]
 #[utoipa::path(
     get,
     path = "/api/repos/{namespace}/{repo_name}/versions/{resource}",
@@ -157,6 +158,7 @@ pub async fn download(
 }
 
 /// Batch download version files
+#[tracing::instrument(skip_all)]
 #[utoipa::path(
     post,
     path = "/api/repos/{namespace}/{repo_name}/versions/batch-download",

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -32,7 +32,8 @@ use actix_web_httpauth::middleware::HttpAuthentication;
 use metrics_exporter_prometheus::BuildError;
 use thiserror::Error;
 
-use middleware::RequestIdMiddleware;
+use middleware::{MetricsMiddleware, RequestIdMiddleware};
+use tracing_actix_web::TracingLogger;
 
 // Note: These 'view' imports are all for the auto-generated docs with utoipa
 use liboxen::model::metadata::{
@@ -391,8 +392,6 @@ async fn server() -> Result<(), ServerError> {
 
     util::perf::init_perf_logging();
 
-    let _metrics_guard = init_metrics();
-
     let sync_dir = match env::var("SYNC_DIR") {
         Ok(dir) => PathBuf::from(dir),
         Err(_) => PathBuf::from("data"),
@@ -549,6 +548,8 @@ async fn start(
                 "%a \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %T %{x-oxen-request-id}o",
             ))
             .wrap(RequestIdMiddleware)
+            .wrap(MetricsMiddleware)
+            .wrap(TracingLogger::default())
     })
     .bind((host.to_owned(), port))?
     .run()

--- a/crates/server/src/middleware.rs
+++ b/crates/server/src/middleware.rs
@@ -5,6 +5,7 @@ use actix_web::{
 use futures_util::future::LocalBoxFuture;
 use liboxen::request_context::REQUEST_ID;
 use std::future::{Ready, ready};
+use std::time::Instant;
 // Oxen request Id
 pub const OXEN_REQUEST_ID: &str = "x-oxen-request-id";
 
@@ -81,6 +82,95 @@ where
                 Ok(res)
             },
         ))
+    }
+}
+
+/// Middleware that records HTTP request count and latency for every route.
+///
+/// Emits two Prometheus metrics per request:
+///   - `http_requests_total{method, path, status}` — counter
+///   - `http_request_duration_ms{method, path}` — histogram (milliseconds)
+///
+/// The `path` label uses the matched Actix route pattern (e.g.
+/// `/api/repos/{namespace}/{repo_name}/branches`) to keep cardinality low.
+pub struct MetricsMiddleware;
+
+impl<S, B> Transform<S, ServiceRequest> for MetricsMiddleware
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = MetricsMiddlewareService<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(MetricsMiddlewareService { service }))
+    }
+}
+
+pub struct MetricsMiddlewareService<S> {
+    service: S,
+}
+
+impl<S, B> Service<ServiceRequest> for MetricsMiddlewareService<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let start = Instant::now();
+        let method = req.method().to_string();
+
+        let fut = self.service.call(req);
+
+        Box::pin(async move {
+            match fut.await {
+                Ok(res) => {
+                    let status = res.status().as_u16().to_string();
+                    let path = res
+                        .request()
+                        .match_pattern()
+                        .unwrap_or_else(|| "unmatched".to_string());
+                    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+                    metrics::counter!("http_requests_total", "method" => method.clone(), "path" => path.clone(), "status" => status.clone())
+                        .increment(1);
+                    if res.status().is_client_error() || res.status().is_server_error() {
+                        metrics::counter!("http_errors_total", "method" => method.clone(), "path" => path.clone(), "status" => status)
+                            .increment(1);
+                    }
+                    metrics::histogram!("http_request_duration_ms", "method" => method, "path" => path)
+                        .record(elapsed_ms);
+
+                    Ok(res)
+                }
+                Err(err) => {
+                    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+                    let status = "500";
+                    let path = "unmatched";
+
+                    metrics::counter!("http_requests_total", "method" => method.clone(), "path" => path, "status" => status)
+                        .increment(1);
+                    metrics::counter!("http_errors_total", "method" => method.clone(), "path" => path, "status" => status)
+                        .increment(1);
+                    metrics::histogram!("http_request_duration_ms", "method" => method, "path" => path)
+                        .record(elapsed_ms);
+
+                    Err(err)
+                }
+            }
+        })
     }
 }
 

--- a/x/x.txt
+++ b/x/x.txt
@@ -1,0 +1,3 @@
+hello world! how are you today?
+
+fine I hope!

--- a/y/test-clone/x.txt
+++ b/y/test-clone/x.txt
@@ -1,0 +1,1 @@
+hello world! how are you today?


### PR DESCRIPTION
Adds a new `"production"` flag to all crates. The intention is to enable
this flag whenever one needs to build and use `oxen` in a production setting.
This feature flag enables ffmpeg thumbnail support in `liboxen` as well as 
OTel telemetry in all crates.

Added README documentation explaining how and when to use this flag.

Also adds a new CI job that runs concurrently with the lint and the other
test jobs. This job makes sure that there are no regressions with the
`"production"`-feature gated code by building the workspace with it
enabled. Additionally, it makes sure that logfile writing is working, makes
sure that we can write spans as log events, and sets up an OTel collector
to ensure that `oxen-server` can push its telemetry events successfully.