### PR TITLE
Only save cache on main

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -68,9 +68,14 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: ${{ matrix.platform == 'windows' && '-D warnings -C link-arg=/DEBUG:NONE' || '-D warnings' }}
-          cache: true # This is the default--making it explicit. This uses Swatinem/rust-cache under the hood.
+          cache: false # We use Swatinem/rust-cache directly below for save-if control.
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
           cache-all-crates: true
-          cache-workspace-crates: true
+          cache-on-failure: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.0.0


### PR DESCRIPTION
At @jcelliott's request...😉 

We decrease cache churn (and speed up typical builds slightly) if we only upload the Rust cache when we run the builds on `main`. The tradeoff is that large changes in dependencies (or updating Rust!) will have slow CI until the PR is merged and it runs again on `main`.