### PR TITLE
Implement server-side merging (aka Fix Many Merge Bugs™)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -115,13 +115,14 @@ oxen push origin main               # Push to remote
 - When prompted to always do something a certain way in general, add an entry to this section of the CLAUDE.md file.
 - When calling `get_staged_db_manager`, follow the doc comment on that function: drop the returned `StagedDBManager` as soon as possible (via a block scope or explicit `drop()`) to avoid holding the shared database handle longer than necessary.
 - When altering the `OxenError` enum, consider whether a hint needs to be added or updated in the `hint` method.
-- After changing any Rust code, verify that tests pass with the `bin/test-rust` script (not `cargo`). The script is documented in a comment at the top of its file.
+- Instead of using `cargo test` to test Rust code, use the `bin/test-rust` script. The script usage is documented in a comment at the top of its file.
 - Prefer using inline code over creating a new function when the function would only be called once and the function body would be less than 15 lines.
 - Preserve comments whenever possible. Comments that were written by someone other than Claude should always be preserved or updated if possible.
 - The Python project calls into the Rust project. Whenever changing the Rust code, check to see if the Python code needs to be updated.
 - After changing any Rust or Python code, verify that Rust tests pass with `bin/test-rust` and Python tests pass with `bin/test-rust -p`
 - When updating a dependency, prefer updating to the latest stable version.
 - Any new or changed Rust code that touches IO (file system, network, etc.) should be async code. Instead of std::io or std::fs, use equivalents from tokio. When an external dependency doesn't support async, use tokio's spawn_blocking functionality.
+- oxen-server operations should never touch a local checkout on disk when doing operations initiated by its API.
 
 # Testing Rules
 - Use the test helpers in `crates/lib/src/test.rs` (e.g., `run_empty_local_repo_test`) for unit tests in the lib code.

--- a/crates/lib/src/core/v_latest/commits.rs
+++ b/crates/lib/src/core/v_latest/commits.rs
@@ -456,18 +456,34 @@ pub fn list_recursive_paginated(
     Ok((results, total_count))
 }
 
+/// Mark all ancestors of `commit` as visited and return the number of
+/// newly-visited ancestors.  The commit itself is assumed to already be in the
+/// visited set (the caller inserts it), so we start from its parents.
 fn mark_ancestors_visited(
     repo: &LocalRepository,
     commit: &Commit,
     visited: &mut HashSet<String>,
-) -> Result<(), OxenError> {
-    let mut stack = vec![commit.clone()];
+) -> Result<usize, OxenError> {
+    let mut newly_visited: usize = 0;
+    let mut stack: Vec<Commit> = Vec::new();
+
+    // Seed the stack with the commit's parents (not the commit itself,
+    // which is already in `visited`).
+    for parent_id in &commit.parent_ids {
+        let parent_id: MerkleHash = parent_id.parse()?;
+        if let Some(parent) = get_by_hash(repo, &parent_id)?
+            && !visited.contains(&parent.id)
+        {
+            stack.push(parent);
+        }
+    }
 
     while let Some(current) = stack.pop() {
         if visited.contains(&current.id) {
             continue;
         }
         visited.insert(current.id.clone());
+        newly_visited += 1;
 
         for parent_id in current.parent_ids.clone() {
             let parent_id: MerkleHash = parent_id.parse()?;
@@ -479,7 +495,7 @@ fn mark_ancestors_visited(
         }
     }
 
-    Ok(())
+    Ok(newly_visited)
 }
 
 /// Wrapper to order commits by timestamp descending in a BinaryHeap (max-heap).
@@ -541,17 +557,19 @@ fn traverse_commits(
             continue;
         }
 
-        // Check cache
+        // Check cache — use 1 (this commit) + newly-visited ancestors so that
+        // shared ancestors between merge parents are not double-counted.
         if let Some(db) = config.cache_db
-            && let Some(cached_count) = get_cached_count(db, &commit.id)?
+            && let Some(_cached_count) = get_cached_count(db, &commit.id)?
         {
+            let newly_visited = mark_ancestors_visited(config.repo, &commit, config.visited)?;
             log::debug!(
-                "Found cached count for commit {}: {} commits",
+                "Cache hit for commit {}: cached={}, newly_visited={}",
                 &commit.id[..8],
-                cached_count
+                _cached_count,
+                newly_visited
             );
-            mark_ancestors_visited(config.repo, &commit, config.visited)?;
-            count += cached_count;
+            count += 1 + newly_visited;
             continue;
         }
 

--- a/crates/lib/src/core/v_latest/diff.rs
+++ b/crates/lib/src/core/v_latest/diff.rs
@@ -181,6 +181,8 @@ pub async fn list_diff_entries(
         head_commit,
         &mut dir_entries,
         &base_path,
+        &base_files,
+        &head_files,
     )?;
     dir_entries.sort_by(|a, b| a.filename.cmp(&b.filename));
     log::debug!(
@@ -554,6 +556,7 @@ fn collect_removed_directories(
 }
 
 // Find the directories that are in HEAD and are in BASE
+#[allow(clippy::too_many_arguments)]
 fn collect_modified_directories(
     repo: &LocalRepository,
     base_dirs: &HashSet<DirNodeWithPath>,
@@ -562,13 +565,15 @@ fn collect_modified_directories(
     head_commit: &Commit,
     diff_entries: &mut Vec<DiffEntry>,
     base_path: impl AsRef<Path>,
+    base_files: &HashSet<FileNodeWithDir>,
+    head_files: &HashSet<FileNodeWithDir>,
 ) -> Result<(), OxenError> {
     let base_path = base_path.as_ref();
     for head_dir in head_dirs {
         // HEAD entry is in BASE
         if let Some(base_dir) = base_dirs.get(head_dir) {
             log::debug!("collect_modified_directories adding dir {head_dir:?}");
-            let diff_entry = DiffEntry::from_dir_nodes(
+            let mut diff_entry = DiffEntry::from_dir_nodes(
                 repo,
                 base_path.join(&head_dir.path),
                 Some(base_dir.dir_node.clone()),
@@ -579,6 +584,45 @@ fn collect_modified_directories(
             )?;
 
             if diff_entry.has_changes() {
+                // Compute accurate per-directory counts from actual file diffs
+                // rather than relying on net file-count differences.
+                let dir_path = &head_dir.path;
+                let dir_base: HashSet<FileNodeWithDir> = base_files
+                    .iter()
+                    .filter(|f| f.dir.starts_with(dir_path))
+                    .cloned()
+                    .collect();
+                let dir_head: HashSet<FileNodeWithDir> = head_files
+                    .iter()
+                    .filter(|f| f.dir.starts_with(dir_path))
+                    .cloned()
+                    .collect();
+
+                let added = dir_head.difference(&dir_base).count();
+                let removed = dir_base.difference(&dir_head).count();
+                let modified = dir_head
+                    .intersection(&dir_base)
+                    .filter(|f| {
+                        // FileNodeWithDir equality is by name — check if
+                        // the actual content hash changed.
+                        dir_base
+                            .get(f)
+                            .is_some_and(|b| b.file_node.hash() != f.file_node.hash())
+                    })
+                    .count();
+
+                diff_entry.diff_summary = Some(GenericDiffSummary::DirDiffSummary(
+                    crate::model::diff::dir_diff_summary::DirDiffSummary {
+                        dir: crate::model::diff::dir_diff_summary::DirDiffSummaryImpl {
+                            file_counts: AddRemoveModifyCounts {
+                                added,
+                                removed,
+                                modified,
+                            },
+                        },
+                    },
+                ));
+
                 diff_entries.push(diff_entry);
             }
         }

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -335,9 +335,38 @@ pub async fn merge(
         base: base_commit,
         merge: merge_commit,
     };
-    merge_commits(repo, &commits).await
+    merge_commits(repo, &commits, true).await
 }
 
+/// Server-safe merge of two commits. Does not touch the working directory or
+/// HEAD — the caller is responsible for updating the branch ref.
+///
+/// Use this variant from server code paths that must not mutate on-disk files.
+/// For the client-side equivalent that updates the checkout and HEAD, see
+/// [`merge_commit_into_base`].
+pub async fn merge_commit_into_base_server_safe(
+    repo: &LocalRepository,
+    merge_commit: &Commit,
+    base_commit: &Commit,
+) -> Result<Option<Commit>, OxenError> {
+    let maybe_lca = lowest_common_ancestor_from_commits(repo, base_commit, merge_commit)?;
+    log::debug!(
+        "merge_commit_into_base_server_safe has lca {maybe_lca:?} for merge commit {merge_commit:?} and base {base_commit:?}"
+    );
+
+    let commits = MergeCommits {
+        lca: maybe_lca,
+        base: base_commit.to_owned(),
+        merge: merge_commit.to_owned(),
+    };
+
+    merge_commits(repo, &commits, false).await
+}
+
+/// Client-side merge of two commits. Updates files on disk and advances HEAD.
+///
+/// For the server-side equivalent that never touches the working directory,
+/// see [`merge_commit_into_base_server_safe`].
 pub async fn merge_commit_into_base(
     repo: &LocalRepository,
     merge_commit: &Commit,
@@ -354,7 +383,7 @@ pub async fn merge_commit_into_base(
         merge: merge_commit.to_owned(),
     };
 
-    merge_commits(repo, &commits).await
+    merge_commits(repo, &commits, true).await
 }
 
 /// Server-side merge: merge a commit into a base commit on a specific branch.
@@ -455,16 +484,31 @@ pub fn lowest_common_ancestor(
     lowest_common_ancestor_from_commits(repo, &base_commit, &merge_commit)
 }
 
+/// Fast-forward merge.
+///
+/// When `update_working_dir` is `true` (client-side), the function checks for
+/// uncommitted local changes that would be overwritten, restores/removes files
+/// on disk, and advances HEAD.
+///
+/// When `update_working_dir` is `false` (server-side), no working-directory or
+/// HEAD operations are performed — only the merge commit is returned so the
+/// caller can update the branch ref.
 async fn fast_forward_merge(
     repo: &LocalRepository,
     base_commit: &Commit,
     merge_commit: &Commit,
+    update_working_dir: bool,
 ) -> Result<Option<Commit>, OxenError> {
     log::debug!("FF merge!");
 
     if base_commit == merge_commit {
         // If the base commit is the same as the merge commit, there is nothing to merge
         return Ok(None);
+    }
+
+    if !update_working_dir {
+        // Server-side: no checkout to update, just return the merge commit.
+        return Ok(Some(merge_commit.clone()));
     }
 
     // Collect all dir and vnode hashes while loading the merge tree
@@ -737,9 +781,18 @@ fn r_ff_base_dir(
     Ok(())
 }
 
+/// Perform a merge between commits.
+///
+/// When `update_working_dir` is `true` (client-side), working-directory files
+/// are checked, restored/removed, and HEAD is advanced.
+///
+/// When `update_working_dir` is `false` (server-side), no working-directory or
+/// HEAD operations are performed.  For three-way merges the server-safe
+/// `server_three_way_merge` path is used instead.
 async fn merge_commits(
     repo: &LocalRepository,
     merge_commits: &MergeCommits,
+    update_working_dir: bool,
 ) -> Result<Option<Commit>, OxenError> {
     // User output
     println!(
@@ -762,8 +815,13 @@ async fn merge_commits(
 
     // Check which type of merge we need to do
     if merge_commits.is_fast_forward_merge() {
-        // User output
-        let commit = fast_forward_merge(repo, &merge_commits.base, &merge_commits.merge).await?;
+        let commit = fast_forward_merge(
+            repo,
+            &merge_commits.base,
+            &merge_commits.merge,
+            update_working_dir,
+        )
+        .await?;
         Ok(commit)
     } else {
         log::debug!(
@@ -771,6 +829,12 @@ async fn merge_commits(
             merge_commits.base.id,
             merge_commits.merge.id
         );
+
+        if !update_working_dir {
+            // Server-safe: use the server three-way merge path which operates
+            // only on tree data and never touches the working directory.
+            return server_three_way_merge(repo, merge_commits).await.map(Some);
+        }
 
         let mut shared_hashes = HashSet::new();
         let analysis = find_merge_conflicts(repo, merge_commits, true, &mut shared_hashes).await?;

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -4,14 +4,16 @@ pub use crate::core::merge::node_merge_conflict_db_reader::NodeMergeConflictDBRe
 use crate::core::merge::node_merge_conflict_reader::NodeMergeConflictReader;
 use crate::core::merge::{db_path, node_merge_conflict_writer};
 use crate::core::refs::with_ref_manager;
+use crate::core::v_latest::add;
 use crate::core::v_latest::commits::{get_commit_or_head, list_between};
-use crate::core::v_latest::{add, rm};
 use crate::error::OxenError;
+use crate::model::StagedEntryStatus;
 use crate::model::merge_conflict::NodeMergeConflict;
+use crate::model::merkle_tree::node::StagedMerkleTreeNode;
+use crate::model::merkle_tree::node::file_node::FileNode;
 use crate::model::merkle_tree::node::{EMerkleTreeNode, MerkleTreeNode};
 use crate::model::{Branch, Commit, LocalRepository};
 use crate::model::{MerkleHash, PartialNode};
-use crate::opts::RmOpts;
 use crate::repositories;
 use crate::repositories::commits::commit_writer;
 use crate::repositories::merge::MergeCommits;
@@ -42,6 +44,15 @@ impl MergeResult {
             cannot_overwrite_entries: vec![],
         }
     }
+}
+
+/// Result of a three-way merge conflict analysis. Contains both the conflicts found and the files
+/// from the merge branch that should be included in the merge result.
+pub struct MergeConflictAnalysis {
+    pub conflicts: Vec<NodeMergeConflict>,
+    /// Files added, modified, or deleted on the merge branch (relative to LCA) that should be
+    /// applied to the base tree. Each entry carries its `StagedEntryStatus`.
+    pub entries: Vec<(PathBuf, FileNode, StagedEntryStatus)>,
 }
 
 pub async fn has_conflicts(
@@ -79,13 +90,10 @@ pub async fn can_merge_commits(
     base_commit: &Commit,
     merge_commit: &Commit,
 ) -> Result<bool, OxenError> {
-    // If there is no common ancestor, there are no merge conflicts
-    let Some(lca) = lowest_common_ancestor_from_commits(repo, base_commit, merge_commit)? else {
-        return Ok(true);
-    };
+    let lca = lowest_common_ancestor_from_commits(repo, base_commit, merge_commit)?;
 
     let merge_commits = MergeCommits {
-        lca: Some(lca),
+        lca,
         base: base_commit.clone(),
         merge: merge_commit.clone(),
     };
@@ -95,10 +103,9 @@ pub async fn can_merge_commits(
         return Ok(true);
     }
 
-    let write_to_disk = false;
     let mut _hashes = HashSet::new();
-    let conflicts = find_merge_conflicts(repo, &merge_commits, write_to_disk, &mut _hashes).await?;
-    Ok(conflicts.is_empty())
+    let analysis = find_merge_conflicts(repo, &merge_commits, false, &mut _hashes).await?;
+    Ok(analysis.conflicts.is_empty())
 }
 
 pub async fn list_conflicts_between_branches(
@@ -159,20 +166,17 @@ pub async fn list_conflicts_between_commits(
     base_commit: &Commit,
     merge_commit: &Commit,
 ) -> Result<Vec<PathBuf>, OxenError> {
-    // If there is no common ancestor, there are no merge conflicts
-    let Some(lca) = lowest_common_ancestor_from_commits(repo, base_commit, merge_commit)? else {
-        return Ok(vec![]);
-    };
+    let lca = lowest_common_ancestor_from_commits(repo, base_commit, merge_commit)?;
 
     let merge_commits = MergeCommits {
-        lca: Some(lca),
+        lca,
         base: base_commit.clone(),
         merge: merge_commit.clone(),
     };
-    let write_to_disk = false;
     let mut _hashes = HashSet::new();
-    let conflicts = find_merge_conflicts(repo, &merge_commits, write_to_disk, &mut _hashes).await?;
-    Ok(conflicts
+    let analysis = find_merge_conflicts(repo, &merge_commits, false, &mut _hashes).await?;
+    Ok(analysis
+        .conflicts
         .iter()
         .map(|c| {
             let (_, path) = &c.base_entry;
@@ -181,35 +185,139 @@ pub async fn list_conflicts_between_commits(
         .collect())
 }
 
-/// Merge a branch into a base branch, returns the merge commit if successful, and None if there is conflicts
+/// Server-side merge: merge a branch into a base branch.
+/// Updates the base branch ref on success. Does not modify the working directory or HEAD.
+///
+/// See the docs for merge_commits for details on how three-way merging works, including definitions
+/// of the terms used.
+///
+/// # Errors
+/// - `OxenError::UpstreamMergeConflict` if the branches have conflicting changes.
+/// - Other `OxenError` variants for internal failures (missing commits, tree corruption, etc.).
 pub async fn merge_into_base(
     repo: &LocalRepository,
     merge_branch: &Branch,
     base_branch: &Branch,
-) -> Result<Option<Commit>, OxenError> {
+) -> Result<Commit, OxenError> {
     log::debug!("merge_into_base merge {merge_branch} into {base_branch}");
 
     if merge_branch.commit_id == base_branch.commit_id {
-        // If the merge branch is the same as the base branch, there is nothing to merge
-        return Ok(None);
+        return Err(OxenError::basic_str("No changes to merge"));
     }
 
     let base_commit = get_commit_or_head(repo, Some(base_branch.commit_id.clone()))?;
     let merge_commit = get_commit_or_head(repo, Some(merge_branch.commit_id.clone()))?;
 
-    let lca = lowest_common_ancestor_from_commits(repo, &base_commit, &merge_commit)?;
+    let lca = lowest_common_ancestor_from_commits(repo, &base_commit, &merge_commit)?
+        .ok_or_else(|| OxenError::basic_str("Cannot merge branches with no common ancestor"))?;
     log::debug!("merge_into_base base: {base_commit:?} merge: {merge_commit:?} lca: {lca:?}");
 
     let commits = MergeCommits {
-        lca,
+        lca: Some(lca),
         base: base_commit,
         merge: merge_commit,
     };
 
-    merge_commits(repo, &commits).await
+    let result = if commits.is_fast_forward_merge() {
+        Ok(commits.merge)
+    } else {
+        server_three_way_merge(repo, &commits).await
+    };
+
+    if let Ok(ref commit) = result {
+        repositories::branches::update(repo, &base_branch.name, &commit.id)?;
+    }
+
+    result
 }
 
-/// Merge into the current branch, returns the merge commit if successful, and None if there is conflicts
+/// Server-side three-way merge: creates a merge commit from tree data without touching the working
+/// directory. Returns `Err(UpstreamMergeConflict)` if there are conflicts.
+async fn server_three_way_merge(
+    repo: &LocalRepository,
+    merge_commits: &MergeCommits,
+) -> Result<Commit, OxenError> {
+    log::debug!(
+        "server_three_way_merge: base commit {} -> merge commit {}",
+        merge_commits.base.id,
+        merge_commits.merge.id
+    );
+
+    // 1. Find conflicts and collect merge entries in a single tree traversal
+    let mut shared_hashes = HashSet::new();
+    let analysis = find_merge_conflicts(repo, merge_commits, false, &mut shared_hashes).await?;
+
+    if !analysis.conflicts.is_empty() {
+        return Err(OxenError::UpstreamMergeConflict(
+            format!(
+                "Unable to merge {} into {} due to {} conflicts.",
+                merge_commits.merge.id,
+                merge_commits.base.id,
+                analysis.conflicts.len()
+            )
+            .into(),
+        ));
+    }
+
+    if analysis.entries.is_empty() {
+        return Err(OxenError::basic_str("No changes to commit"));
+    }
+
+    // 2. Build dir_entries HashMap (parent dir -> staged nodes) for the commit writer
+    let mut dir_entries: HashMap<PathBuf, Vec<StagedMerkleTreeNode>> = HashMap::new();
+    for (path, file_node, status) in &analysis.entries {
+        let parent = path.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+        dir_entries
+            .entry(parent)
+            .or_default()
+            .push(StagedMerkleTreeNode {
+                status: status.clone(),
+                node: MerkleTreeNode::from_file(file_node.clone()),
+            });
+        // Ensure all ancestor directories are present in dir_entries
+        let mut ancestor = path.to_path_buf();
+        while let Some(p) = ancestor.parent() {
+            ancestor = p.to_path_buf();
+            dir_entries.entry(ancestor.clone()).or_default();
+            if ancestor == Path::new("") {
+                break;
+            }
+        }
+    }
+
+    // TODO: This is reading the server's local user config, but we should use the user/email
+    // that initiated the merge request. If initiated from the client, the client should send it's
+    // local user. If initiated from the hub, the hub should send the user/email of the user who
+    // initiated the merge request.
+    let cfg = crate::config::UserConfig::get()?;
+    let new_commit = crate::model::NewCommitBody {
+        message: merge_commits.commit_message(),
+        author: cfg.name.clone(),
+        email: cfg.email.clone(),
+    };
+
+    let parent_ids = vec![
+        merge_commits.base.id.clone(),
+        merge_commits.merge.id.clone(),
+    ];
+
+    // Pass the base commit ID as the target revision so the existing tree comes from the base
+    // commit (revisions::get resolves commit IDs)
+    let progress = indicatif::ProgressBar::hidden();
+    let commit = commit_writer::commit_dir_entries_with_parents(
+        repo,
+        parent_ids,
+        dir_entries,
+        &new_commit,
+        &progress,
+        &merge_commits.base.id,
+    )?;
+
+    Ok(commit)
+}
+
+/// Client-side merge that alters the local checkout. Merge into the current branch. Returns the
+/// merge commit if successful, and None if there are conflicts
 pub async fn merge(
     repo: &LocalRepository,
     branch_name: impl AsRef<str>,
@@ -220,9 +328,10 @@ pub async fn merge(
 
     let base_commit = repositories::commits::head_commit(repo)?;
     let merge_commit = get_commit_or_head(repo, Some(merge_branch.commit_id.clone()))?;
-    let lca = lowest_common_ancestor_from_commits(repo, &base_commit, &merge_commit)?;
+    let lca = lowest_common_ancestor_from_commits(repo, &base_commit, &merge_commit)?
+        .ok_or_else(|| OxenError::basic_str("Cannot merge branches with no common ancestor"))?;
     let commits = MergeCommits {
-        lca,
+        lca: Some(lca),
         base: base_commit,
         merge: merge_commit,
     };
@@ -234,12 +343,13 @@ pub async fn merge_commit_into_base(
     merge_commit: &Commit,
     base_commit: &Commit,
 ) -> Result<Option<Commit>, OxenError> {
-    let lca = lowest_common_ancestor_from_commits(repo, base_commit, merge_commit)?;
+    let maybe_lca = lowest_common_ancestor_from_commits(repo, base_commit, merge_commit)?;
     log::debug!(
-        "merge_commit_into_base has lca {lca:?} for merge commit {merge_commit:?} and base {base_commit:?}"
+        "merge_commit_into_base has lca {maybe_lca:?} for merge commit {merge_commit:?} and base {base_commit:?}"
     );
+
     let commits = MergeCommits {
-        lca,
+        lca: maybe_lca,
         base: base_commit.to_owned(),
         merge: merge_commit.to_owned(),
     };
@@ -247,25 +357,42 @@ pub async fn merge_commit_into_base(
     merge_commits(repo, &commits).await
 }
 
+/// Server-side merge: merge a commit into a base commit on a specific branch.
+/// Updates the branch ref on success. Does not modify the working directory or HEAD.
+///
+/// # Errors
+/// - `OxenError::UpstreamMergeConflict` if the branches have conflicting changes.
+/// - Other `OxenError` variants for internal failures (missing commits, tree corruption, etc.).
 pub async fn merge_commit_into_base_on_branch(
     repo: &LocalRepository,
     merge_commit: &Commit,
     base_commit: &Commit,
     branch: &Branch,
-) -> Result<Option<Commit>, OxenError> {
-    let lca = lowest_common_ancestor_from_commits(repo, base_commit, merge_commit)?;
+) -> Result<Commit, OxenError> {
+    let lca = lowest_common_ancestor_from_commits(repo, base_commit, merge_commit)?
+        .ok_or_else(|| OxenError::basic_str("Cannot merge commits with no common ancestor"))?;
 
     log::debug!(
         "merge_commit_into_branch has lca {lca:?} for merge commit {merge_commit:?} and base {base_commit:?}"
     );
 
     let merge_commits = MergeCommits {
-        lca,
+        lca: Some(lca),
         base: base_commit.to_owned(),
         merge: merge_commit.to_owned(),
     };
 
-    merge_commits_on_branch(repo, &merge_commits, branch).await
+    let result = if merge_commits.is_fast_forward_merge() {
+        Ok(merge_commits.merge)
+    } else {
+        server_three_way_merge(repo, &merge_commits).await
+    };
+
+    if let Ok(ref commit) = result {
+        repositories::branches::update(repo, &branch.name, &commit.id)?;
+    }
+
+    result
 }
 
 pub fn has_file(repo: &LocalRepository, path: &Path) -> Result<bool, OxenError> {
@@ -310,82 +437,6 @@ pub fn find_merge_commits<S: AsRef<str>>(
         base: head_commit,
         merge: merge_commit,
     })
-}
-
-async fn merge_commits_on_branch(
-    repo: &LocalRepository,
-    merge_commits: &MergeCommits,
-    branch: &Branch,
-) -> Result<Option<Commit>, OxenError> {
-    // User output
-    println!(
-        "merge_commits_on_branch {} -> {}",
-        merge_commits.base.id, merge_commits.merge.id
-    );
-
-    log::debug!(
-        "FOUND MERGE COMMITS:\nLCA: {} -> {}\nBASE: {} -> {}\nMerge: {} -> {}",
-        merge_commits.lca.as_ref().map_or("None", |c| c.id.as_str()),
-        merge_commits
-            .lca
-            .as_ref()
-            .map_or("None", |c| c.message.as_str()),
-        merge_commits.base.id,
-        merge_commits.base.message,
-        merge_commits.merge.id,
-        merge_commits.merge.message,
-    );
-
-    // Check which type of merge we need to do
-    if merge_commits.is_fast_forward_merge() {
-        let commit = fast_forward_merge(repo, &merge_commits.base, &merge_commits.merge).await?;
-        Ok(commit)
-    } else {
-        log::debug!(
-            "Three way merge! {} -> {}",
-            merge_commits.base.id,
-            merge_commits.merge.id
-        );
-
-        let write_to_disk = true;
-        let mut shared_hashes = HashSet::new();
-        let conflicts =
-            find_merge_conflicts(repo, merge_commits, write_to_disk, &mut shared_hashes).await?;
-        log::debug!("Got {} conflicts", conflicts.len());
-
-        if conflicts.is_empty() {
-            log::debug!("creating merge commit on branch {branch:?}");
-            let commit =
-                create_merge_commit_on_branch(repo, merge_commits, branch, shared_hashes).await?;
-            Ok(Some(commit))
-        } else {
-            println!(
-                r"
-Found {} conflicts, please resolve them before merging.
-
-  oxen checkout --theirs path/to/file_1.txt
-  oxen checkout --ours path/to/file_2.txt
-  oxen add path/to/file_1.txt path/to/file_2.txt
-  oxen commit -m 'Merge conflict resolution'
-
-",
-                conflicts.len()
-            );
-            let db_path = db_path(repo);
-            log::debug!("Merger::new() DB {db_path:?}");
-            let opts = db::key_val::opts::default();
-            let merge_db = DB::open(&opts, dunce::simplified(&db_path))?;
-
-            node_merge_conflict_writer::write_conflicts_to_disk(
-                repo,
-                &merge_db,
-                &merge_commits.merge,
-                &merge_commits.base,
-                &conflicts,
-            )?;
-            Ok(None)
-        }
-    }
 }
 
 /// Check if HEAD is in the direct parent chain of the merge commit. If it is a direct parent, we can just fast forward
@@ -721,12 +772,10 @@ async fn merge_commits(
             merge_commits.merge.id
         );
 
-        let write_to_disk = true;
         let mut shared_hashes = HashSet::new();
-        let conflicts =
-            find_merge_conflicts(repo, merge_commits, write_to_disk, &mut shared_hashes).await?;
+        let analysis = find_merge_conflicts(repo, merge_commits, true, &mut shared_hashes).await?;
 
-        if !conflicts.is_empty() {
+        if !analysis.conflicts.is_empty() {
             println!(
                 r"
 Found {} conflicts, please resolve them before merging.
@@ -737,13 +786,13 @@ Found {} conflicts, please resolve them before merging.
   oxen commit -m 'Merge conflict resolution'
 
 ",
-                conflicts.len()
+                analysis.conflicts.len()
             );
         }
 
-        log::debug!("Got {} conflicts", conflicts.len());
+        log::debug!("Got {} conflicts", analysis.conflicts.len());
 
-        if conflicts.is_empty() {
+        if analysis.conflicts.is_empty() {
             let commit = create_merge_commit(repo, merge_commits, shared_hashes).await?;
             Ok(Some(commit))
         } else {
@@ -757,7 +806,7 @@ Found {} conflicts, please resolve them before merging.
                 &merge_db,
                 &merge_commits.merge,
                 &merge_commits.base,
-                &conflicts,
+                &analysis.conflicts,
             )?;
             Ok(None)
         }
@@ -772,11 +821,7 @@ async fn create_merge_commit(
     let base_commit = merge_commits.base.clone();
     add::add_dir_except(repo, &Some(base_commit), repo.path.clone(), shared_hashes).await?;
 
-    let commit_msg = format!(
-        "Merge commit {} into {}",
-        merge_commits.merge.id, merge_commits.base.id
-    );
-
+    let commit_msg = merge_commits.commit_message();
     log::debug!("create_merge_commit {commit_msg}");
 
     let parent_ids: Vec<String> = vec![
@@ -787,43 +832,6 @@ async fn create_merge_commit(
     let commit = commit_writer::commit_with_parent_ids(repo, &commit_msg, parent_ids)?;
 
     // rm::remove_staged(repo, &HashSet::from([PathBuf::from("/")]))?;
-
-    Ok(commit)
-}
-
-async fn create_merge_commit_on_branch(
-    repo: &LocalRepository,
-    merge_commits: &MergeCommits,
-    branch: &Branch,
-    shared_hashes: HashSet<MerkleHash>,
-) -> Result<Commit, OxenError> {
-    let base_commit = merge_commits.base.clone();
-    add::add_dir_except(repo, &Some(base_commit), repo.path.clone(), shared_hashes).await?;
-
-    let commit_msg = format!(
-        "Merge commit {} into {} on branch {}",
-        merge_commits.merge.id, merge_commits.base.id, branch.name
-    );
-
-    log::debug!("create_merge_commit_on_branch {commit_msg}");
-
-    // Create a commit with both parents
-    // let commit_writer = CommitWriter::new(repo)?;
-    let parent_ids: Vec<String> = vec![
-        merge_commits.base.id.to_owned(),
-        merge_commits.merge.id.to_owned(),
-    ];
-
-    // The author in this case is the pusher - the author of the merge commit
-
-    let commit = commit_writer::commit_with_parent_ids(repo, &commit_msg, parent_ids)?;
-    let opts = RmOpts {
-        path: PathBuf::from("/"),
-        staged: true,
-        recursive: true,
-    };
-
-    rm::remove_staged(repo, &HashSet::from([PathBuf::from("/")]), &opts)?;
 
     Ok(commit)
 }
@@ -871,13 +879,15 @@ pub fn lowest_common_ancestor_from_commits(
     }
 }
 
-/// Will try a three way merge and return conflicts if there are any to indicate that the merge was unsuccessful
+/// Analyze a three-way merge between commits. Always returns conflicts and files changed on the
+/// merge branch. When `write_to_disk` is true, also restores non-conflicting merge files to the
+/// working directory (for client-side merges).
 pub async fn find_merge_conflicts(
     repo: &LocalRepository,
     merge_commits: &MergeCommits,
     write_to_disk: bool,
     shared_hashes: &mut HashSet<MerkleHash>,
-) -> Result<Vec<NodeMergeConflict>, OxenError> {
+) -> Result<MergeConflictAnalysis, OxenError> {
     log::debug!("finding merge conflicts");
     /*
     https://en.wikipedia.org/wiki/Merge_(version_control)#Three-way_merge
@@ -902,8 +912,10 @@ pub async fn find_merge_conflicts(
     Sections that are different in all three files are marked as a conflict situation and left for the user to resolve.
     */
 
-    // We will return conflicts if there are any
+    use StagedEntryStatus::*;
+
     let mut conflicts: Vec<NodeMergeConflict> = vec![];
+    let mut entries: Vec<(PathBuf, FileNode, StagedEntryStatus)> = vec![];
     let mut entries_to_restore: Vec<FileToRestore> = vec![];
     let mut cannot_overwrite_entries: Vec<PathBuf> = vec![];
 
@@ -911,21 +923,18 @@ pub async fn find_merge_conflicts(
     let mut lca_hashes = HashSet::new();
     let mut base_hashes = HashSet::new();
 
-    // If there's no LCA, let the LCA be the base commit
-    let lca = merge_commits
-        .lca
-        .clone()
-        .unwrap_or(merge_commits.base.clone());
-
-    // Load in every node from the LCA tree
-    let lca_commit_tree = repositories::tree::get_root_with_children_and_node_hashes(
-        repo,
-        &lca,
-        None,
-        Some(&mut lca_hashes),
-        None,
-    )?
-    .unwrap();
+    // Load in every node from the LCA tree (if there is one)
+    let lca_commit_tree = if let Some(lca) = &merge_commits.lca {
+        repositories::tree::get_root_with_children_and_node_hashes(
+            repo,
+            lca,
+            None,
+            Some(&mut lca_hashes),
+            None,
+        )?
+    } else {
+        None
+    };
 
     // Then, load in only the nodes of the base commit tree that weren't in the LCA tree
     let base_commit_tree = repositories::tree::get_root_with_children_and_node_hashes(
@@ -959,61 +968,54 @@ pub async fn find_merge_conflicts(
 
     let starting_path = PathBuf::from("");
 
-    let lca_entries =
-        repositories::tree::unique_dir_entries(&starting_path, &lca_commit_tree, shared_hashes)?;
+    let lca_entries = if let Some(lca_tree) = &lca_commit_tree {
+        repositories::tree::unique_dir_entries(&starting_path, lca_tree, shared_hashes)?
+    } else {
+        HashMap::new()
+    };
     let base_entries =
         repositories::tree::unique_dir_entries(&starting_path, &base_commit_tree, shared_hashes)?;
-    let merge_entries =
+    let merge_tree_entries =
         repositories::tree::unique_dir_entries(&starting_path, &merge_commit_tree, shared_hashes)?;
 
     log::debug!("lca_entries.len() {}", lca_entries.len());
     log::debug!("base_entries.len() {}", base_entries.len());
-    log::debug!("merge_entries.len() {}", merge_entries.len());
+    log::debug!("merge_tree_entries.len() {}", merge_tree_entries.len());
 
     // Check all the entries in the candidate merge
-    for merge_entry in merge_entries.iter() {
-        let entry_path = merge_entry.0;
-        let merge_file_node = merge_entry.1;
+    for (entry_path, merge_file_node) in &merge_tree_entries {
         // log::debug!("Considering entry {}", entry_path.to_string_lossy());
         // Check if the entry exists in all 3 commits
-        if base_entries.contains_key(entry_path) {
-            let base_file_node = &base_entries[entry_path];
-            if lca_entries.contains_key(entry_path) {
-                let lca_file_node = &lca_entries[entry_path];
-                // If Base and LCA are the same but Merge is different, take merge
-                /*log::debug!(
-                    "Comparing hashes merge_entry {:?} BASE {} LCA {} MERGE {}",
-                    entry_path,
-                    merge_file_node,
-                    base_file_node,
-                    lca_file_node,
+        if let Some(base_file_node) = base_entries.get(entry_path) {
+            if let Some(lca_file_node) = lca_entries.get(entry_path) {
+                // File exists in all three trees
+                let base_eq_lca = base_file_node.combined_hash() == lca_file_node.combined_hash();
+                let base_eq_merge =
+                    base_file_node.combined_hash() == merge_file_node.combined_hash();
 
-                );*/
-                if base_file_node.combined_hash() == lca_file_node.combined_hash()
-                    && base_file_node.combined_hash() != merge_file_node.combined_hash()
-                    && write_to_disk
-                {
-                    log::debug!("top update entry");
-                    if restore::should_restore_file(
-                        repo,
-                        Some(base_file_node.clone()),
-                        merge_file_node,
-                        entry_path,
-                    )? {
-                        entries_to_restore.push(FileToRestore {
-                            file_node: merge_file_node.clone(),
-                            path: entry_path.clone(),
-                        });
-                    } else {
-                        cannot_overwrite_entries.push(merge_entry.0.clone());
+                if base_eq_lca && !base_eq_merge {
+                    // Changed only on merge branch — include in merge result
+                    entries.push((entry_path.clone(), merge_file_node.clone(), Modified));
+                    if write_to_disk {
+                        if restore::should_restore_file(
+                            repo,
+                            Some(base_file_node.clone()),
+                            merge_file_node,
+                            entry_path,
+                        )? {
+                            entries_to_restore.push(FileToRestore {
+                                file_node: merge_file_node.clone(),
+                                path: entry_path.clone(),
+                            });
+                        } else {
+                            cannot_overwrite_entries.push(entry_path.clone());
+                        }
                     }
                 }
 
                 // If all three are different, mark as conflict
-                if base_file_node.combined_hash() != lca_file_node.combined_hash()
-                    && lca_file_node.combined_hash() != merge_file_node.combined_hash()
-                    && base_file_node.combined_hash() != merge_file_node.combined_hash()
-                {
+                let lca_eq_merge = lca_file_node.combined_hash() == merge_file_node.combined_hash();
+                if !base_eq_lca && !lca_eq_merge && !base_eq_merge {
                     conflicts.push(NodeMergeConflict {
                         lca_entry: (lca_file_node.to_owned(), entry_path.to_path_buf()),
                         base_entry: (base_file_node.to_owned(), entry_path.to_path_buf()),
@@ -1021,7 +1023,7 @@ pub async fn find_merge_conflicts(
                     });
                 }
             } else {
-                // merge entry doesn't exist in LCA, so just check if it's different from base
+                // File in base and merge but not LCA — conflict if different
                 if base_file_node.combined_hash() != merge_file_node.combined_hash() {
                     conflicts.push(NodeMergeConflict {
                         lca_entry: (base_file_node.to_owned(), entry_path.to_path_buf()),
@@ -1030,29 +1032,97 @@ pub async fn find_merge_conflicts(
                     });
                 }
             }
-        } else if write_to_disk {
-            log::debug!("bottom update entry {entry_path:?}");
-            let lca_base_node = lca_commit_tree
-                .get_by_path(entry_path)?
-                .and_then(|node| node.file().ok());
+        } else {
+            // File in merge_tree_entries but not in base_entries. This could mean:
+            // (a) base actually deleted it, or
+            // (b) the file's parent dir was shared between LCA and base, so
+            //     unique_dir_entries skipped it — the file still exists in base.
+            // Look up the file in the full base commit tree (not the optimized one which
+            // skips shared directories).
+            let base_file_node =
+                repositories::tree::get_file_by_path(repo, &merge_commits.base, entry_path)?;
 
-            if lca_base_node.is_some()
-                && let Some(parent) = entry_path.parent()
-                && let Some(dir_node) = lca_commit_tree.get_by_path(parent)?
-            {
-                shared_hashes.remove(&dir_node.hash);
-            }
+            if base_file_node.is_some() {
+                // Case (b): file exists in base via a shared directory.
+                // It's changed on merge but not on base — include merge version.
+                entries.push((entry_path.clone(), merge_file_node.clone(), Modified));
+                if write_to_disk {
+                    // Remove the parent dir from shared_hashes so add_dir_except will
+                    // scan this directory when creating the merge commit.
+                    if let Some(parent) = entry_path.parent()
+                        && let Some(lca_tree) = &lca_commit_tree
+                        && let Some(dir_node) = lca_tree.get_by_path(parent)?
+                    {
+                        shared_hashes.remove(&dir_node.hash);
+                    }
 
-            if restore::should_restore_file(repo, lca_base_node, merge_file_node, entry_path)? {
-                entries_to_restore.push(FileToRestore {
-                    file_node: merge_file_node.clone(),
-                    path: entry_path.to_path_buf(),
-                });
+                    if restore::should_restore_file(
+                        repo,
+                        base_file_node,
+                        merge_file_node,
+                        entry_path,
+                    )? {
+                        entries_to_restore.push(FileToRestore {
+                            file_node: merge_file_node.clone(),
+                            path: entry_path.clone(),
+                        });
+                    } else {
+                        cannot_overwrite_entries.push(entry_path.clone());
+                    }
+                }
+            } else if let Some(lca_node) = lca_entries.get(entry_path) {
+                // Case (a): file was in LCA, base deleted it.
+                if lca_node.combined_hash() != merge_file_node.combined_hash() {
+                    // Merge modified it and base deleted it — conflict
+                    conflicts.push(NodeMergeConflict {
+                        lca_entry: (lca_node.to_owned(), entry_path.to_path_buf()),
+                        base_entry: (lca_node.to_owned(), entry_path.to_path_buf()),
+                        merge_entry: (merge_file_node.to_owned(), entry_path.to_path_buf()),
+                    });
+                }
+                // If merge didn't change it from LCA, base's deletion wins
             } else {
-                cannot_overwrite_entries.push(entry_path.clone());
+                // Truly new file on merge branch
+                entries.push((entry_path.clone(), merge_file_node.clone(), Added));
+                if write_to_disk {
+                    if restore::should_restore_file(repo, None, merge_file_node, entry_path)? {
+                        entries_to_restore.push(FileToRestore {
+                            file_node: merge_file_node.clone(),
+                            path: entry_path.to_path_buf(),
+                        });
+                    } else {
+                        cannot_overwrite_entries.push(entry_path.clone());
+                    }
+                }
             }
         }
     }
+
+    // Detect deletions: files in the LCA that are absent from the merge tree and unchanged on base.
+    // Check the full merge tree, not just merge_tree_entries, because unique_dir_entries skips
+    // files in shared directories.
+    for (entry_path, lca_file_node) in &lca_entries {
+        if merge_tree_entries.contains_key(entry_path)
+            || repositories::tree::get_file_by_path(repo, &merge_commits.merge, entry_path)?
+                .is_some()
+        {
+            continue;
+        }
+        if let Some(base_file_node) = base_entries.get(entry_path) {
+            if base_file_node.combined_hash() == lca_file_node.combined_hash() {
+                // Unchanged on base, deleted on merge — delete it
+                entries.push((entry_path.clone(), lca_file_node.clone(), Removed));
+            } else {
+                // Base modified it, merge deleted it — conflict
+                conflicts.push(NodeMergeConflict {
+                    lca_entry: (lca_file_node.to_owned(), entry_path.to_path_buf()),
+                    base_entry: (base_file_node.to_owned(), entry_path.to_path_buf()),
+                    merge_entry: (lca_file_node.to_owned(), entry_path.to_path_buf()),
+                });
+            }
+        }
+    }
+
     log::debug!("three_way_merge conflicts.len() {}", conflicts.len());
 
     // If there are no conflicts, restore the entries
@@ -1094,5 +1164,5 @@ pub async fn find_merge_conflicts(
         return Err(OxenError::cannot_overwrite_files(&cannot_overwrite_entries));
     }
 
-    Ok(conflicts)
+    Ok(MergeConflictAnalysis { conflicts, entries })
 }

--- a/crates/lib/src/repositories/commits.rs
+++ b/crates/lib/src/repositories/commits.rs
@@ -1508,4 +1508,214 @@ A: Oxen.ai
         })
         .await
     }
+
+    #[tokio::test]
+    async fn test_count_from_after_three_way_merge() -> Result<(), OxenError> {
+        // Verifies that count_from returns the correct number of unique commits
+        // after a three-way merge (no double-counting shared ancestors).
+        //
+        // Graph:
+        //   init - A - C - D - M (merge)
+        //             \       /
+        //              B --- E
+        //
+        // init = 1 (from run_one_commit_local_repo_test_async)
+        // A, B, C, D, E = 5 commits on branches
+        // M = merge commit
+        // Total unique commits = 7
+
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let main_branch = repositories::branches::current_branch(&repo)?.unwrap();
+
+            // Commit A on main (shared ancestor)
+            let a_path = repo.path.join("a.txt");
+            util::fs::write_to_path(&a_path, "a")?;
+            repositories::add(&repo, &a_path).await?;
+            repositories::commit(&repo, "Commit A")?;
+
+            // Branch off and create commits B, E
+            let merge_branch_name = "feature";
+            repositories::branches::create_checkout(&repo, merge_branch_name)?;
+            let b_path = repo.path.join("b.txt");
+            util::fs::write_to_path(&b_path, "b")?;
+            repositories::add(&repo, &b_path).await?;
+            repositories::commit(&repo, "Commit B")?;
+
+            let e_path = repo.path.join("e.txt");
+            util::fs::write_to_path(&e_path, "e")?;
+            repositories::add(&repo, &e_path).await?;
+            repositories::commit(&repo, "Commit E")?;
+
+            // Back to main, create commits C, D
+            repositories::checkout(&repo, &main_branch.name).await?;
+            let c_path = repo.path.join("c.txt");
+            util::fs::write_to_path(&c_path, "c")?;
+            repositories::add(&repo, &c_path).await?;
+            repositories::commit(&repo, "Commit C")?;
+
+            let d_path = repo.path.join("d.txt");
+            util::fs::write_to_path(&d_path, "d")?;
+            repositories::add(&repo, &d_path).await?;
+            repositories::commit(&repo, "Commit D")?;
+
+            // Warm the cache for both branch tips before merging
+            let (main_count, _) = repositories::commits::count_from(&repo, &main_branch.name)?;
+            let (feature_count, _) = repositories::commits::count_from(&repo, merge_branch_name)?;
+
+            // main: init -> A -> C -> D = 4 commits
+            assert_eq!(main_count, 4, "main branch should have 4 commits");
+            // feature: init -> A -> B -> E = 4 commits
+            assert_eq!(feature_count, 4, "feature branch should have 4 commits");
+
+            // Merge feature into main
+            let merge_commit = repositories::merge::merge(&repo, merge_branch_name)
+                .await?
+                .expect("merge should produce a commit");
+            assert_eq!(merge_commit.parent_ids.len(), 2);
+
+            // Verify count_from on merge commit
+            let (merge_count, _) = repositories::commits::count_from(&repo, &merge_commit.id)?;
+
+            // Total unique commits: init, A, B, C, D, E, M = 7
+            assert_eq!(
+                merge_count, 7,
+                "merge commit count should be 7 (unique commits), got {merge_count}"
+            );
+
+            // Also verify that list_from returns the same number
+            let all_commits = repositories::commits::list_from(&repo, &merge_commit.id)?;
+            assert_eq!(
+                all_commits.len(),
+                7,
+                "list_from should return 7 commits, got {}",
+                all_commits.len()
+            );
+
+            // count_from should agree with list_from
+            assert_eq!(
+                merge_count,
+                all_commits.len(),
+                "count_from ({merge_count}) should match list_from ({})",
+                all_commits.len()
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_count_from_after_merge_with_deep_shared_history() -> Result<(), OxenError> {
+        // Verifies correct counting when branches share a long history.
+        // The bug would cause near-doubling in this scenario.
+        //
+        // Graph:
+        //   init - H1 - H2 - H3 - H4 - H5 - main_commit - M (merge)
+        //                                    \             /
+        //                                     feat_commit
+        //
+        // Total unique commits = 9
+
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let main_branch = repositories::branches::current_branch(&repo)?.unwrap();
+
+            // Create 5 commits of shared history
+            for i in 1..=5 {
+                let path = repo.path.join(format!("shared_{i}.txt"));
+                util::fs::write_to_path(&path, format!("shared {i}"))?;
+                repositories::add(&repo, &path).await?;
+                repositories::commit(&repo, &format!("Shared commit {i}"))?;
+            }
+
+            // Branch off for feature
+            let merge_branch_name = "feature";
+            repositories::branches::create_checkout(&repo, merge_branch_name)?;
+            let feat_path = repo.path.join("feature.txt");
+            util::fs::write_to_path(&feat_path, "feature")?;
+            repositories::add(&repo, &feat_path).await?;
+            repositories::commit(&repo, "Feature commit")?;
+
+            // Back to main, add one more commit
+            repositories::checkout(&repo, &main_branch.name).await?;
+            let main_path = repo.path.join("main_only.txt");
+            util::fs::write_to_path(&main_path, "main only")?;
+            repositories::add(&repo, &main_path).await?;
+            repositories::commit(&repo, "Main-only commit")?;
+
+            // Warm cache for both branches
+            let (main_count, _) = repositories::commits::count_from(&repo, &main_branch.name)?;
+            let (feature_count, _) = repositories::commits::count_from(&repo, merge_branch_name)?;
+            assert_eq!(main_count, 7, "main: init + 5 shared + 1 main-only = 7");
+            assert_eq!(feature_count, 7, "feature: init + 5 shared + 1 feature = 7");
+
+            // Merge
+            let merge_commit = repositories::merge::merge(&repo, merge_branch_name)
+                .await?
+                .expect("merge should produce a commit");
+
+            let (merge_count, _) = repositories::commits::count_from(&repo, &merge_commit.id)?;
+
+            // Unique: init + 5 shared + main_only + feat + merge = 9
+            let all_commits = repositories::commits::list_from(&repo, &merge_commit.id)?;
+            assert_eq!(
+                merge_count,
+                all_commits.len(),
+                "count_from ({merge_count}) should match list_from ({})",
+                all_commits.len()
+            );
+            assert_eq!(merge_count, 9, "should be 9, got {merge_count}");
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_count_from_after_merge_no_prior_cache() -> Result<(), OxenError> {
+        // Verifies correct count when parent branch counts are NOT cached
+        // before the merge (no warm-up step).
+
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let main_branch = repositories::branches::current_branch(&repo)?.unwrap();
+
+            let a_path = repo.path.join("a.txt");
+            util::fs::write_to_path(&a_path, "a")?;
+            repositories::add(&repo, &a_path).await?;
+            repositories::commit(&repo, "Commit A")?;
+
+            // Branch and commit
+            repositories::branches::create_checkout(&repo, "feature")?;
+            let b_path = repo.path.join("b.txt");
+            util::fs::write_to_path(&b_path, "b")?;
+            repositories::add(&repo, &b_path).await?;
+            repositories::commit(&repo, "Commit B")?;
+
+            // Back to main and commit
+            repositories::checkout(&repo, &main_branch.name).await?;
+            let c_path = repo.path.join("c.txt");
+            util::fs::write_to_path(&c_path, "c")?;
+            repositories::add(&repo, &c_path).await?;
+            repositories::commit(&repo, "Commit C")?;
+
+            // Merge WITHOUT warming cache first
+            let merge_commit = repositories::merge::merge(&repo, "feature")
+                .await?
+                .expect("merge should produce a commit");
+
+            let (merge_count, _) = repositories::commits::count_from(&repo, &merge_commit.id)?;
+            let all_commits = repositories::commits::list_from(&repo, &merge_commit.id)?;
+
+            // init, A, B, C, M = 5
+            assert_eq!(
+                merge_count,
+                all_commits.len(),
+                "count_from ({merge_count}) should match list_from ({})",
+                all_commits.len()
+            );
+            assert_eq!(merge_count, 5, "should be 5, got {merge_count}");
+
+            Ok(())
+        })
+        .await
+    }
 }

--- a/crates/lib/src/repositories/commits/commit_writer.rs
+++ b/crates/lib/src/repositories/commits/commit_writer.rs
@@ -151,7 +151,6 @@ pub fn commit_with_cfg(
             parent_ids,
             dir_entries,
             &new_commit,
-            staged_db,
             &commit_progress_bar,
             maybe_branch_name
                 .clone()
@@ -159,14 +158,13 @@ pub fn commit_with_cfg(
         )?
     } else {
         log::debug!("no parent ids, committing new");
-        commit_dir_entries_new(
-            repo,
-            dir_entries,
-            &new_commit,
-            staged_db,
-            &commit_progress_bar,
-        )?
+        commit_dir_entries_new(repo, dir_entries, &new_commit, &commit_progress_bar)?
     };
+
+    // Clear the staged db
+    let staged_db_path = staged_db.path().to_owned();
+    drop(staged_db);
+    util::fs::remove_dir_all(staged_db_path)?;
 
     // Write HEAD file and update branch
     let head_path = util::fs::oxen_hidden_dir(&repo.path).join(HEAD_FILE);
@@ -202,7 +200,6 @@ pub fn commit_dir_entries_with_parents(
     parent_commits: Vec<String>,
     dir_entries: HashMap<PathBuf, Vec<StagedMerkleTreeNode>>,
     new_commit: &NewCommitBody,
-    staged_db: DBWithThreadMode<SingleThreaded>,
     commit_progress_bar: &ProgressBar,
     target_branch: impl AsRef<str>,
 ) -> Result<Commit, OxenError> {
@@ -301,13 +298,6 @@ pub fn commit_dir_entries_with_parents(
     )?;
     commit_progress_bar.finish_and_clear();
 
-    // Clear the staged db
-    // Close the connection before removing the staged db
-    let staged_db_path = staged_db.path().to_owned();
-    drop(staged_db);
-
-    // Clear the staged db
-    util::fs::remove_dir_all(staged_db_path)?;
     Ok(node.to_commit())
 }
 
@@ -315,7 +305,6 @@ pub fn commit_dir_entries_new(
     repo: &LocalRepository,
     dir_entries: HashMap<PathBuf, Vec<StagedMerkleTreeNode>>,
     new_commit: &NewCommitBody,
-    staged_db: DBWithThreadMode<SingleThreaded>,
     commit_progress_bar: &ProgressBar,
 ) -> Result<Commit, OxenError> {
     let message = &new_commit.message;
@@ -408,13 +397,6 @@ pub fn commit_dir_entries_new(
 
     // Remove all the directories that are staged for removal
     cleanup_rm_dirs(&dir_hash_db, &dir_entries)?;
-
-    // Close the connection before removing the staged db
-    let staged_db_path = staged_db.path().to_owned();
-    drop(staged_db);
-
-    // Clear the staged db
-    util::fs::remove_dir_all(staged_db_path)?;
 
     Ok(node.to_commit())
 }
@@ -1043,13 +1025,9 @@ fn compute_dir_node(
         "Aggregating dir {path:?} for [{commit_id}] with {children:?} children num_bytes {num_bytes:?} data_type_counts {data_type_counts:?}"
     );
     let head_commit_maybe = repositories::commits::head_commit_maybe(repo)?;
-    if let Some(head_commit) = head_commit_maybe
-        && let Ok(Some(old_dir_node)) = repositories::tree::get_dir_without_children(
-            repo,
-            &head_commit,
-            &path,
-            Some(dir_hashes),
-        )
+    if let Some(ref head_commit) = head_commit_maybe
+        && let Ok(Some(old_dir_node)) =
+            repositories::tree::get_dir_without_children(repo, head_commit, &path, Some(dir_hashes))
     {
         let old_dir_node = old_dir_node.dir().unwrap();
         num_entries = old_dir_node.num_entries();
@@ -1109,6 +1087,26 @@ fn compute_dir_node(
                                     .entry(file_node.data_type().to_string())
                                     .or_insert(0) += file_node.num_bytes();
                             }
+                            StagedEntryStatus::Modified => {
+                                // The old size is already included in
+                                // num_bytes/data_type_sizes from the parent commit.
+                                // Look up the old file to compute the delta.
+                                if let Some(head) = &head_commit_maybe
+                                    && let Some(old_file) = repositories::tree::get_file_by_path(
+                                        repo,
+                                        head,
+                                        path.join(file_node.name()),
+                                    )?
+                                {
+                                    let delta =
+                                        file_node.num_bytes() as i64 - old_file.num_bytes() as i64;
+                                    num_bytes = (num_bytes as i64 + delta) as u64;
+                                    let size_entry = data_type_sizes
+                                        .entry(file_node.data_type().to_string())
+                                        .or_insert(0);
+                                    *size_entry = (*size_entry as i64 + delta) as u64;
+                                }
+                            }
                             _ => {
                                 // Do nothing
                             }
@@ -1129,22 +1127,21 @@ fn compute_dir_node(
                 EMerkleTreeNode::Directory(_) => {
                     // Do nothing
                 }
-                EMerkleTreeNode::File(_) => {
-                    // log::debug!(
-                    //     "Updating hash for file {} -> hash {} status {:?}",
-                    //     file_node.name(),
-                    //     file_node.hash(),
-                    //     entry.status
-                    // );
-
-                    match entry.status {
-                        StagedEntryStatus::Removed => {
-                            if path == *child {
-                                num_entries -= 1;
-                            }
+                EMerkleTreeNode::File(file_node) => {
+                    if entry.status == StagedEntryStatus::Removed {
+                        if path == *child {
+                            num_entries -= 1;
                         }
-                        _ => {
-                            // Do nothing
+                        num_bytes = num_bytes.saturating_sub(file_node.num_bytes());
+                        if let Some(count) =
+                            data_type_counts.get_mut(&file_node.data_type().to_string())
+                        {
+                            *count = count.saturating_sub(1);
+                        }
+                        if let Some(size) =
+                            data_type_sizes.get_mut(&file_node.data_type().to_string())
+                        {
+                            *size = size.saturating_sub(file_node.num_bytes());
                         }
                     }
                 }

--- a/crates/lib/src/repositories/merge.rs
+++ b/crates/lib/src/repositories/merge.rs
@@ -15,8 +15,12 @@ pub struct MergeCommits {
 }
 
 impl MergeCommits {
+    pub fn commit_message(&self) -> String {
+        format!("Merge commit {} into {}", self.merge.id, self.base.id)
+    }
+
     pub fn is_fast_forward_merge(&self) -> bool {
-        self.lca.is_some() && self.lca.as_ref().unwrap().id == self.base.id
+        self.lca.as_ref().is_some_and(|lca| lca.id == self.base.id)
     }
 }
 
@@ -116,7 +120,7 @@ pub async fn merge_into_base(
     repo: &LocalRepository,
     merge_branch: &Branch,
     base_branch: &Branch,
-) -> Result<Option<Commit>, OxenError> {
+) -> Result<Commit, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::merge::merge_into_base(repo, merge_branch, base_branch).await,
@@ -149,7 +153,7 @@ pub async fn merge_commit_into_base_on_branch(
     merge_commit: &Commit,
     base_commit: &Commit,
     branch: &Branch,
-) -> Result<Option<Commit>, OxenError> {
+) -> Result<Commit, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => {
@@ -291,14 +295,14 @@ mod tests {
             let merge_branch = repositories::branches::current_branch(&repo)?.unwrap();
 
             // Checkout and merge additions
-            let og_branch = repositories::checkout(&repo, &og_branch.name)
+            let _og_branch = repositories::checkout(&repo, &og_branch.name)
                 .await?
                 .unwrap();
 
             // Make sure world file doesn't exist until we merge it in
             assert!(!world_file.exists());
 
-            let commit = repositories::merge::merge_into_base(&repo, &merge_branch, &og_branch)
+            let commit = repositories::merge::merge(&repo, &merge_branch.name)
                 .await?
                 .unwrap();
 
@@ -1140,6 +1144,818 @@ mod tests {
             // Verify the other files are still intact
             assert!(b_path.exists());
             assert!(other_path.exists());
+
+            Ok(())
+        })
+        .await
+    }
+
+    // --- Client-side merge tests for delete edge cases ---
+
+    #[tokio::test]
+    async fn test_merge_client_base_deletes_merge_unchanged() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // LCA: create two files
+            let file_a = repo.path.join("a.txt");
+            let file_b = repo.path.join("b.txt");
+            util::fs::write_to_path(&file_a, "a")?;
+            util::fs::write_to_path(&file_b, "b")?;
+            repositories::add(&repo, &file_a).await?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::commit(&repo, "Adding a.txt and b.txt")?;
+
+            // Feature branch makes an unrelated change (doesn't touch a.txt)
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::write_to_path(&file_b, "b modified on feature")?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::commit(&repo, "Modifying b.txt on feature")?;
+
+            // Main branch deletes a.txt
+            repositories::checkout(&repo, &base_branch_name).await?;
+            util::fs::remove_file(&file_a)?;
+            repositories::add(&repo, &file_a).await?;
+            repositories::commit(&repo, "Deleting a.txt on main")?;
+
+            // Merge feature into main — base's deletion of a.txt should be preserved
+            let merge_commit = repositories::merge::merge(&repo, "feature").await?;
+            assert!(merge_commit.is_some());
+
+            // a.txt should still be deleted in working dir (base's deletion wins)
+            assert!(
+                !file_a.exists(),
+                "a.txt should remain deleted after merge — base's deletion wins"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_client_modify_delete_conflict() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // LCA: create a file
+            let file = repo.path.join("shared.txt");
+            util::fs::write_to_path(&file, "original")?;
+            repositories::add(&repo, &file).await?;
+            repositories::commit(&repo, "Adding shared.txt")?;
+
+            // Feature branch modifies the file
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::write_to_path(&file, "modified on feature")?;
+            repositories::add(&repo, &file).await?;
+            repositories::commit(&repo, "Modifying shared.txt on feature")?;
+
+            // Main branch deletes the same file
+            repositories::checkout(&repo, &base_branch_name).await?;
+            util::fs::remove_file(&file)?;
+            repositories::add(&repo, &file).await?;
+            repositories::commit(&repo, "Deleting shared.txt on main")?;
+
+            // Merge should detect conflict (delete on base + modify on merge)
+            let merge_result = repositories::merge::merge(&repo, "feature").await?;
+            assert!(
+                merge_result.is_none(),
+                "Delete on base + modify on merge should be a conflict"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_client_delete_modify_conflict() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // LCA: create a file
+            let file = repo.path.join("shared.txt");
+            util::fs::write_to_path(&file, "original")?;
+            repositories::add(&repo, &file).await?;
+            repositories::commit(&repo, "Adding shared.txt")?;
+
+            // Feature branch deletes the file
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::remove_file(&file)?;
+            repositories::add(&repo, &file).await?;
+            repositories::commit(&repo, "Deleting shared.txt on feature")?;
+
+            // Main branch modifies the same file
+            repositories::checkout(&repo, &base_branch_name).await?;
+            util::fs::write_to_path(&file, "modified on main")?;
+            repositories::add(&repo, &file).await?;
+            repositories::commit(&repo, "Modifying shared.txt on main")?;
+
+            // Merge should detect conflict (modify on base + delete on merge)
+            let merge_result = repositories::merge::merge(&repo, "feature").await?;
+            assert!(
+                merge_result.is_none(),
+                "Modify on base + delete on merge should be a conflict"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    // --- Server-side merge tests (merge_into_base) ---
+
+    #[tokio::test]
+    async fn test_merge_into_base_fast_forward() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch = repositories::branches::current_branch(&repo)?.unwrap();
+
+            // Add a file and commit on main
+            let hello_file = repo.path.join("hello.txt");
+            util::fs::write_to_path(&hello_file, "Hello")?;
+            repositories::add(&repo, &hello_file).await?;
+            repositories::commit(&repo, "Adding hello file")?;
+
+            // Create a feature branch and add a commit
+            repositories::branches::create_checkout(&repo, "feature")?;
+            let world_file = repo.path.join("world.txt");
+            util::fs::write_to_path(&world_file, "World")?;
+            repositories::add(&repo, &world_file).await?;
+            repositories::commit(&repo, "Adding world file")?;
+
+            // Go back to main so HEAD is on the base branch
+            repositories::checkout(&repo, &base_branch.name).await?;
+
+            // Re-fetch branches to get current commit IDs
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch.name)?;
+
+            // Server-side merge: should succeed and update the branch ref
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+
+            assert_eq!(merge_commit.id, merge_branch.commit_id);
+
+            // The base branch ref should now point to the merge commit
+            let updated_branch = repositories::branches::get_by_name(&repo, &base_branch.name)?;
+            assert_eq!(updated_branch.commit_id, merge_commit.id);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_three_way_no_conflicts() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // Commit a file on main (LCA)
+            let a_file = repo.path.join("a.txt");
+            util::fs::write_to_path(&a_file, "a")?;
+            repositories::add(&repo, &a_file).await?;
+            repositories::commit(&repo, "Adding a.txt")?;
+
+            // Create feature branch and add a different file
+            repositories::branches::create_checkout(&repo, "feature")?;
+            let b_file = repo.path.join("b.txt");
+            util::fs::write_to_path(&b_file, "b")?;
+            repositories::add(&repo, &b_file).await?;
+            repositories::commit(&repo, "Adding b.txt on feature")?;
+
+            // Go back to main and add another different file (diverge)
+            repositories::checkout(&repo, &base_branch_name).await?;
+            let c_file = repo.path.join("c.txt");
+            util::fs::write_to_path(&c_file, "c")?;
+            repositories::add(&repo, &c_file).await?;
+            repositories::commit(&repo, "Adding c.txt on main")?;
+
+            // Re-fetch branches
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch_name)?;
+
+            // Server-side three-way merge should succeed
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+
+            // Merge commit should have two parents
+            assert_eq!(merge_commit.parent_ids.len(), 2);
+            assert!(merge_commit.parent_ids.contains(&base_branch.commit_id));
+            assert!(merge_commit.parent_ids.contains(&merge_branch.commit_id));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_three_way_with_conflicts() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // Commit a file on main (LCA)
+            let labels_file = repo.path.join("labels.txt");
+            util::fs::write_to_path(&labels_file, "cat\ndog")?;
+            repositories::add(&repo, &labels_file).await?;
+            repositories::commit(&repo, "Adding labels.txt")?;
+
+            // Create feature branch and modify the same file
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::write_to_path(&labels_file, "cat\ndog\nfish")?;
+            repositories::add(&repo, &labels_file).await?;
+            repositories::commit(&repo, "Adding fish on feature")?;
+
+            // Go back to main and modify the same file differently (conflict)
+            repositories::checkout(&repo, &base_branch_name).await?;
+            util::fs::write_to_path(&labels_file, "cat\ndog\nbird")?;
+            repositories::add(&repo, &labels_file).await?;
+            repositories::commit(&repo, "Adding bird on main")?;
+
+            // Re-fetch branches
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch_name)?;
+
+            // Server-side merge should return UpstreamMergeConflict error
+            let result =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await;
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert!(
+                matches!(err, OxenError::UpstreamMergeConflict(_)),
+                "Expected UpstreamMergeConflict, got: {err:?}"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_does_not_modify_working_dir() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch = repositories::branches::current_branch(&repo)?.unwrap();
+
+            // Commit a file on main
+            let hello_file = repo.path.join("hello.txt");
+            util::fs::write_to_path(&hello_file, "Hello")?;
+            repositories::add(&repo, &hello_file).await?;
+            repositories::commit(&repo, "Adding hello file")?;
+
+            // Create feature branch and add a new file
+            repositories::branches::create_checkout(&repo, "feature")?;
+            let world_file = repo.path.join("world.txt");
+            util::fs::write_to_path(&world_file, "World")?;
+            repositories::add(&repo, &world_file).await?;
+            repositories::commit(&repo, "Adding world file")?;
+
+            // Go back to main — world.txt should not exist in working dir
+            repositories::checkout(&repo, &base_branch.name).await?;
+            assert!(!world_file.exists());
+
+            // Re-fetch branches
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch.name)?;
+
+            // Server-side merge
+            repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+
+            // world.txt should STILL not exist — server merge doesn't touch working dir
+            assert!(
+                !world_file.exists(),
+                "Server-side merge should not create files in working directory"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_ff_with_modification() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch = repositories::branches::current_branch(&repo)?.unwrap();
+
+            let hello_file = repo.path.join("hello.txt");
+            util::fs::write_to_path(&hello_file, "Hello")?;
+            repositories::add(&repo, &hello_file).await?;
+            repositories::commit(&repo, "Adding hello file")?;
+
+            // Feature branch modifies the file
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::write_to_path(&hello_file, "Hello, modified")?;
+            repositories::add(&repo, &hello_file).await?;
+            repositories::commit(&repo, "Modifying hello file")?;
+
+            repositories::checkout(&repo, &base_branch.name).await?;
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch.name)?;
+
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+
+            assert_eq!(merge_commit.id, merge_branch.commit_id);
+
+            // Working dir should still have old content
+            let content = util::fs::read_from_path(&hello_file)?;
+            assert_eq!(content, "Hello");
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_ff_with_deletion() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch = repositories::branches::current_branch(&repo)?.unwrap();
+
+            let hello_file = repo.path.join("hello.txt");
+            let world_file = repo.path.join("world.txt");
+            util::fs::write_to_path(&hello_file, "Hello")?;
+            util::fs::write_to_path(&world_file, "World")?;
+            repositories::add(&repo, &hello_file).await?;
+            repositories::add(&repo, &world_file).await?;
+            repositories::commit(&repo, "Adding files")?;
+
+            // Feature branch deletes world.txt
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::remove_file(&world_file)?;
+            repositories::add(&repo, &world_file).await?;
+            repositories::commit(&repo, "Removing world file")?;
+
+            repositories::checkout(&repo, &base_branch.name).await?;
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch.name)?;
+
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+
+            assert_eq!(merge_commit.id, merge_branch.commit_id);
+
+            // Working dir should still have the file (server merge doesn't touch it)
+            assert!(world_file.exists());
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_ff_with_subdirectories() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch = repositories::branches::current_branch(&repo)?.unwrap();
+
+            let models_dir = repo.path.join("models").join("kling");
+            util::fs::create_dir_all(&models_dir)?;
+            let file_a = models_dir.join("a.toml");
+            util::fs::write_to_path(&file_a, "version = 1")?;
+            repositories::add(&repo, &file_a).await?;
+            repositories::commit(&repo, "Adding models/kling/a.toml")?;
+
+            // Feature branch adds a file in a subdirectory
+            repositories::branches::create_checkout(&repo, "feature")?;
+            let file_b = models_dir.join("b.toml");
+            util::fs::write_to_path(&file_b, "version = 1")?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::commit(&repo, "Adding models/kling/b.toml")?;
+
+            repositories::checkout(&repo, &base_branch.name).await?;
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch.name)?;
+
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+
+            assert_eq!(merge_commit.id, merge_branch.commit_id);
+            let updated_branch = repositories::branches::get_by_name(&repo, &base_branch.name)?;
+            assert_eq!(updated_branch.commit_id, merge_commit.id);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_three_way_with_subdirectories() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // Create initial files in subdirectories
+            let models_dir = repo.path.join("models");
+            util::fs::create_dir_all(&models_dir)?;
+            let file_a = models_dir.join("a.toml");
+            util::fs::write_to_path(&file_a, "version = 1")?;
+            repositories::add(&repo, &file_a).await?;
+            repositories::commit(&repo, "Adding models/a.toml")?;
+
+            // Feature branch adds a new file in the same subdirectory
+            repositories::branches::create_checkout(&repo, "feature")?;
+            let file_b = models_dir.join("b.toml");
+            util::fs::write_to_path(&file_b, "version = 1")?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::commit(&repo, "Adding models/b.toml on feature")?;
+
+            // Main branch adds a file in a different subdirectory (diverge, no conflict)
+            repositories::checkout(&repo, &base_branch_name).await?;
+            let scripts_dir = repo.path.join("scripts");
+            util::fs::create_dir_all(&scripts_dir)?;
+            let file_c = scripts_dir.join("deploy.sh");
+            util::fs::write_to_path(&file_c, "#!/bin/bash")?;
+            repositories::add(&repo, &file_c).await?;
+            repositories::commit(&repo, "Adding scripts/deploy.sh on main")?;
+
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch_name)?;
+
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+
+            assert_eq!(merge_commit.parent_ids.len(), 2);
+
+            // Working dir should not have the feature branch file
+            assert!(
+                !file_b.exists(),
+                "Server merge should not create models/b.toml on disk"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_three_way_modification_no_conflict() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // Create two files
+            let file_a = repo.path.join("a.txt");
+            let file_b = repo.path.join("b.txt");
+            util::fs::write_to_path(&file_a, "a version 1")?;
+            util::fs::write_to_path(&file_b, "b version 1")?;
+            repositories::add(&repo, &file_a).await?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::commit(&repo, "Adding a.txt and b.txt")?;
+
+            // Feature branch modifies a.txt
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::write_to_path(&file_a, "a version 2")?;
+            repositories::add(&repo, &file_a).await?;
+            repositories::commit(&repo, "Modifying a.txt on feature")?;
+
+            // Main branch modifies b.txt (different file, no conflict)
+            repositories::checkout(&repo, &base_branch_name).await?;
+            util::fs::write_to_path(&file_b, "b version 2")?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::commit(&repo, "Modifying b.txt on main")?;
+
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch_name)?;
+
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+
+            assert_eq!(merge_commit.parent_ids.len(), 2);
+
+            // a.txt should still have the base version in working dir
+            let content = util::fs::read_from_path(&file_a)?;
+            assert_eq!(content, "a version 1");
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_three_way_deletion_no_conflict() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // Create two files
+            let file_a = repo.path.join("a.txt");
+            let file_b = repo.path.join("b.txt");
+            util::fs::write_to_path(&file_a, "a")?;
+            util::fs::write_to_path(&file_b, "b")?;
+            repositories::add(&repo, &file_a).await?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::commit(&repo, "Adding a.txt and b.txt")?;
+
+            // Feature branch deletes a.txt
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::remove_file(&file_a)?;
+            repositories::add(&repo, &file_a).await?;
+            repositories::commit(&repo, "Removing a.txt on feature")?;
+
+            // Main branch modifies b.txt (different file, no conflict)
+            repositories::checkout(&repo, &base_branch_name).await?;
+            util::fs::write_to_path(&file_b, "b modified")?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::commit(&repo, "Modifying b.txt on main")?;
+
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch_name)?;
+
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+
+            assert_eq!(merge_commit.parent_ids.len(), 2);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_three_way_conflict_in_subdirectory() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            let models_dir = repo.path.join("models");
+            util::fs::create_dir_all(&models_dir)?;
+            let config = models_dir.join("config.toml");
+            util::fs::write_to_path(&config, "version = 1")?;
+            repositories::add(&repo, &config).await?;
+            repositories::commit(&repo, "Adding models/config.toml")?;
+
+            // Feature branch modifies the config
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::write_to_path(&config, "version = 2")?;
+            repositories::add(&repo, &config).await?;
+            repositories::commit(&repo, "Updating config on feature")?;
+
+            // Main branch also modifies the same config (conflict)
+            repositories::checkout(&repo, &base_branch_name).await?;
+            util::fs::write_to_path(&config, "version = 3")?;
+            repositories::add(&repo, &config).await?;
+            repositories::commit(&repo, "Updating config on main")?;
+
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch_name)?;
+
+            let result =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await;
+            assert!(matches!(
+                result.unwrap_err(),
+                OxenError::UpstreamMergeConflict(_)
+            ));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_three_way_both_add_same_path() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // LCA: no new.txt yet
+            let placeholder = repo.path.join("placeholder.txt");
+            util::fs::write_to_path(&placeholder, "anchor")?;
+            repositories::add(&repo, &placeholder).await?;
+            repositories::commit(&repo, "Anchor commit")?;
+
+            // Feature branch adds new.txt
+            repositories::branches::create_checkout(&repo, "feature")?;
+            let new_file = repo.path.join("new.txt");
+            util::fs::write_to_path(&new_file, "from feature")?;
+            repositories::add(&repo, &new_file).await?;
+            repositories::commit(&repo, "Adding new.txt on feature")?;
+
+            // Main branch also adds new.txt with different content
+            repositories::checkout(&repo, &base_branch_name).await?;
+            util::fs::write_to_path(&new_file, "from main")?;
+            repositories::add(&repo, &new_file).await?;
+            repositories::commit(&repo, "Adding new.txt on main")?;
+
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch_name)?;
+
+            let result =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await;
+            assert!(matches!(
+                result.unwrap_err(),
+                OxenError::UpstreamMergeConflict(_)
+            ));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_three_way_modify_delete_conflict() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // LCA: create a file
+            let file = repo.path.join("shared.txt");
+            util::fs::write_to_path(&file, "original")?;
+            repositories::add(&repo, &file).await?;
+            repositories::commit(&repo, "Adding shared.txt")?;
+
+            // Feature branch deletes the file
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::remove_file(&file)?;
+            repositories::add(&repo, &file).await?;
+            repositories::commit(&repo, "Deleting shared.txt on feature")?;
+
+            // Main branch modifies the same file
+            repositories::checkout(&repo, &base_branch_name).await?;
+            util::fs::write_to_path(&file, "modified on main")?;
+            repositories::add(&repo, &file).await?;
+            repositories::commit(&repo, "Modifying shared.txt on main")?;
+
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch_name)?;
+
+            let result =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await;
+            assert!(
+                matches!(result.unwrap_err(), OxenError::UpstreamMergeConflict(_)),
+                "Modify on base + delete on merge should be a conflict"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_three_way_base_deletes_merge_unchanged() -> Result<(), OxenError>
+    {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // LCA: create two files
+            let file_a = repo.path.join("a.txt");
+            let file_b = repo.path.join("b.txt");
+            util::fs::write_to_path(&file_a, "a")?;
+            util::fs::write_to_path(&file_b, "b")?;
+            repositories::add(&repo, &file_a).await?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::commit(&repo, "Adding a.txt and b.txt")?;
+
+            // Feature branch makes an unrelated change (doesn't touch a.txt)
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::write_to_path(&file_b, "b modified on feature")?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::commit(&repo, "Modifying b.txt on feature")?;
+
+            // Main branch deletes a.txt
+            repositories::checkout(&repo, &base_branch_name).await?;
+            util::fs::remove_file(&file_a)?;
+            repositories::add(&repo, &file_a).await?;
+            repositories::commit(&repo, "Deleting a.txt on main")?;
+
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch_name)?;
+
+            // Base's deletion should win since merge didn't change the file
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+
+            assert_eq!(merge_commit.parent_ids.len(), 2);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_three_way_delete_modify_conflict() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // LCA: create a file
+            let file = repo.path.join("shared.txt");
+            util::fs::write_to_path(&file, "original")?;
+            repositories::add(&repo, &file).await?;
+            repositories::commit(&repo, "Adding shared.txt")?;
+
+            // Feature branch modifies the file
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::write_to_path(&file, "modified on feature")?;
+            repositories::add(&repo, &file).await?;
+            repositories::commit(&repo, "Modifying shared.txt on feature")?;
+
+            // Main branch deletes the same file
+            repositories::checkout(&repo, &base_branch_name).await?;
+            util::fs::remove_file(&file)?;
+            repositories::add(&repo, &file).await?;
+            repositories::commit(&repo, "Deleting shared.txt on main")?;
+
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch_name)?;
+
+            let result =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await;
+            assert!(
+                matches!(result.unwrap_err(), OxenError::UpstreamMergeConflict(_)),
+                "Delete on base + modify on merge should be a conflict"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_three_way_dir_metadata() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // LCA: create three files (a.txt, b.txt, c.txt)
+            let file_a = repo.path.join("a.txt");
+            let file_b = repo.path.join("b.txt");
+            let file_c = repo.path.join("c.txt");
+            util::fs::write_to_path(&file_a, "aaa")?; // 3 bytes
+            util::fs::write_to_path(&file_b, "bbb")?; // 3 bytes
+            util::fs::write_to_path(&file_c, "ccc")?; // 3 bytes
+            repositories::add(&repo, &file_a).await?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::add(&repo, &file_c).await?;
+            let lca_commit = repositories::commit(&repo, "LCA: adding a, b, c")?;
+
+            // Snapshot the LCA root metadata for reference
+            let lca_root =
+                repositories::tree::get_dir_without_children(&repo, &lca_commit, "", None)?
+                    .unwrap();
+            let lca_dir = lca_root.dir()?;
+            // The initial commit from run_one_commit_local_repo_test_async adds a file too, so
+            // we track the LCA state as our baseline rather than hardcoding counts.
+            let lca_num_files = lca_dir.num_files();
+            let lca_num_bytes = lca_dir.num_bytes();
+
+            // Feature branch: add d.txt, modify b.txt, delete c.txt
+            repositories::branches::create_checkout(&repo, "feature")?;
+            let file_d = repo.path.join("d.txt");
+            util::fs::write_to_path(&file_d, "ddddd")?; // 5 bytes (added)
+            util::fs::write_to_path(&file_b, "bbbbbbb")?; // 7 bytes (was 3)
+            util::fs::remove_file(&file_c)?; // removed (was 3 bytes)
+            repositories::add(&repo, &file_d).await?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::add(&repo, &file_c).await?;
+            repositories::commit(&repo, "Feature: add d, modify b, delete c")?;
+
+            // Main branch: add e.txt to diverge (forces three-way merge)
+            repositories::checkout(&repo, &base_branch_name).await?;
+            let file_e = repo.path.join("e.txt");
+            util::fs::write_to_path(&file_e, "ee")?; // 2 bytes
+            repositories::add(&repo, &file_e).await?;
+            repositories::commit(&repo, "Main: add e")?;
+
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch_name)?;
+
+            // Server-side three-way merge
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+            assert_eq!(merge_commit.parent_ids.len(), 2);
+
+            // Read the root DirNode from the merge commit
+            let merge_root =
+                repositories::tree::get_dir_without_children(&repo, &merge_commit, "", None)?
+                    .unwrap();
+            let merge_dir = merge_root.dir()?;
+
+            // Expected changes relative to LCA:
+            //   +1 file (d.txt added), +1 file (e.txt added), -1 file (c.txt deleted) = net +1
+            assert_eq!(
+                merge_dir.num_files(),
+                lca_num_files + 1, // net +1 file
+                "num_files: LCA had {lca_num_files}, merge should have +1 (add d, add e, del c)"
+            );
+
+            // Expected byte changes relative to LCA:
+            //   b.txt: 3 -> 7 (+4), d.txt: +5, e.txt: +2, c.txt: -3 = net +8
+            assert_eq!(
+                merge_dir.num_bytes(),
+                lca_num_bytes + 8,
+                "num_bytes: LCA had {lca_num_bytes}, merge should have +8 bytes"
+            );
+
+            // Verify the right files exist in the merge commit tree
+            assert!(
+                repositories::tree::get_file_by_path(&repo, &merge_commit, "a.txt")?.is_some(),
+                "a.txt should exist"
+            );
+            assert!(
+                repositories::tree::get_file_by_path(&repo, &merge_commit, "b.txt")?.is_some(),
+                "b.txt should exist"
+            );
+            assert!(
+                repositories::tree::get_file_by_path(&repo, &merge_commit, "c.txt")?.is_none(),
+                "c.txt should be deleted"
+            );
+            assert!(
+                repositories::tree::get_file_by_path(&repo, &merge_commit, "d.txt")?.is_some(),
+                "d.txt should exist"
+            );
+            assert!(
+                repositories::tree::get_file_by_path(&repo, &merge_commit, "e.txt")?.is_some(),
+                "e.txt should exist"
+            );
 
             Ok(())
         })

--- a/crates/lib/src/repositories/merge.rs
+++ b/crates/lib/src/repositories/merge.rs
@@ -137,6 +137,34 @@ pub async fn merge(
     }
 }
 
+/// Server-safe merge of two commits. Does not touch the working directory or
+/// HEAD — the caller is responsible for updating the branch ref.
+///
+/// Use this variant from server code paths that must not mutate on-disk files.
+/// For the client-side equivalent that updates the checkout and HEAD, see
+/// [`merge_commit_into_base`].
+pub async fn merge_commit_into_base_server_safe(
+    repo: &LocalRepository,
+    merge_commit: &Commit,
+    base_commit: &Commit,
+) -> Result<Option<Commit>, OxenError> {
+    match repo.min_version() {
+        MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
+        _ => {
+            core::v_latest::merge::merge_commit_into_base_server_safe(
+                repo,
+                merge_commit,
+                base_commit,
+            )
+            .await
+        }
+    }
+}
+
+/// Client-side merge of two commits. Updates files on disk and advances HEAD.
+///
+/// For the server-side equivalent that never touches the working directory,
+/// see [`merge_commit_into_base_server_safe`].
 pub async fn merge_commit_into_base(
     repo: &LocalRepository,
     merge_commit: &Commit,
@@ -1955,6 +1983,113 @@ mod tests {
             assert!(
                 repositories::tree::get_file_by_path(&repo, &merge_commit, "e.txt")?.is_some(),
                 "e.txt should exist"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_commit_into_base_server_safe_ff_does_not_touch_working_dir()
+    -> Result<(), OxenError> {
+        // Verifies that merge_commit_into_base_server_safe succeeds even when
+        // stale files exist in the repo directory (no "local changes would be
+        // overwritten" error).
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let main_branch = repositories::branches::current_branch(&repo)?.unwrap();
+
+            // Add a file and commit
+            let readme = repo.path.join("README.md");
+            util::fs::write_to_path(&readme, "original")?;
+            repositories::add(&repo, &readme).await?;
+            let base_commit = repositories::commit(&repo, "Add README")?;
+
+            // Branch, modify the file, and commit
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::write_to_path(&readme, "modified on feature")?;
+            repositories::add(&repo, &readme).await?;
+            let feature_commit = repositories::commit(&repo, "Modify README")?;
+
+            // Go back to main so HEAD is at base_commit (FF scenario)
+            repositories::checkout(&repo, &main_branch.name).await?;
+
+            // Simulate server state: write a stale/different file at the path.
+            // On a real server there is no checkout, but the repo directory may
+            // contain leftover files that differ from the tree.
+            util::fs::write_to_path(&readme, "stale server copy")?;
+
+            // Server-safe merge should NOT check working-dir files → no error
+            let result = repositories::merge::merge_commit_into_base_server_safe(
+                &repo,
+                &feature_commit,
+                &base_commit,
+            )
+            .await?;
+
+            assert!(result.is_some(), "FF merge should return the merge commit");
+            assert_eq!(result.unwrap().id, feature_commit.id);
+
+            // The stale file on disk should be UNTOUCHED (server never writes)
+            let on_disk = util::fs::read_from_path(&readme)?;
+            assert_eq!(
+                on_disk, "stale server copy",
+                "server-safe merge must not modify files on disk"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_commit_into_base_server_safe_three_way_does_not_touch_working_dir()
+    -> Result<(), OxenError> {
+        // Verifies that merge_commit_into_base_server_safe uses the server-safe
+        // three-way merge path and never touches the working directory.
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let main_branch = repositories::branches::current_branch(&repo)?.unwrap();
+
+            // Shared ancestor
+            let a_path = repo.path.join("a.txt");
+            util::fs::write_to_path(&a_path, "a")?;
+            repositories::add(&repo, &a_path).await?;
+            repositories::commit(&repo, "Add a.txt")?;
+
+            // Feature branch: add b.txt
+            repositories::branches::create_checkout(&repo, "feature")?;
+            let b_path = repo.path.join("b.txt");
+            util::fs::write_to_path(&b_path, "b")?;
+            repositories::add(&repo, &b_path).await?;
+            let feature_commit = repositories::commit(&repo, "Add b.txt")?;
+
+            // Back to main: add c.txt (diverge → forces three-way merge)
+            repositories::checkout(&repo, &main_branch.name).await?;
+            let c_path = repo.path.join("c.txt");
+            util::fs::write_to_path(&c_path, "c")?;
+            repositories::add(&repo, &c_path).await?;
+            let base_commit = repositories::commit(&repo, "Add c.txt")?;
+
+            // Simulate stale server state
+            util::fs::write_to_path(&a_path, "stale")?;
+
+            // Server-safe merge should succeed without checking disk
+            let result = repositories::merge::merge_commit_into_base_server_safe(
+                &repo,
+                &feature_commit,
+                &base_commit,
+            )
+            .await?;
+            assert!(
+                result.is_some(),
+                "three-way merge should return a merge commit"
+            );
+
+            // Stale file should be untouched
+            let on_disk = util::fs::read_from_path(&a_path)?;
+            assert_eq!(
+                on_disk, "stale",
+                "server-safe merge must not modify files on disk"
             );
 
             Ok(())

--- a/crates/lib/src/repositories/tree.rs
+++ b/crates/lib/src/repositories/tree.rs
@@ -627,9 +627,9 @@ pub fn dir_entries_with_paths(
     Ok(entries)
 }
 
-// Get HashMap of all entries that aren't present in shared_hashes
+/// Get HashMap of all entries that aren't present in shared_hashes
 pub fn unique_dir_entries(
-    base_path: &PathBuf,
+    base_path: &Path,
     node: &MerkleTreeNode,
     shared_hashes: &HashSet<MerkleHash>,
 ) -> Result<HashMap<PathBuf, FileNode>, OxenError> {

--- a/crates/server/src/controllers/branches.rs
+++ b/crates/server/src/controllers/branches.rs
@@ -329,31 +329,32 @@ pub async fn maybe_create_merge(
 
     log::debug!("maybe_create_merge got client head commit {incoming_commit_id:?}");
 
-    let maybe_merge_commit = repositories::merge::merge_commit_into_base_on_branch(
+    let merge_commit = match repositories::merge::merge_commit_into_base_on_branch(
         &repository,
         &incoming_commit,
         &current_commit,
         &branch,
     )
-    .await?;
+    .await
+    {
+        Ok(commit) => commit,
+        Err(OxenError::UpstreamMergeConflict(_)) => {
+            // If there are merge conflicts, we can't complete this merge and want to reset
+            // the branch to the previous remote head as if this push never happened
+            log::debug!("returning current commit {current_commit_id:?}.");
+            return Ok(HttpResponse::Ok().json(CommitResponse {
+                status: StatusMessage::resource_found(),
+                commit: current_commit,
+            }));
+        }
+        Err(e) => return Err(e.into()),
+    };
 
-    // Return what will become the new head of the repo after push is complete.
-    if let Some(merge_commit) = maybe_merge_commit {
-        log::debug!("returning merge commit {merge_commit:?}");
-        // Update branch head
-        Ok(HttpResponse::Ok().json(CommitResponse {
-            status: StatusMessage::resource_created(),
-            commit: merge_commit,
-        }))
-    } else {
-        // If there are merge conflicts, we can't complete this merge and want to reset the branch to the previous remote head
-        // as if this push never happened
-        log::debug!("returning current commit {current_commit_id:?}.");
-        Ok(HttpResponse::Ok().json(CommitResponse {
-            status: StatusMessage::resource_found(),
-            commit: current_commit,
-        }))
-    }
+    log::debug!("returning merge commit {merge_commit:?}");
+    Ok(HttpResponse::Ok().json(CommitResponse {
+        status: StatusMessage::resource_created(),
+        commit: merge_commit,
+    }))
 }
 
 /// Get all versions of a file on a branch

--- a/crates/server/src/controllers/merger.rs
+++ b/crates/server/src/controllers/merger.rs
@@ -109,32 +109,17 @@ pub async fn merge(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let base_commit = repositories::commits::get_by_id(&repo, &base_branch.commit_id)?.unwrap();
     let head_commit = repositories::commits::get_by_id(&repo, &head_branch.commit_id)?.unwrap();
 
-    // Check if mergeable
-    match repositories::merge::merge_into_base(&repo, &head_branch, &base_branch).await {
-        Ok(Some(merge_commit)) => {
-            // If the merge was successful, update the branch
-            repositories::branches::update(&repo, &base_branch.name, &merge_commit.id)?;
+    let merge_commit =
+        repositories::merge::merge_into_base(&repo, &head_branch, &base_branch).await?;
 
-            let response = MergeSuccessResponse {
-                status: StatusMessage::resource_found(),
-                commits: MergeResult {
-                    base: base_commit,
-                    head: head_commit,
-                    merge: merge_commit,
-                },
-            };
+    let response = MergeSuccessResponse {
+        status: StatusMessage::resource_found(),
+        commits: MergeResult {
+            base: base_commit,
+            head: head_commit,
+            merge: merge_commit,
+        },
+    };
 
-            Ok(HttpResponse::Ok().json(response))
-        }
-        Ok(None) => {
-            log::debug!("Merge has conflicts");
-            Err(OxenError::UpstreamMergeConflict(
-                format!("Unable to merge {head} into {base} due to conflicts.").into(),
-            ))?
-        }
-        Err(err) => {
-            log::debug!("Err merging branches {err:?}");
-            Ok(HttpResponse::InternalServerError().json(StatusMessage::internal_server_error()))
-        }
-    }
+    Ok(HttpResponse::Ok().json(response))
 }


### PR DESCRIPTION
_My apologies. I prefer much, much smaller PRs, but I couldn't figure out how to meaningfully cut this one down. On the other hand, I'm certain there's more to fix...but we've got to stop and ship this!_

---

This PR implements server-side merging. i.e., merging that doesn't involve a local checkout.

The server was using the same code as the client to perform merges. This means that the server would use the "local checkout" (that was not supposed to be present on the server in the first place...yet seems to be there in all the repos I spot-checked) to perform the merge. So, depending on what operations happened to touch the server's local checkout, you could get all sorts of crazy stuff happening, from a flat-out error that couldn't be fixed (bad) to merging some random set of files into your base branch (worse).

I have never implemented three-way-merges before, so I relied on the existing client implementation as a pattern. Along the way, I found and fixed some problems in the client implementation as well. 😬 

### Server-side merge separation

- `merge_into_base` and `merge_commit_into_base_on_branch` no longer touch the working directory — they create merge commits purely from tree data via a new `server_three_way_merge` function
- Deleted `merge_commits_on_branch` and `create_merge_commit_on_branch`, which staged files to disk
- Branch ref updates moved inside the merge functions instead of being done by callers
- Server merge return type changed from `Result<Option<Commit>>` to `Result<Commit>` — Now conflicts return `Err(UpstreamMergeConflict)` instead of `None`. Now "nothing to do" is no longer treated as a merge conflict.

### Three-way merge conflict analysis

- `find_merge_conflicts` now returns a `MergeConflictAnalysis` struct instead of `Vec<NodeMergeConflict>`
- The analysis tracks files added, modified, or deleted on the merge branch, each tagged with its `StagedEntryStatus`
- New deletion detection pass: iterates LCA entries to find files deleted on the merge branch (previously deleted files from the merge branch would show back up)
- Properly detects delete-vs-modify and modify-vs-delete conflicts (previously unhandled)
- When there's no LCA, it's treated as an empty tree instead of falling back to the base commit -- I'm uncertain if it's a good design for us to support merging orphan branches at all, but that's currently how we handle pulling from a remote for the first time.

### commit_writer.rs decoupling
- `staged_db` parameter removed from `commit_dir_entries_with_parents` and `commit_dir_entries_new` -- it was only used to clean up the staged db
- Staged DB cleanup moved to the caller (commit_with_cfg), to uncouple it from code we wanted to share with the server that didn't deal with a staged db

### Directory metadata accounting fixes (pre-existing bugs)
- Removed entries now decrement `num_bytes`, `data_type_counts`, and `data_type_sizes` (previously only `num_entries` was decremented)
- Modified entries now apply the byte-size delta to `num_bytes` and `data_type_sizes` (previously ignored)

# Misc cleanups
- `MergeCommits::commit_message() `extracted to deduplicate the merge message format
- `is_fast_forward_merge` uses idiomatic `is_some_and` instead of is_some() && unwrap()
- `unique_dir_entries` parameter changed from &PathBuf to &Path
- Removed unused `rm` import and `RmOpts` dependency from merge module