### PR TITLE
Reduce test fixture sizes for faster test suite

### DIFF
--- a/crates/lib/src/api/client/workspaces/data_frames/embeddings.rs
+++ b/crates/lib/src/api/client/workspaces/data_frames/embeddings.rs
@@ -425,11 +425,12 @@ mod tests {
                 .await?;
                 assert!(output_path.exists());
 
-                // There should be 10000 rows by 4 columns
+                // Row count matches the fixture; width is 4 (prompt, response, embedding,
+                // OXEN_ROW_ID).
                 let df = tabular::read_df(&output_path, DFOpts::empty()).await?;
                 println!("{df}");
                 assert_eq!(df.width(), 4);
-                assert_eq!(df.height(), 10000);
+                assert_eq!(df.height(), test::EMBEDDINGS_FIXTURE_ROWS);
                 Ok(())
             })
             .await?;

--- a/crates/lib/src/repositories/commits.rs
+++ b/crates/lib/src/repositories/commits.rs
@@ -997,14 +997,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_commit_10k_files_vnode_size_10k() -> Result<(), OxenError> {
+    async fn test_commit_files_at_vnode_size_boundary() -> Result<(), OxenError> {
+        // Regression coverage: committing exactly `vnode_size` files in one directory must
+        // not interfere with path lookups for sibling files. Originally written with the
+        // production default (10k files at vnode_size=10k); rewritten to set a small
+        // vnode_size so the same boundary case runs in a fraction of the time.
+        const N: usize = 10;
         test::run_empty_local_repo_test_async(|repo| async move {
-            // Make a dir
+            let mut repo = repo;
+            repo.set_vnode_size(N as u64);
+
             let dir_path = Path::new("test_dir");
             let dir_repo_path = repo.path.join(dir_path);
             util::fs::create_dir_all(&dir_repo_path)?;
 
-            for i in 0..10000 {
+            for i in 0..N {
                 let file_path = dir_path.join(format!("file_{i}.txt"));
                 let file_repo_path = repo.path.join(&file_path);
                 util::fs::write_to_path(&file_repo_path, "test")?;
@@ -1017,7 +1024,7 @@ mod tests {
 
             repositories::add(&repo, &dir_repo_path).await?;
             repositories::add(&repo, &images_csv_repo_path).await?;
-            let commit = repositories::commit(&repo, "adding 10k files")?;
+            let commit = repositories::commit(&repo, &format!("adding {N} files"))?;
 
             repositories::tree::print_tree(&repo, &commit)?;
 

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -1434,14 +1434,21 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
     Ok(())
 }
 
+/// Number of rows in the embeddings.jsonl fixture written by `create_embeddings_jsonl`.
+/// Tests that download the full table assert against this count, so they get the size
+/// from here rather than hardcoding it. Originally 10k; reduced to make the embeddings
+/// tests run faster — they exercise indexing/query/download mechanics, not large-N
+/// behavior.
+pub const EMBEDDINGS_FIXTURE_ROWS: usize = 100;
+
 fn create_embeddings_jsonl(repo_path: &Path) -> Result<(), OxenError> {
     let dir = repo_path.join("annotations").join("train");
     // Create dir
     util::fs::create_dir_all(&dir)?;
 
-    // Make a jsonl file with 10k embeddings
+    // Make a jsonl file with EMBEDDINGS_FIXTURE_ROWS embeddings
     let mut embeddings = Vec::new();
-    for i in 0..10000 {
+    for i in 0..EMBEDDINGS_FIXTURE_ROWS {
         embeddings.push(format!(r#"{{"prompt": "What is great way to version {i} images?", "response": "Checkout Oxen.ai", "embedding": [{i}.0, {i}.1, {i}.2]}}"#));
     }
 
@@ -1901,12 +1908,29 @@ pub fn populate_prompts(repo_dir: &Path) -> Result<(), OxenError> {
     Ok(())
 }
 
-pub fn populate_large_files(repo_dir: &Path) -> Result<(), OxenError> {
+pub fn populate_csv_files(repo_dir: &Path) -> Result<(), OxenError> {
+    // `large_files/test.csv` used to be a straight copy of the full 200k-row celeb_a CSV
+    // (~9.6 MB). Almost none of the tests that use this fixture actually need the size —
+    // they exercise push/pull/clone/merge-conflict mechanics or just check that the file
+    // exists after a download. Tests that genuinely need the 200k-row dataset load it
+    // directly via `test_200k_csv()` / `test_text_file_with_name("celeb_a_200k.csv")`.
+    //
+    // Write a tiny CSV with the same schema so the fixture still looks realistic without
+    // paying the I/O + network cost of pushing 9.6 MB through localhost HTTP per test.
     let large_dir = repo_dir.join("large_files");
     util::fs::create_dir_all(&large_dir)?;
     let large_file_1 = large_dir.join("test.csv");
-    let from_file = test_200k_csv();
-    util::fs::copy(from_file, large_file_1)?;
+
+    let mut csv = String::from(
+        "image_id,lefteye_x,lefteye_y,righteye_x,righteye_y,nose_x,nose_y,\
+         leftmouth_x,leftmouth_y,rightmouth_x,rightmouth_y\n",
+    );
+    for i in 1..=100 {
+        csv.push_str(&format!(
+            "{i:06}.jpg,69,109,106,113,77,142,73,152,108,154\n"
+        ));
+    }
+    write_txt_file_to_path(large_file_1, csv)?;
 
     Ok(())
 }
@@ -2120,8 +2144,7 @@ pub fn populate_dir_with_training_data(repo_dir: &Path) -> Result<(), OxenError>
     // prompts.jsonl
     populate_prompts(repo_dir)?;
 
-    // large_files/test.csv
-    populate_large_files(repo_dir)?;
+    populate_csv_files(repo_dir)?;
 
     // train/
     populate_train_dir(repo_dir)?;
@@ -2149,9 +2172,8 @@ pub fn populate_select_training_data(repo_dir: &Path, data: &str) -> Result<(), 
         populate_labels(repo_dir)?;
     }
 
-    // large_files/test.csv
     if data.contains("large_files") {
-        populate_large_files(repo_dir)?;
+        populate_csv_files(repo_dir)?;
     }
 
     // train/


### PR DESCRIPTION
This reduces test time for a bunch of the slowest tests. It doesn't speed up overall test time on my M5 yet because of the massive parallelism, but it may have a much larger effect in CI (and continually speeding up tests will add up even locally).

- Rewrite `test_commit_10k_files_vnode_size_10k` as `test_commit_files_at_vnode_size_boundary` using `set_vnode_size(10) + 10` files instead of 10k files at the default vnode size
- Shrink `embeddings.jsonl` fixture from 10k to 100 rows
- Replace 9.6 MB `celeb_a_200k.csv` copy in `populate_csv_files` with a 100-row synthetic CSV (tests needing the full 200k file load it directly via `test_200k_csv()`)