### PR TITLE
Add oxen branch -f and oxen push --force

### DIFF
--- a/crates/cli/src/cmd/branch.rs
+++ b/crates/cli/src/cmd/branch.rs
@@ -196,6 +196,7 @@ impl BranchCmd {
         name: &str,
         commit_id: &str,
     ) -> Result<(), OxenError> {
+        log::info!("Force updating branch '{name}' to {commit_id}");
         let branch = repositories::branches::update(repo, name, commit_id)?;
         println!("Updated branch '{}' to {}", branch.name, branch.commit_id);
         Ok(())

--- a/crates/cli/src/cmd/branch.rs
+++ b/crates/cli/src/cmd/branch.rs
@@ -29,7 +29,20 @@ impl RunCmd for BranchCmd {
         Command::new(NAME)
             .about("Manage branches in repository")
             .subcommand(unlock::BranchUnlockCmd.args())
-            .arg(Arg::new("name").help("Name of the branch").exclusive(true))
+            .arg(Arg::new("name").help("Name of the branch"))
+            .arg(
+                Arg::new("commit_id")
+                    .help("Commit ID to point the branch to (used with --force)")
+                    .requires("force"),
+            )
+            .arg(
+                Arg::new("force")
+                    .long("force")
+                    .short('f')
+                    .help("Force update an existing branch to point to a specific commit")
+                    .requires("name")
+                    .action(clap::ArgAction::SetTrue),
+            )
             .arg(
                 Arg::new("all")
                     .long("all")
@@ -95,7 +108,14 @@ impl RunCmd for BranchCmd {
                 self.list_remote_branches(&repo, remote_name).await
             }
         } else if let Some(name) = args.get_one::<String>("name") {
-            self.create_branch(&repo, name)
+            if args.get_flag("force") {
+                let commit_id = args
+                    .get_one::<String>("commit_id")
+                    .ok_or_else(|| OxenError::basic_str("Must supply a commit ID with --force"))?;
+                self.force_update_branch(&repo, name, commit_id)
+            } else {
+                self.create_branch(&repo, name)
+            }
         } else if let Some(name) = args.get_one::<String>("delete") {
             self.delete_branch(&repo, name)
         } else if let Some(name) = args.get_one::<String>("force-delete") {
@@ -167,6 +187,17 @@ impl BranchCmd {
 
     pub fn create_branch(&self, repo: &LocalRepository, name: &str) -> Result<(), OxenError> {
         repositories::branches::create_from_head(repo, name)?;
+        Ok(())
+    }
+
+    pub fn force_update_branch(
+        &self,
+        repo: &LocalRepository,
+        name: &str,
+        commit_id: &str,
+    ) -> Result<(), OxenError> {
+        let branch = repositories::branches::force_update(repo, name, commit_id)?;
+        println!("Updated branch '{}' to {}", branch.name, branch.commit_id);
         Ok(())
     }
 

--- a/crates/cli/src/cmd/branch.rs
+++ b/crates/cli/src/cmd/branch.rs
@@ -196,7 +196,7 @@ impl BranchCmd {
         name: &str,
         commit_id: &str,
     ) -> Result<(), OxenError> {
-        let branch = repositories::branches::force_update(repo, name, commit_id)?;
+        let branch = repositories::branches::update(repo, name, commit_id)?;
         println!("Updated branch '{}' to {}", branch.name, branch.commit_id);
         Ok(())
     }

--- a/crates/cli/src/cmd/push.rs
+++ b/crates/cli/src/cmd/push.rs
@@ -54,6 +54,13 @@ impl RunCmd for PushCmd {
                     .help("Revalidate file hashes on remote and push any missing files.")
                     .action(clap::ArgAction::SetTrue)
             )
+            .arg(
+                Arg::new("force")
+                    .long("force")
+                    .short('f')
+                    .help("Force push even if the remote branch is not a fast-forward")
+                    .action(clap::ArgAction::SetTrue)
+            )
     }
 
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
@@ -73,6 +80,7 @@ impl RunCmd for PushCmd {
                 (false, None)
             };
         let revalidate = args.get_flag("revalidate");
+        let force = args.get_flag("force");
 
         let repo = LocalRepository::from_current_dir()?;
         let current_branch = repositories::branches::current_branch(&repo)?;
@@ -90,6 +98,7 @@ impl RunCmd for PushCmd {
             remote: remote.to_string(),
             branch: branch_name,
             delete,
+            force,
             missing_files,
             missing_files_commit_id,
             revalidate,

--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -129,9 +129,10 @@ async fn push_to_existing_branch(
 
     match repositories::commits::list_from(repo, &commit.id) {
         Ok(commits) => {
-            if commits.iter().any(|c| c.id == remote_branch.commit_id) {
-                //we're ahead
+            let is_ahead = commits.iter().any(|c| c.id == remote_branch.commit_id);
 
+            if is_ahead {
+                // Fast-forward: push only the new commits
                 let latest_remote_commit =
                     repositories::commits::get_by_id(repo, &remote_branch.commit_id)?.ok_or_else(
                         || OxenError::RevisionNotFound(remote_branch.commit_id.clone().into()),
@@ -143,10 +144,17 @@ async fn push_to_existing_branch(
 
                 push_commits(repo, remote_repo, Some(latest_remote_commit), commits, opts).await?;
                 api::client::branches::update(remote_repo, &remote_branch.name, commit).await?;
+            } else if opts.force {
+                // Force push: push the full history and update the branch pointer
+                let latest_remote_commit = find_latest_remote_commit(repo, remote_repo).await?;
+                let history = repositories::commits::list_from(repo, &commit.id)?;
+
+                push_commits(repo, remote_repo, latest_remote_commit, history, opts).await?;
+                api::client::branches::update(remote_repo, &remote_branch.name, commit).await?;
             } else {
-                //we're behind
+                // Behind and not forcing
                 let err_str = format!(
-                    "Branch {} is behind remote commit {}.\nRun `oxen pull` to update your local branch",
+                    "Branch {} is behind remote commit {}.\nRun `oxen pull` to update your local branch, or use `oxen push --force` to force push.",
                     remote_branch.name, remote_branch.commit_id
                 );
                 return Err(OxenError::basic_str(err_str));

--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -146,6 +146,11 @@ async fn push_to_existing_branch(
                 api::client::branches::update(remote_repo, &remote_branch.name, commit).await?;
             } else if opts.force {
                 // Force push: push the full history and update the branch pointer
+                log::info!(
+                    "Force pushing branch '{}' to {}",
+                    &remote_branch.name,
+                    commit.id
+                );
                 let latest_remote_commit = find_latest_remote_commit(repo, remote_repo).await?;
                 let history = repositories::commits::list_from(repo, &commit.id)?;
 

--- a/crates/lib/src/opts/push_opts.rs
+++ b/crates/lib/src/opts/push_opts.rs
@@ -3,6 +3,7 @@ pub struct PushOpts {
     pub remote: String,
     pub branch: String,
     pub delete: bool,
+    pub force: bool,
     pub missing_files: bool,
     pub missing_files_commit_id: Option<String>,
     pub revalidate: bool,

--- a/crates/lib/src/repositories/branches.rs
+++ b/crates/lib/src/repositories/branches.rs
@@ -112,6 +112,23 @@ pub fn create_checkout(repo: &LocalRepository, name: impl AsRef<str>) -> Result<
     })
 }
 
+/// Force update a branch to point to a specific commit id, validating the commit exists.
+/// Creates the branch if it doesn't exist.
+pub fn force_update(
+    repo: &LocalRepository,
+    name: impl AsRef<str>,
+    commit_id: impl AsRef<str>,
+) -> Result<Branch, OxenError> {
+    let name = name.as_ref();
+    let commit_id = commit_id.as_ref();
+
+    if !repositories::commits::commit_id_exists(repo, commit_id)? {
+        return Err(OxenError::commit_id_does_not_exist(commit_id));
+    }
+
+    update(repo, name, commit_id)
+}
+
 /// Update the branch name to point to a commit id
 pub fn update(
     repo: &LocalRepository,

--- a/crates/lib/src/repositories/branches.rs
+++ b/crates/lib/src/repositories/branches.rs
@@ -112,9 +112,9 @@ pub fn create_checkout(repo: &LocalRepository, name: impl AsRef<str>) -> Result<
     })
 }
 
-/// Force update a branch to point to a specific commit id, validating the commit exists.
-/// Creates the branch if it doesn't exist.
-pub fn force_update(
+/// Update the branch name to point to a commit id, creating the branch if it doesn't exist.
+/// Validates that the commit exists before updating.
+pub fn update(
     repo: &LocalRepository,
     name: impl AsRef<str>,
     commit_id: impl AsRef<str>,
@@ -126,24 +126,14 @@ pub fn force_update(
         return Err(OxenError::commit_id_does_not_exist(commit_id));
     }
 
-    update(repo, name, commit_id)
-}
-
-/// Update the branch name to point to a commit id
-pub fn update(
-    repo: &LocalRepository,
-    name: impl AsRef<str>,
-    commit_id: impl AsRef<str>,
-) -> Result<Branch, OxenError> {
-    let name = name.as_ref();
-    let commit_id = commit_id.as_ref();
     with_ref_manager(repo, |manager| {
-        if let Some(branch) = manager.get_branch_by_name(name)? {
+        if let Some(mut branch) = manager.get_branch_by_name(name)? {
             // Set the branch to point to the commit
             manager.set_branch_commit_id(name, commit_id)?;
+            branch.commit_id = commit_id.to_string();
             Ok(branch)
         } else {
-            create(repo, name, commit_id)
+            manager.create_branch(name, commit_id)
         }
     })
 }
@@ -505,7 +495,7 @@ mod tests {
             repositories::branches::create_checkout(&repo, "test-branch")?;
 
             // Force update it back to commit_1
-            repositories::branches::force_update(&repo, "test-branch", &commit_1.id)?;
+            repositories::branches::update(&repo, "test-branch", &commit_1.id)?;
 
             // Verify the branch now points to commit_1
             let fetched = repositories::branches::get_by_name(&repo, "test-branch")?.unwrap();
@@ -522,7 +512,7 @@ mod tests {
             let head = repositories::commits::head_commit(&repo)?;
 
             // Force update a branch that doesn't exist yet
-            let branch = repositories::branches::force_update(&repo, "new-branch", &head.id)?;
+            let branch = repositories::branches::update(&repo, "new-branch", &head.id)?;
             assert_eq!(branch.commit_id, head.id);
             assert_eq!(branch.name, "new-branch");
 
@@ -535,7 +525,7 @@ mod tests {
     async fn test_force_update_invalid_commit_fails() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|repo| async move {
             let result =
-                repositories::branches::force_update(&repo, "test-branch", "nonexistent_commit_id");
+                repositories::branches::update(&repo, "test-branch", "nonexistent_commit_id");
             assert!(result.is_err());
 
             Ok(())

--- a/crates/lib/src/repositories/branches.rs
+++ b/crates/lib/src/repositories/branches.rs
@@ -498,7 +498,7 @@ mod tests {
             repositories::branches::update(&repo, "test-branch", &commit_1.id)?;
 
             // Verify the branch now points to commit_1
-            let fetched = repositories::branches::get_by_name(&repo, "test-branch")?.unwrap();
+            let fetched = repositories::branches::get_by_name(&repo, "test-branch")?;
             assert_eq!(fetched.commit_id, commit_1.id);
 
             Ok(())

--- a/crates/lib/src/repositories/branches.rs
+++ b/crates/lib/src/repositories/branches.rs
@@ -489,6 +489,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_force_update_existing_branch() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            // Create two commits
+            let file_path = repo.path.join("file.txt");
+            util::fs::write_to_path(&file_path, "first")?;
+            repositories::add(&repo, &file_path).await?;
+            let commit_1 = repositories::commit(&repo, "first commit")?;
+
+            util::fs::write_to_path(&file_path, "second")?;
+            repositories::add(&repo, &file_path).await?;
+            let _commit_2 = repositories::commit(&repo, "second commit")?;
+
+            // Create a branch at current HEAD (commit_2)
+            repositories::branches::create_checkout(&repo, "test-branch")?;
+
+            // Force update it back to commit_1
+            repositories::branches::force_update(&repo, "test-branch", &commit_1.id)?;
+
+            // Verify the branch now points to commit_1
+            let fetched = repositories::branches::get_by_name(&repo, "test-branch")?.unwrap();
+            assert_eq!(fetched.commit_id, commit_1.id);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_force_update_creates_new_branch() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let head = repositories::commits::head_commit(&repo)?;
+
+            // Force update a branch that doesn't exist yet
+            let branch = repositories::branches::force_update(&repo, "new-branch", &head.id)?;
+            assert_eq!(branch.commit_id, head.id);
+            assert_eq!(branch.name, "new-branch");
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_force_update_invalid_commit_fails() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let result =
+                repositories::branches::force_update(&repo, "test-branch", "nonexistent_commit_id");
+            assert!(result.is_err());
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
     async fn test_local_delete_branch() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|repo| async move {
             // Get the original branches

--- a/crates/lib/src/repositories/push.rs
+++ b/crates/lib/src/repositories/push.rs
@@ -777,6 +777,78 @@ mod tests {
         .await
     }
 
+    // Test that force push succeeds when the remote is ahead (non-fast-forward)
+    // * Clone repo to user A and user B
+    // * User A makes a commit and pushes
+    // * User B makes a different commit — normal push fails
+    // * User B force pushes — succeeds and remote matches user B's history
+    #[tokio::test]
+    async fn test_force_push_when_remote_is_ahead() -> Result<(), OxenError> {
+        test::run_training_data_fully_sync_remote(|_, remote_repo| async move {
+            let remote_repo_copy = remote_repo.clone();
+
+            // Clone to user A
+            test::run_empty_dir_test_async(|user_a_dir| async move {
+                let user_a_repo = repositories::clone_url(
+                    &remote_repo.remote.url,
+                    &user_a_dir.join("user_a_repo"),
+                )
+                .await?;
+
+                // Clone to user B
+                test::run_empty_dir_test_async(|user_b_dir| async move {
+                    let user_b_repo = repositories::clone_url(
+                        &remote_repo.remote.url,
+                        &user_b_dir.join("user_b_repo"),
+                    )
+                    .await?;
+
+                    // User A modifies README.md and pushes
+                    let a_file = user_a_repo.path.join("README.md");
+                    test::write_txt_file_to_path(a_file, "User A's changes")?;
+                    repositories::add(&user_a_repo, &user_a_repo.path).await?;
+                    repositories::commit(&user_a_repo, "User A commit")?;
+                    repositories::push(&user_a_repo).await?;
+
+                    // User B modifies README.md and tries to push — should fail
+                    let b_file = user_b_repo.path.join("README.md");
+                    test::write_txt_file_to_path(b_file, "User B's changes")?;
+                    repositories::add(&user_b_repo, &user_b_repo.path).await?;
+                    let user_b_commit = repositories::commit(&user_b_repo, "User B commit")?;
+                    let normal_push = repositories::push(&user_b_repo).await;
+                    assert!(normal_push.is_err());
+
+                    // User B force pushes — should succeed
+                    let opts = PushOpts {
+                        remote: DEFAULT_REMOTE_NAME.to_string(),
+                        branch: DEFAULT_BRANCH_NAME.to_string(),
+                        force: true,
+                        ..Default::default()
+                    };
+                    let force_push =
+                        repositories::push::push_remote_branch(&user_b_repo, &opts).await;
+                    assert!(force_push.is_ok());
+
+                    // Verify remote branch now points to user B's commit
+                    let remote_branch =
+                        api::client::branches::get_by_name(&remote_repo, DEFAULT_BRANCH_NAME)
+                            .await?
+                            .unwrap();
+                    assert_eq!(remote_branch.commit_id, user_b_commit.id);
+
+                    Ok(())
+                })
+                .await?;
+
+                Ok(())
+            })
+            .await?;
+
+            Ok(remote_repo_copy)
+        })
+        .await
+    }
+
     // Test that we cannot push when the remote repo is ahead
     // * Clone repo to user A
     // * Clone repo to user B


### PR DESCRIPTION
Adds support for force-updating branches and force-pushing, analogous to git branch -f and git push --force.

- `oxen branch -f <name> <commit_id>`: Point a branch at an arbitrary commit (creates the branch if it doesn't exist). Validates the commit ID exists before updating.
- `oxen push -f`: Allow non-fast-forward pushes to a remote. When the local branch has diverged from the remote,
force push sends the full commit history and updates the remote branch pointer. The existing server PUT /branches
endpoint already supported this; these changes expose it through the CLI.
- Updated the non-force-push error message to hint at --force.