### PR TITLE
Ramdisk for tests

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -94,6 +94,34 @@ jobs:
         with:
           tool: nextest@0.9.114
 
+      # Ramdisk for test data
+      - name: Setup ramdisk (Linux)
+        if: matrix.platform == 'linux'
+        run: |
+          RAMDISK_PATH=$(mktemp -d /dev/shm/oxen_test_XXXXXX)
+          echo "OXEN_TEST_RUN_DIR=$RAMDISK_PATH/test" >> "$GITHUB_ENV"
+          echo "SYNC_DIR=$RAMDISK_PATH/sync" >> "$GITHUB_ENV"
+          mkdir -p "$RAMDISK_PATH/test" "$RAMDISK_PATH/sync"
+
+      - name: Setup ramdisk (macOS)
+        if: matrix.platform == 'macos'
+        run: |
+          RAMDISK_DEV=$(hdiutil attach -nomount ram://8388608 | xargs)  # 4 GB
+          diskutil eraseDisk APFS OxenTest "$RAMDISK_DEV"
+          echo "OXEN_TEST_RUN_DIR=/Volumes/OxenTest/test" >> "$GITHUB_ENV"
+          echo "SYNC_DIR=/Volumes/OxenTest/sync" >> "$GITHUB_ENV"
+          mkdir -p /Volumes/OxenTest/test /Volumes/OxenTest/sync
+
+      - name: Setup ramdisk (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          choco install imdisk -y
+          imdisk -a -s 16G -m R: -p "/fs:ntfs /q /y"
+          echo "OXEN_TEST_RUN_DIR=R:\test" >> $env:GITHUB_ENV
+          echo "SYNC_DIR=R:\sync" >> $env:GITHUB_ENV
+          mkdir R:\test
+          mkdir R:\sync
+
       # Oxen Rust Tests
       - name: Setup test directories (Linux/macOS)
         if: matrix.platform != 'windows'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Test Suite
+  rust-test:
+    name: Rust Tests
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -73,7 +73,9 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
+          prefix-key: rust-test
+          # TODO: Commented out to test caching. Uncomment before merging.
+          #          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
           cache-all-crates: true
           cache-on-failure: true
 
@@ -160,6 +162,119 @@ jobs:
         run: |
           Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start"
           cargo nextest run --workspace --profile ci
+
+  python-test:
+    name: Python Tests
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-x64-8cpu-32ram-300ssd]
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            shell: bash -leo pipefail {0}
+          - os: macos-latest
+            platform: macos
+            shell: bash -leo pipefail {0}
+          - os: windows-x64-8cpu-32ram-300ssd
+            platform: windows
+            shell: powershell
+      fail-fast: false
+
+    steps:
+      - name: Free up disk space
+        if: matrix.platform == 'linux'
+        run: |
+          echo "=== Before cleanup ==="
+          df -h
+
+          # Remove unnecessary tools and files to free up space
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+
+          # Clean apt cache
+          sudo apt-get clean
+
+          echo "=== After cleanup ==="
+          df -h
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          role-duration-seconds: 3600
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ${{ matrix.platform == 'windows' && '-D warnings -C link-arg=/DEBUG:NONE' || '-D warnings' }}
+          cache: false # We use Swatinem/rust-cache directly below for save-if control.
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: python-test
+          # TODO: Commented out to test caching. Uncomment before merging.
+          #          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
+          cache-all-crates: true
+          cache-on-failure: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          python-version: "3.11" # Test against the earliest supported Python version
+
+      - name: Install dependencies (macOS)
+        if: matrix.platform == 'macos'
+        run: |
+          brew update
+          brew install redis pkg-config
+          brew services start redis
+
+      - name: Setup test directories (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: |
+          mkdir -p data/test/runs
+          mkdir -p /tmp/oxen_sync/
+
+      - name: Setup test directories (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          mkdir .\data\test\runs
+
+      - name: Build oxen rust project
+        run: cargo build --workspace
+
+      - name: Setup oxen-server user (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: |
+          ./target/debug/oxen-server add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          cp user_config.toml data/test/config/user_config.toml
+
+      - name: Setup oxen-server user (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          copy user_config.toml data\test\config\user_config.toml
+
+      - name: Start oxen-server (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: ./target/debug/oxen-server start &
+
+      - name: Start oxen-server (Windows)
+        if: matrix.platform == 'windows'
+        run: Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start"
 
       # CLI Tests
       - name: Run CLI tests (Linux/macOS)

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Test Suite
+  rust-test:
+    name: Rust Tests
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -73,7 +73,9 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
+          prefix-key: rust-test
+          # TODO: Commented out to test caching. Uncomment before merging.
+          #          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
           cache-all-crates: true
           cache-on-failure: true
 
@@ -132,6 +134,119 @@ jobs:
         run: |
           Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start"
           cargo nextest run --workspace --profile ci
+
+  python-test:
+    name: Python Tests
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-x64-8cpu-32ram-300ssd]
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            shell: bash -leo pipefail {0}
+          - os: macos-latest
+            platform: macos
+            shell: bash -leo pipefail {0}
+          - os: windows-x64-8cpu-32ram-300ssd
+            platform: windows
+            shell: powershell
+      fail-fast: false
+
+    steps:
+      - name: Free up disk space
+        if: matrix.platform == 'linux'
+        run: |
+          echo "=== Before cleanup ==="
+          df -h
+
+          # Remove unnecessary tools and files to free up space
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+
+          # Clean apt cache
+          sudo apt-get clean
+
+          echo "=== After cleanup ==="
+          df -h
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          role-duration-seconds: 3600
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ${{ matrix.platform == 'windows' && '-D warnings -C link-arg=/DEBUG:NONE' || '-D warnings' }}
+          cache: false # We use Swatinem/rust-cache directly below for save-if control.
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: python-test
+          # TODO: Commented out to test caching. Uncomment before merging.
+          #          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
+          cache-all-crates: true
+          cache-on-failure: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          python-version: "3.11" # Test against the earliest supported Python version
+
+      - name: Install dependencies (macOS)
+        if: matrix.platform == 'macos'
+        run: |
+          brew update
+          brew install redis pkg-config
+          brew services start redis
+
+      - name: Setup test directories (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: |
+          mkdir -p data/test/runs
+          mkdir -p /tmp/oxen_sync/
+
+      - name: Setup test directories (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          mkdir .\data\test\runs
+
+      - name: Build oxen rust project
+        run: cargo build --workspace
+
+      - name: Setup oxen-server user (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: |
+          ./target/debug/oxen-server add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          cp user_config.toml data/test/config/user_config.toml
+
+      - name: Setup oxen-server user (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          copy user_config.toml data\test\config\user_config.toml
+
+      - name: Start oxen-server (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: ./target/debug/oxen-server start &
+
+      - name: Start oxen-server (Windows)
+        if: matrix.platform == 'windows'
+        run: Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start"
 
       # CLI Tests
       - name: Run CLI tests (Linux/macOS)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -883,7 +883,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.1",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -898,7 +898,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -2223,11 +2223,11 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
- "crossterm 0.29.0",
+ "crossterm 0.28.1",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -2553,15 +2553,14 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.29.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.11.0",
  "crossterm_winapi",
- "document-features",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "winapi",
 ]
 
@@ -2937,15 +2936,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2953,12 +2943,13 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "duckdb"
-version = "1.10501.0"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13bc6d6487032fc2825a62ef8b4924b2378a2eb3166e132e5f3141ae9dd633f"
+checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
 dependencies = [
  "arrow",
  "cast",
+ "comfy-table",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3306,7 +3297,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -4431,9 +4422,9 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10501.0"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12096c1694924782b3fe21e790630b77bacb4fcb7ad9d7ee0fec626f985bf248"
+checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
 dependencies = [
  "cc",
  "flate2",
@@ -4640,6 +4631,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -4649,12 +4646,6 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "local-channel"
@@ -6317,7 +6308,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -7332,6 +7323,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -7339,7 +7343,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -8329,7 +8333,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -9943,7 +9947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ dialoguer = "0.11.0"
 difference = "2.0.0"
 dirs = "5.0.1"
 dotenv = "0.15.0"
-duckdb = { package = "duckdb", version = "=1.10501.0", default-features = false, features = ["serde_json"] }
+duckdb = { package = "duckdb", version = "=1.10502.0", default-features = false, features = ["serde_json"] }
 dunce = "1.0.4"
 env_logger = "0.11.3"
 filetime = "0.2.22"
@@ -84,7 +84,7 @@ itertools = "0.13.0"
 jsonwebtoken = "9.3.0"
 jwalk = "0.8.1"
 lazy_static = "1.4.0"
-libduckdb-sys = { version = "=1.10501.0" }
+libduckdb-sys = { version = "=1.10502.0" }
 lofty = "0.22.2"
 log = "0.4.20"
 lru = "0.14.0"

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -54,9 +54,8 @@ cd "$SCRIPT_DIR/.."
 SERVER_PID=""
 RAMDISK_DEV=""
 
-# Create a ramdisk for test data. On macOS this creates an APFS RAM disk via
-# hdiutil; on Linux it uses /dev/shm (tmpfs). Falls back to the regular
-# filesystem if ramdisk creation fails.
+# Create a ramdisk for test data. On macOS this creates an APFS RAM disk via hdiutil; on Linux it
+# uses /dev/shm (tmpfs). Falls back to the regular filesystem if ramdisk creation fails.
 setup_ramdisk() {
     local size_mb=4096
     if [ "$(uname)" = "Darwin" ]; then

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -52,6 +52,41 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
 SERVER_PID=""
+RAMDISK_DEV=""
+
+# Create a ramdisk for test data. On macOS this creates an APFS RAM disk via
+# hdiutil; on Linux it uses /dev/shm (tmpfs). Falls back to the regular
+# filesystem if ramdisk creation fails.
+setup_ramdisk() {
+    local size_mb=4096
+    if [ "$(uname)" = "Darwin" ]; then
+        local sectors=$(( size_mb * 2048 ))  # 512-byte sectors
+        local vol_name="OxenTest_$$"
+        RAMDISK_DEV=$(hdiutil attach -nomount "ram://$sectors" 2>/dev/null | xargs) || return 1
+        diskutil eraseDisk APFS "$vol_name" "$RAMDISK_DEV" >/dev/null 2>&1 || {
+            hdiutil detach "$RAMDISK_DEV" 2>/dev/null
+            RAMDISK_DEV=""
+            return 1
+        }
+        RAMDISK_PATH="/Volumes/$vol_name"
+    else
+        RAMDISK_PATH=$(mktemp -d /dev/shm/oxen_test_XXXXXX 2>/dev/null) || return 1
+    fi
+
+    export OXEN_TEST_RUN_DIR="$RAMDISK_PATH/test"
+    export SYNC_DIR="$RAMDISK_PATH/sync"
+    mkdir -p "$OXEN_TEST_RUN_DIR" "$SYNC_DIR"
+    echo "==> Ramdisk at $RAMDISK_PATH"
+}
+
+cleanup_ramdisk() {
+    if [ "$(uname)" = "Darwin" ] && [ -n "$RAMDISK_DEV" ]; then
+        echo "==> Detaching ramdisk $RAMDISK_DEV..."
+        hdiutil detach "$RAMDISK_DEV" -force 2>/dev/null || true
+    elif [ -n "${RAMDISK_PATH:-}" ] && [[ "${RAMDISK_PATH:-}" == /dev/shm/* ]]; then
+        rm -rf "$RAMDISK_PATH"
+    fi
+}
 
 cleanup() {
     if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
@@ -69,15 +104,18 @@ cleanup() {
         echo "==> Removing test data..."
         rm -rf ./data/ox
         rm -rf ./data/test/runs
-        if [ -n "${OXEN_TEST_RUN_DIR:-}" ]; then
-            rm -rf "$OXEN_TEST_RUN_DIR"
-        fi
+        cleanup_ramdisk
     else
         echo "==> Keeping test data in data/ox and data/test/runs"
     fi
 }
 
 trap cleanup EXIT INT TERM
+
+# Set up ramdisk for test data
+if ! setup_ramdisk; then
+    echo "==> Ramdisk setup failed, using regular filesystem."
+fi
 
 # Ensure all prerequisites are installed
 if [ "$SKIP_DEPS" = false ]; then

--- a/crates/lib/src/api/client/commits.rs
+++ b/crates/lib/src/api/client/commits.rs
@@ -329,9 +329,8 @@ pub async fn download_dir_hashes_from_url(
             // }
 
             log::debug!("unpacking to {full_unpacked_path:?}");
-            let archive_result = archive.unpack(&full_unpacked_path).await;
-            log::debug!("archive_result for url {url} is {archive_result:?}");
-            archive_result?;
+            util::fs::unpack_async_tar_archive(archive, full_unpacked_path).await?;
+            log::debug!("archive_result for url {url} is ok");
 
             // if !full_unpacked_path.exists() {
             //     log::debug!("{} creating {:?}", current_function!(), full_unpacked_path);
@@ -407,9 +406,8 @@ pub async fn download_dir_hashes_db_to_path(
             // create the temp path if it doesn't exist
             util::fs::create_dir_all(&tmp_path)?;
 
-            let archive_result = archive.unpack(&tmp_path).await;
-            log::debug!("archive_result for commit {commit_id:?} is {archive_result:?}");
-            archive_result?;
+            util::fs::unpack_async_tar_archive(archive, &tmp_path).await?;
+            log::debug!("archive_result for commit {commit_id:?} is ok");
 
             if full_unpacked_path.exists() {
                 log::debug!(

--- a/crates/lib/src/api/client/tree.rs
+++ b/crates/lib/src/api/client/tree.rs
@@ -366,14 +366,14 @@ async fn node_download_request(
 
         // Unpack the tar in a temp dir
         log::debug!("node_download_request unpacking to {temp_path:?}");
-        archive.unpack(&temp_path).await?;
+        util::fs::unpack_async_tar_archive(archive, temp_path).await?;
         log::debug!("Succesfully unpacked tar to temp dir");
 
         // Copy to the repo
         util::fs::copy_dir_all(&temp_dir, &full_unpacked_path)?;
     } else {
         // Else, unpack directly to the repo
-        archive.unpack(&full_unpacked_path).await?;
+        util::fs::unpack_async_tar_archive(archive, &full_unpacked_path).await?;
     }
 
     Ok(())

--- a/crates/lib/src/api/client/workspaces/files.rs
+++ b/crates/lib/src/api/client/workspaces/files.rs
@@ -2080,7 +2080,7 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
 
             // Get the absolute path to the file
-            let path = test::test_img_file().canonicalize()?;
+            let path = crate::util::fs::canonicalize(test::test_img_file())?;
             let result = api::client::workspaces::files::add(
                 &remote_repo,
                 &workspace_id,

--- a/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
+++ b/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
@@ -64,7 +64,7 @@ pub fn run_on_all_repos(path: &Path) -> Result<(), OxenError> {
         // Show the canonical namespace path
         log::debug!(
             "This is the namespace path we're walking: {:?}",
-            namespace_path.canonicalize()?
+            util::fs::canonicalize(&namespace_path)?
         );
         let repos = repositories::list_repos_in_namespace(&namespace_path);
         for repo in repos {
@@ -73,7 +73,7 @@ pub fn run_on_all_repos(path: &Path) -> Result<(), OxenError> {
                 Err(err) => {
                     log::error!(
                         "Could not migrate version files for repo {:?}\nErr: {}",
-                        repo.path.canonicalize(),
+                        util::fs::canonicalize(&repo.path),
                         err
                     )
                 }

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -358,6 +358,9 @@ pub enum OxenError {
     // TODO: remove all uses of `Basic` and replace with specific errors.
     #[error("{0}")]
     Basic(StringError),
+
+    #[error("{0}")]
+    InternalError(StringError),
 }
 
 impl OxenError {
@@ -555,6 +558,11 @@ impl OxenError {
     /// Make a new OxenError::Basic error.
     pub fn basic_str(s: impl AsRef<str>) -> Self {
         OxenError::Basic(StringError::from(s.as_ref()))
+    }
+
+    /// Make a new OxenError::InternalError error.
+    pub fn internal_error(s: impl AsRef<str>) -> Self {
+        OxenError::InternalError(StringError::from(s.as_ref()))
     }
 
     //

--- a/crates/lib/src/repositories/add.rs
+++ b/crates/lib/src/repositories/add.rs
@@ -767,7 +767,7 @@ A: Oxen.ai
     /// Checks that only the expected relative paths exist from the given root.
     /// Ignores any relative paths that start with one of the [ignore_prefixes].
     async fn expect_filesystem(root: &Path, expected_relative: &[&Path], ignore_prefixes: &[&str]) {
-        let root = root.canonicalize().expect("could not canonicalize");
+        let root = util::fs::canonicalize(root).expect("could not canonicalize root");
 
         let all_from_root: HashSet<PathBuf> = {
             let mut all_from_root = HashSet::new();
@@ -775,7 +775,8 @@ A: Oxen.ai
             loop {
                 match entries.next().await {
                     Some(Ok(entry)) => {
-                        let path = entry.path().canonicalize().expect("could not canonicalize");
+                        let path = util::fs::canonicalize(entry.path())
+                            .expect("could not canonicalize entry");
                         if let Some(relative) = ensure_relative(&root, &path) {
                             if relative.as_os_str().is_empty() {
                                 continue;

--- a/crates/lib/src/repositories/diffs.rs
+++ b/crates/lib/src/repositories/diffs.rs
@@ -1933,7 +1933,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             util::fs::write_to_path(&file2, "hello\nhi\nhow are you doing?")?;
 
             let opts = DiffOpts {
-                repo_dir: Some(dir.canonicalize()?),
+                repo_dir: Some(util::fs::canonicalize(&dir)?),
                 path_1: file1,
                 path_2: Some(file2),
                 keys: vec![],

--- a/crates/lib/src/repositories/load.rs
+++ b/crates/lib/src/repositories/load.rs
@@ -1,6 +1,7 @@
-use flate2::read::GzDecoder;
-use std::{fs::File, path::Path};
-use tar::Archive;
+use async_compression::futures::bufread::GzipDecoder;
+use async_tar::Archive;
+use std::path::Path;
+use tokio_util::compat::TokioAsyncReadCompatExt;
 
 use crate::constants::DEFAULT_BRANCH_NAME;
 use crate::repositories;
@@ -25,11 +26,12 @@ pub async fn load(
         dest_path.to_path_buf()
     };
 
-    let file = File::open(src_path)?;
-    let tar = GzDecoder::new(file);
+    let file = tokio::fs::File::open(src_path).await?;
+    let reader = futures::io::BufReader::new(file.compat());
+    let decoder = GzipDecoder::new(reader);
+    let archive = Archive::new(decoder);
     println!("🐂 Decompressing oxen repo into {dest_path:?}");
-    let mut archive = Archive::new(tar);
-    archive.unpack(&dest_path)?;
+    util::fs::unpack_async_tar_archive(archive, &dest_path).await?;
 
     // Server repos - done unpacking
     if no_working_dir {

--- a/crates/lib/src/repositories/remote_mode/status.rs
+++ b/crates/lib/src/repositories/remote_mode/status.rs
@@ -321,7 +321,7 @@ mod tests {
                 assert!(cloned_repo.is_remote_mode());
 
                 let repo_path = cloned_repo.path.clone();
-                log::debug!("Cloned repo path: {:?}", cloned_repo.path.canonicalize());
+                log::debug!("Cloned repo path: {:?}", util::fs::canonicalize(&cloned_repo.path));
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
                 let directory = ".".to_string();
 

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -1022,7 +1022,7 @@ pub fn canonicalize(path: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
             if path.is_absolute() {
                 Ok(path.to_path_buf())
             } else {
-                Ok(std::env::current_dir()?.join(path))
+                Ok(std::path::absolute(path)?)
             }
         }
         Err(e) => Err(OxenError::basic_str(format!(

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -1697,7 +1697,7 @@ pub async fn unpack_async_tar_archive<R: futures_util::AsyncRead + Unpin>(
 
         let entry_type = file.header().entry_type();
         if !entry_type.is_file() && !entry_type.is_dir() {
-            return Err(crate::error::OxenError::basic_str(format!(
+            return Err(crate::error::OxenError::internal_error(format!(
                 "Unsupported archive entry type for {}: only regular files and directories \
                  are allowed",
                 path.display()
@@ -1709,7 +1709,7 @@ pub async fn unpack_async_tar_archive<R: futures_util::AsyncRead + Unpin>(
             match part {
                 Component::Normal(part) => file_dst.push(part),
                 Component::ParentDir => {
-                    return Err(crate::error::OxenError::basic_str(format!(
+                    return Err(crate::error::OxenError::internal_error(format!(
                         "Path traversal detected in archive entry: {}",
                         path.display()
                     )));

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -1010,14 +1010,20 @@ pub fn canonicalize(path: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
     let path = path.as_ref();
     match dunce::canonicalize(path) {
         Ok(canon_path) => Ok(canon_path),
-        Err(_) => {
+        Err(e) if e.kind() == std::io::ErrorKind::Unsupported => {
             // Fallback: convert to absolute path without symlink resolution.
+            // This is needed on filesystems whose drivers don't implement
+            // canonicalization (e.g. Windows imdisk ramdisks return
+            // ERROR_INVALID_FUNCTION which maps to ErrorKind::Unsupported).
             if path.is_absolute() {
                 Ok(path.to_path_buf())
             } else {
                 Ok(std::env::current_dir()?.join(path))
             }
         }
+        Err(e) => Err(OxenError::basic_str(format!(
+            "path {path:?} cannot be canonicalized: {e}"
+        ))),
     }
 }
 

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -1003,18 +1003,17 @@ pub fn is_canonical(path: impl AsRef<Path>) -> Result<bool, OxenError> {
     Ok(false)
 }
 
-// Return canonicalized path if possible. Falls back to converting to an absolute path
-// without symlink resolution, which is needed on filesystems that don't support
-// canonicalization (e.g. Windows imdisk ramdisks).
+// Return canonicalized path if possible. Falls back to converting to an absolute path without
+// symlink resolution, which is needed on filesystems that don't support canonicalization (e.g.
+// Windows imdisk ramdisks).
 pub fn canonicalize(path: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
     let path = path.as_ref();
     match dunce::canonicalize(path) {
         Ok(canon_path) => Ok(canon_path),
         Err(e) if e.kind() == std::io::ErrorKind::Unsupported => {
-            // Fallback: convert to absolute path without symlink resolution.
-            // This is needed on filesystems whose drivers don't implement
-            // canonicalization (e.g. Windows imdisk ramdisks return
-            // ERROR_INVALID_FUNCTION which maps to ErrorKind::Unsupported).
+            // Fallback: convert to absolute path without symlink resolution. This is needed on
+            // filesystems whose drivers don't implement canonicalization (e.g. Windows imdisk
+            // ramdisks return ERROR_INVALID_FUNCTION which maps to ErrorKind::Unsupported).
             if path.is_absolute() {
                 Ok(path.to_path_buf())
             } else {
@@ -1676,11 +1675,10 @@ pub fn validate_and_normalize_path(path: impl AsRef<Path>) -> Result<PathBuf, Ox
     Ok(normalized)
 }
 
-/// Unpack an async-tar archive to a destination directory without calling
-/// `canonicalize`. This is needed because `archive.unpack()` and
-/// `entry.unpack_in()` internally call `std::fs::canonicalize`, which fails on
-/// filesystems that don't support it (e.g. Windows imdisk ramdisks). Path
-/// traversal is checked by rejecting parent components.
+/// Unpack an async-tar archive to a destination directory without calling `canonicalize`. This is
+/// needed because `archive.unpack()` and `entry.unpack_in()` internally call
+/// `std::fs::canonicalize`, which fails on filesystems that don't support it (e.g. Windows imdisk
+/// ramdisks). Path traversal is checked by rejecting parent components.
 pub async fn unpack_async_tar_archive<R: futures_util::AsyncRead + Unpin>(
     archive: async_tar::Archive<R>,
     dst: &Path,

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -1003,15 +1003,21 @@ pub fn is_canonical(path: impl AsRef<Path>) -> Result<bool, OxenError> {
     Ok(false)
 }
 
-// Return canonicalized path if possible, otherwise return original
+// Return canonicalized path if possible. Falls back to converting to an absolute path
+// without symlink resolution, which is needed on filesystems that don't support
+// canonicalization (e.g. Windows imdisk ramdisks).
 pub fn canonicalize(path: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
     let path = path.as_ref();
-    //log::debug!("Path to canonicalize: {path:?}");
     match dunce::canonicalize(path) {
         Ok(canon_path) => Ok(canon_path),
-        Err(err) => Err(OxenError::basic_str(format!(
-            "path {path:?} cannot be canonicalized due to err {err:?}"
-        ))),
+        Err(_) => {
+            // Fallback: convert to absolute path without symlink resolution.
+            if path.is_absolute() {
+                Ok(path.to_path_buf())
+            } else {
+                Ok(std::env::current_dir()?.join(path))
+            }
+        }
     }
 }
 
@@ -1662,6 +1668,66 @@ pub fn validate_and_normalize_path(path: impl AsRef<Path>) -> Result<PathBuf, Ox
     }
 
     Ok(normalized)
+}
+
+/// Unpack an async-tar archive to a destination directory without calling
+/// `canonicalize`. This is needed because `archive.unpack()` and
+/// `entry.unpack_in()` internally call `std::fs::canonicalize`, which fails on
+/// filesystems that don't support it (e.g. Windows imdisk ramdisks). Path
+/// traversal is checked by rejecting parent components.
+pub async fn unpack_async_tar_archive<R: futures_util::AsyncRead + Unpin>(
+    archive: async_tar::Archive<R>,
+    dst: &Path,
+) -> Result<(), crate::error::OxenError> {
+    create_dir_all(dst)?;
+
+    let mut entries = archive.entries()?;
+    while let Some(entry) = entries.next().await {
+        let mut file = entry?;
+        let path = file.path()?.to_path_buf();
+
+        let entry_type = file.header().entry_type();
+        if entry_type.is_symlink() || entry_type.is_hard_link() {
+            return Err(crate::error::OxenError::basic_str(format!(
+                "Symlinks/hard links not allowed in archive: {}",
+                path.display()
+            )));
+        }
+
+        let mut file_dst = dst.to_path_buf();
+        for part in path.components() {
+            match part {
+                Component::Normal(part) => file_dst.push(part),
+                Component::ParentDir => {
+                    return Err(crate::error::OxenError::basic_str(format!(
+                        "Path traversal detected in archive entry: {}",
+                        path.display()
+                    )));
+                }
+                _ => continue,
+            }
+        }
+
+        // Skip empty paths (e.g. entries that were only "." or "/")
+        if file_dst == dst {
+            continue;
+        }
+
+        if file.header().entry_type().is_dir() {
+            create_dir_all(&file_dst)?;
+        } else {
+            if let Some(parent) = file_dst.parent() {
+                create_dir_all(parent)?;
+            }
+            file.unpack(&file_dst).await.map_err(|e| {
+                crate::error::OxenError::basic_str(format!(
+                    "Failed to unpack {}: {e}",
+                    file_dst.display()
+                ))
+            })?;
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -1010,10 +1010,15 @@ pub fn canonicalize(path: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
     let path = path.as_ref();
     match dunce::canonicalize(path) {
         Ok(canon_path) => Ok(canon_path),
-        Err(e) if e.kind() == std::io::ErrorKind::Unsupported => {
+        Err(e)
+            if e.kind() == std::io::ErrorKind::Unsupported
+                // On Windows, ERROR_INVALID_FUNCTION (os error 1) from ramdisk drivers maps
+                // to Uncategorized rather than Unsupported, so also check the raw code.
+                || (cfg!(windows) && e.raw_os_error() == Some(1)) =>
+        {
             // Fallback: convert to absolute path without symlink resolution. This is needed on
             // filesystems whose drivers don't implement canonicalization (e.g. Windows imdisk
-            // ramdisks return ERROR_INVALID_FUNCTION which maps to ErrorKind::Unsupported).
+            // ramdisks).
             if path.is_absolute() {
                 Ok(path.to_path_buf())
             } else {

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -1693,9 +1693,10 @@ pub async fn unpack_async_tar_archive<R: futures_util::AsyncRead + Unpin>(
         let path = file.path()?.to_path_buf();
 
         let entry_type = file.header().entry_type();
-        if entry_type.is_symlink() || entry_type.is_hard_link() {
+        if !entry_type.is_file() && !entry_type.is_dir() {
             return Err(crate::error::OxenError::basic_str(format!(
-                "Symlinks/hard links not allowed in archive: {}",
+                "Unsupported archive entry type for {}: only regular files and directories \
+                 are allowed",
                 path.display()
             )));
         }
@@ -1719,7 +1720,7 @@ pub async fn unpack_async_tar_archive<R: futures_util::AsyncRead + Unpin>(
             continue;
         }
 
-        if file.header().entry_type().is_dir() {
+        if entry_type.is_dir() {
             create_dir_all(&file_dst)?;
         } else {
             if let Some(parent) = file_dst.parent() {

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -1260,6 +1260,10 @@ async fn unpack_entry_tarball_async(
                     _ => continue,
                 }
             }
+            // Skip empty paths (e.g. entries that were only "." or "/")
+            if dest == hidden_dir {
+                continue;
+            }
             if let Some(parent) = dest.parent() {
                 util::fs::create_dir_all(parent)?;
             }

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -1240,9 +1240,10 @@ async fn unpack_entry_tarball_async(
             // because unpack_in() calls canonicalize() internally, which fails on Windows ramdisks
             // (imdisk).
             let entry_type = file.header().entry_type();
-            if entry_type.is_symlink() || entry_type.is_hard_link() {
+            if !entry_type.is_file() && !entry_type.is_dir() {
                 return Err(OxenError::basic_str(format!(
-                    "Symlinks/hard links not allowed in archive: {}",
+                    "Unsupported archive entry type for {}: only regular files and \
+                     directories are allowed",
                     path.display()
                 )));
             }

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -1236,8 +1236,33 @@ async fn unpack_entry_tarball_async(
                 .store_version_from_reader(&hash, Box::new(file), entry_size)
                 .await?;
         } else {
-            // For non-version files, unpack to hidden dir
-            file.unpack_in(&hidden_dir)
+            // We manually construct the path and check for traversal instead of using unpack_in(),
+            // because unpack_in() calls canonicalize() internally, which fails on Windows ramdisks
+            // (imdisk).
+            let entry_type = file.header().entry_type();
+            if entry_type.is_symlink() || entry_type.is_hard_link() {
+                return Err(OxenError::basic_str(format!(
+                    "Symlinks/hard links not allowed in archive: {}",
+                    path.display()
+                )));
+            }
+            let mut dest = hidden_dir.clone();
+            for component in path.components() {
+                match component {
+                    std::path::Component::Normal(part) => dest.push(part),
+                    std::path::Component::ParentDir => {
+                        return Err(OxenError::basic_str(format!(
+                            "Path traversal detected in archive entry: {}",
+                            path.display()
+                        )));
+                    }
+                    _ => continue,
+                }
+            }
+            if let Some(parent) = dest.parent() {
+                util::fs::create_dir_all(parent)?;
+            }
+            file.unpack(&dest)
                 .await
                 .map_err(|e| OxenError::basic_str(format!("Failed to unpack file: {e}")))?;
         }

--- a/crates/server/src/errors.rs
+++ b/crates/server/src/errors.rs
@@ -498,7 +498,7 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::InternalServerError().json(error_json)
                     }
-                    OxenError::Basic(error) => {
+                    OxenError::Basic(error) | OxenError::InternalError(error) => {
                         let error_json = json!({
                             "error": {
                                 "type": MSG_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
Experiment with using a ramdisk, and the changes needed to enable doing that.

The hope here is that we can speed up tests, especially in CI. On my M5, I only saw a ~5% speedup. Hopefully the speedup in CI will be more significant, especially on Windows (which is by far the slowest).

I suspect that most of our test time is currently being eaten by sync code in oxen-server that's blocking the tokio runtime during concurrent tests, but that will take a lot of fixing to speed up, so I'll be more than happy if we can squeeze out 10% improvement with simple usage of a ramdisk.

- Rust changes: the standard library's `canonicalize` method doesn't work on ramdisks on Windows, which is where we need the ramdisk most (even without a ramdisk, macos and linux run tests more than twice as fast as Windows when Windows is on 4x beefier hardware). The Rust code changes work around this by using a custom implementation that has a fallback on Windows.

---

**Update**: Excellent results! ~11% speedup. From 13.5m to 12m.

<img width="807" height="707" alt="image" src="https://github.com/user-attachments/assets/87beb42f-f82b-41a7-b267-140bcfd43f31" />
