### PR TITLE
Split Rust and Python CI jobs - Reduce CI time to 13m

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -74,8 +74,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: rust-test
-          # TODO: Commented out to test caching. Uncomment before merging.
-          #          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
+          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
           cache-all-crates: true
           cache-on-failure: true
 
@@ -197,8 +196,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: python-test
-          # TODO: Commented out to test caching. Uncomment before merging.
-          #          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
+          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
           cache-all-crates: true
           cache-on-failure: true
 

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Test Suite
+  rust-test:
+    name: Rust Tests
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -73,7 +73,9 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
+          prefix-key: rust-test
+          # TODO: Commented out to test caching. Uncomment before merging.
+          #          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
           cache-all-crates: true
           cache-on-failure: true
 
@@ -132,6 +134,119 @@ jobs:
         run: |
           Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start"
           cargo nextest run --workspace --profile ci
+
+  python-test:
+    name: Python Tests
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-x64-8cpu-32ram-300ssd]
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            shell: bash -leo pipefail {0}
+          - os: macos-latest
+            platform: macos
+            shell: bash -leo pipefail {0}
+          - os: windows-x64-8cpu-32ram-300ssd
+            platform: windows
+            shell: powershell
+      fail-fast: false
+
+    steps:
+      - name: Free up disk space
+        if: matrix.platform == 'linux'
+        run: |
+          echo "=== Before cleanup ==="
+          df -h
+
+          # Remove unnecessary tools and files to free up space
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+
+          # Clean apt cache
+          sudo apt-get clean
+
+          echo "=== After cleanup ==="
+          df -h
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          role-duration-seconds: 3600
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ${{ matrix.platform == 'windows' && '-D warnings -C link-arg=/DEBUG:NONE' || '-D warnings' }}
+          cache: false # We use Swatinem/rust-cache directly below for save-if control.
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: python-test
+          # TODO: Commented out to test caching. Uncomment before merging.
+          #          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on main; always restore.
+          cache-all-crates: true
+          cache-on-failure: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          python-version: "3.11" # Test against the earliest supported Python version
+
+      - name: Install dependencies (macOS)
+        if: matrix.platform == 'macos'
+        run: |
+          brew update
+          brew install redis pkg-config
+          brew services start redis
+
+      - name: Setup test directories (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: |
+          mkdir -p data/test/runs
+          mkdir -p /tmp/oxen_sync/
+
+      - name: Setup test directories (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          mkdir .\data\test\runs
+
+      - name: Build oxen rust project
+        run: cargo build --workspace
+
+      - name: Setup oxen-server user (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: |
+          ./target/debug/oxen-server add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          cp user_config.toml data/test/config/user_config.toml
+
+      - name: Setup oxen-server user (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          copy user_config.toml data\test\config\user_config.toml
+
+      - name: Start oxen-server (Linux/macOS)
+        if: matrix.platform != 'windows'
+        run: ./target/debug/oxen-server start &
+
+      - name: Start oxen-server (Windows)
+        if: matrix.platform == 'windows'
+        run: Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start"
 
       # CLI Tests
       - name: Run CLI tests (Linux/macOS)

--- a/oxen-python/pyproject.toml
+++ b/oxen-python/pyproject.toml
@@ -42,3 +42,4 @@ build-backend = "maturin"
 manifest-path = "../crates/oxen-py/Cargo.toml"
 module-name = "oxen.oxen_py"
 python-source = "python"
+features = ["pyo3/extension-module"]

--- a/oxen-python/pyproject.toml
+++ b/oxen-python/pyproject.toml
@@ -42,4 +42,3 @@ build-backend = "maturin"
 manifest-path = "../crates/oxen-py/Cargo.toml"
 module-name = "oxen.oxen_py"
 python-source = "python"
-features = ["pyo3/extension-module"]


### PR DESCRIPTION
Chasing lower CI times now that our GitHub Action Cache size has been bumped larger by @jcelliott 

Update: Big win for CI times!!! Overall time reduced from 20m -> 13m for cache hits!!!

@jcelliott -- To make this change we need to:
1. Disable all required CI checks
2. Merge this PR
3. Merge main into open PRs (or wait until all currently-open PRs have been merged)
4. Enable required CI checks for the new job names.
