### PR TITLE
Fix merge bug due to bare filename vs relative path name

### DIFF
--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -267,12 +267,16 @@ async fn server_three_way_merge(
     let mut dir_entries: HashMap<PathBuf, Vec<StagedMerkleTreeNode>> = HashMap::new();
     for (path, file_node, status) in &analysis.entries {
         let parent = path.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+        // The commit writer's existing children use full relative paths (e.g. "data/b.txt") as
+        // their names, so our staged entries must match.
+        let mut named_node = file_node.clone();
+        named_node.set_name(path.to_str().unwrap());
         dir_entries
             .entry(parent)
             .or_default()
             .push(StagedMerkleTreeNode {
                 status: status.clone(),
-                node: MerkleTreeNode::from_file(file_node.clone()),
+                node: MerkleTreeNode::from_file(named_node),
             });
         // Ensure all ancestor directories are present in dir_entries
         let mut ancestor = path.to_path_buf();
@@ -1032,8 +1036,12 @@ pub async fn find_merge_conflicts(
 
     let starting_path = PathBuf::from("");
 
+    // Walk the full LCA tree without the shared_hashes filter. The LCA tree is fully loaded
+    // (no exclusions), and pruning it would hide files in directories shared between LCA and
+    // base — causing missed deletions and incorrect "not in LCA" classifications.
+    let no_filter = HashSet::new();
     let lca_entries = if let Some(lca_tree) = &lca_commit_tree {
-        repositories::tree::unique_dir_entries(&starting_path, lca_tree, shared_hashes)?
+        repositories::tree::unique_dir_entries(&starting_path, lca_tree, &no_filter)?
     } else {
         HashMap::new()
     };
@@ -1162,9 +1170,8 @@ pub async fn find_merge_conflicts(
         }
     }
 
-    // Detect deletions: files in the LCA that are absent from the merge tree and unchanged on base.
-    // Check the full merge tree, not just merge_tree_entries, because unique_dir_entries skips
-    // files in shared directories.
+    // Detect deletions: files in the LCA that are absent from the merge tree. `base_entries` is
+    // pruned (shared dirs skipped), so we use `get_file_by_path` for base lookups.
     for (entry_path, lca_file_node) in &lca_entries {
         if merge_tree_entries.contains_key(entry_path)
             || repositories::tree::get_file_by_path(repo, &merge_commits.merge, entry_path)?
@@ -1172,7 +1179,10 @@ pub async fn find_merge_conflicts(
         {
             continue;
         }
-        if let Some(base_file_node) = base_entries.get(entry_path) {
+        // File is in LCA but absent from merge — check base to decide delete vs conflict.
+        let base_file_node =
+            repositories::tree::get_file_by_path(repo, &merge_commits.base, entry_path)?;
+        if let Some(base_file_node) = base_file_node {
             if base_file_node.combined_hash() == lca_file_node.combined_hash() {
                 // Unchanged on base, deleted on merge — delete it
                 entries.push((entry_path.clone(), lca_file_node.clone(), Removed));

--- a/crates/lib/src/repositories/merge.rs
+++ b/crates/lib/src/repositories/merge.rs
@@ -1990,6 +1990,61 @@ mod tests {
         .await
     }
 
+    /// Regression test: deletion of a file in a directory that's shared between LCA and base
+    /// (i.e., the directory hash is identical in both, so `unique_dir_entries` prunes it).
+    /// The merge branch deletes a file from that shared directory.
+    #[tokio::test]
+    async fn test_merge_into_base_three_way_delete_in_shared_dir() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch_name = repositories::branches::current_branch(&repo)?.unwrap().name;
+
+            // LCA: create files in a subdirectory
+            let dir = repo.path.join("data");
+            util::fs::create_dir_all(&dir)?;
+            let file_a = dir.join("a.txt");
+            let file_b = dir.join("b.txt");
+            util::fs::write_to_path(&file_a, "aaa")?;
+            util::fs::write_to_path(&file_b, "bbb")?;
+            repositories::add(&repo, &file_a).await?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::commit(&repo, "LCA: adding data/a.txt and data/b.txt")?;
+
+            // Feature branch: delete data/b.txt (leaving data/a.txt untouched)
+            repositories::branches::create_checkout(&repo, "feature")?;
+            util::fs::remove_file(&file_b)?;
+            repositories::add(&repo, &file_b).await?;
+            repositories::commit(&repo, "Feature: delete data/b.txt")?;
+
+            // Main branch: add an unrelated file to force divergence (3-way merge).
+            // Crucially, do NOT touch data/ — so data/ is identical in LCA and base.
+            repositories::checkout(&repo, &base_branch_name).await?;
+            let unrelated = repo.path.join("other.txt");
+            util::fs::write_to_path(&unrelated, "x")?;
+            repositories::add(&repo, &unrelated).await?;
+            repositories::commit(&repo, "Main: add other.txt")?;
+
+            let merge_branch = repositories::branches::get_by_name(&repo, "feature")?;
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch_name)?;
+
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+            assert_eq!(merge_commit.parent_ids.len(), 2);
+
+            // data/a.txt should still exist, data/b.txt should be deleted
+            assert!(
+                repositories::tree::get_file_by_path(&repo, &merge_commit, "data/a.txt")?.is_some(),
+                "data/a.txt should exist in merge commit"
+            );
+            assert!(
+                repositories::tree::get_file_by_path(&repo, &merge_commit, "data/b.txt")?.is_none(),
+                "data/b.txt should be deleted in merge commit"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
     #[tokio::test]
     async fn test_merge_commit_into_base_server_safe_ff_does_not_touch_working_dir()
     -> Result<(), OxenError> {


### PR DESCRIPTION
Another corner-case bug fix in merging after https://github.com/Oxen-AI/Oxen/pull/426

We were comparing bare file names to relative file paths again.