### PR TITLE
Collapse `Entry` newtype into `CommitEntry`

### DIFF
--- a/crates/lib/src/api/client/commits.rs
+++ b/crates/lib/src/api/client/commits.rs
@@ -496,7 +496,7 @@ pub async fn post_commits_to_server(
             .join(HISTORY_DIR)
             .join(&commit_with_entries.commit.id);
         let entries_size =
-            repositories::entries::compute_generic_entries_size(&commit_with_entries.entries)?;
+            repositories::entries::compute_entries_size(&commit_with_entries.entries)?;
 
         let size = match fs_extra::dir::get_size(&commit_history_dir) {
             Ok(size) => size + entries_size,

--- a/crates/lib/src/api/client/entries.rs
+++ b/crates/lib/src/api/client/entries.rs
@@ -2,9 +2,8 @@ use crate::api::client;
 use crate::config::UserConfig;
 use crate::constants::{AVG_CHUNK_SIZE, DEFAULT_BRANCH_NAME};
 use crate::error::OxenError;
-use crate::model::entry::commit_entry::Entry;
 use crate::model::{
-    EntryDataType, LocalRepository, MetadataEntry, NewCommitBody, RemoteRepository,
+    CommitEntry, EntryDataType, LocalRepository, MetadataEntry, NewCommitBody, RemoteRepository,
 };
 use crate::opts::UploadOpts;
 use crate::repositories;
@@ -329,14 +328,14 @@ pub async fn pull_large_entry(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,
     remote_path: impl AsRef<Path>,
-    entry: &Entry,
+    commit_entry: &CommitEntry,
 ) -> Result<(), OxenError> {
     // Read chunks
     let chunk_size = AVG_CHUNK_SIZE;
-    let total_size = entry.num_bytes();
+    let total_size = commit_entry.num_bytes;
     let num_chunks = total_size.div_ceil(chunk_size) as usize;
-    let hash = entry.hash();
-    let revision = entry.commit_id();
+    let hash = commit_entry.hash.clone();
+    let revision = commit_entry.commit_id.clone();
     let version_store = repo.version_store()?;
 
     let remote_path = remote_path.as_ref();

--- a/crates/lib/src/api/client/versions.rs
+++ b/crates/lib/src/api/client/versions.rs
@@ -3,8 +3,7 @@ use crate::api::client;
 use crate::api::client::internal_types::LocalOrBase;
 use crate::constants::{AVG_CHUNK_SIZE, max_retries};
 use crate::error::OxenError;
-use crate::model::entry::commit_entry::Entry;
-use crate::model::{LocalRepository, MerkleHash, RemoteRepository};
+use crate::model::{CommitEntry, LocalRepository, MerkleHash, RemoteRepository};
 use crate::util::{self, concurrency, hasher};
 use crate::view::versions::{
     CleanCorruptedVersionsResponse, CompleteVersionUploadRequest, CompletedFileUpload,
@@ -103,13 +102,13 @@ pub async fn parallel_large_file_upload(
     dst_dir: Option<impl AsRef<Path>>, // dst_dir is provided for workspace add workflow
     workspace_id: Option<String>,
     update_timestamp: bool,
-    entry: Option<Entry>,                 // entry is provided for push workflow
+    commit_entry: Option<CommitEntry>, // entry is provided for push workflow
     progress: Option<&Arc<PushProgress>>, // for push workflow
 ) -> Result<MultipartLargeFileUpload, OxenError> {
     log::debug!("multipart_large_file_upload path: {:?}", file_path.as_ref());
 
     let mut upload =
-        create_multipart_large_file_upload(remote_repo, file_path, dst_dir, entry).await?;
+        create_multipart_large_file_upload(remote_repo, file_path, dst_dir, commit_entry).await?;
 
     log::debug!("multipart_large_file_upload upload: {:?}", upload.hash);
 
@@ -143,13 +142,13 @@ async fn create_multipart_large_file_upload(
     remote_repo: &RemoteRepository,
     file_path: impl AsRef<Path>,
     dst_dir: Option<impl AsRef<Path>>,
-    entry: Option<Entry>,
+    commit_entry: Option<CommitEntry>,
 ) -> Result<MultipartLargeFileUpload, OxenError> {
     let file_path = file_path.as_ref();
     let dst_dir = dst_dir.as_ref();
 
-    let (file_size, hash) = match entry {
-        Some(entry) => (entry.num_bytes(), entry.hash()),
+    let (file_size, hash) = match commit_entry {
+        Some(commit_entry) => (commit_entry.num_bytes, commit_entry.hash.clone()),
         None => {
             // Figure out how many parts we need to upload
             let Ok(metadata) = file_path.metadata() else {
@@ -482,7 +481,7 @@ async fn complete_multipart_large_file_upload(
 pub async fn multipart_batch_upload_with_retry(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    chunk: &Vec<Entry>,
+    chunk: &[CommitEntry],
     client: &reqwest::Client,
 ) -> Result<(), OxenError> {
     let mut files_to_retry: Vec<ErrorFileInfo> = vec![];
@@ -514,7 +513,7 @@ pub async fn multipart_batch_upload_with_retry(
 pub async fn multipart_batch_upload(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    chunk: &Vec<Entry>,
+    chunk: &[CommitEntry],
     client: &reqwest::Client,
     files_to_retry: Vec<ErrorFileInfo>,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
@@ -529,32 +528,32 @@ pub async fn multipart_batch_upload(
         files_to_retry.iter().map(|f| f.hash.clone()).collect()
     };
 
-    for entry in chunk {
-        let file_hash = entry.hash();
+    for commit_entry in chunk {
+        let file_hash = &commit_entry.hash;
 
         // if it's not the first try and the file is not in the retry list, skip
-        if !files_to_retry.is_empty() && !retry_hashes.contains(&file_hash) {
+        if !files_to_retry.is_empty() && !retry_hashes.contains(file_hash) {
             continue;
         }
 
-        let data = version_store.get_version(&file_hash).await?;
+        let data = version_store.get_version(file_hash).await?;
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         std::io::copy(&mut data.as_slice(), &mut encoder)?;
         let compressed_bytes = match encoder.finish() {
             Ok(bytes) => bytes,
             Err(e) => {
-                log::error!("Failed to finish gzip for file {}: {}", &file_hash, e);
+                log::error!("Failed to finish gzip for file {}: {}", file_hash, e);
                 err_files.push(ErrorFileInfo {
                     hash: file_hash.clone(),
                     path: None,
-                    error: format!("Failed to finish gzip for file {}: {}", &file_hash, e),
+                    error: format!("Failed to finish gzip for file {}: {}", file_hash, e),
                 });
                 continue;
             }
         };
 
         let file_part = reqwest::multipart::Part::bytes(compressed_bytes)
-            .file_name(entry.hash().to_string())
+            .file_name(commit_entry.hash.clone())
             .mime_str("application/gzip")?;
         form = form.part("file[]", file_part);
     }

--- a/crates/lib/src/core/v_latest/download.rs
+++ b/crates/lib/src/core/v_latest/download.rs
@@ -4,7 +4,6 @@ use crate::model::CommitEntry;
 use crate::model::LocalRepository;
 use crate::model::MetadataEntry;
 use crate::model::RemoteRepository;
-use crate::model::entry::commit_entry::Entry;
 use crate::model::merkle_tree::node::EMerkleTreeNode;
 use crate::model::merkle_tree::node::MerkleTreeNode;
 use crate::{api, repositories};
@@ -118,18 +117,18 @@ async fn r_download_entries(
     }
 
     if let EMerkleTreeNode::VNode(_) = &node.node {
-        let mut entries: Vec<Entry> = vec![];
+        let mut entries: Vec<CommitEntry> = vec![];
 
         for child in &node.children {
             if let EMerkleTreeNode::File(file_node) = &child.node {
-                entries.push(Entry::CommitEntry(CommitEntry {
+                entries.push(CommitEntry {
                     commit_id: file_node.last_commit_id().to_string(),
                     path: directory.join(file_node.name()),
                     hash: child.hash.to_string(),
                     num_bytes: file_node.num_bytes(),
                     last_modified_seconds: file_node.last_modified_seconds(),
                     last_modified_nanoseconds: file_node.last_modified_nanoseconds(),
-                }));
+                });
             }
         }
 

--- a/crates/lib/src/core/v_latest/fetch.rs
+++ b/crates/lib/src/core/v_latest/fetch.rs
@@ -7,7 +7,6 @@ use crate::constants::{AVG_CHUNK_SIZE, OXEN_HIDDEN_DIR};
 use crate::core;
 use crate::core::refs::with_ref_manager;
 use crate::error::OxenError;
-use crate::model::entry::commit_entry::Entry;
 use crate::model::merkle_tree::node::{EMerkleTreeNode, MerkleTreeNode};
 use crate::model::{Branch, Commit, CommitEntry, MerkleHash};
 use crate::model::{LocalRepository, RemoteBranch, RemoteRepository};
@@ -141,7 +140,7 @@ pub async fn fetch_remote_branch(
         "Fetch got {} potentially missing entries",
         missing_entries.len()
     );
-    let missing_entries: Vec<Entry> = missing_entries.into_iter().collect();
+    let missing_entries: Vec<CommitEntry> = missing_entries.into_iter().collect();
     pull_progress.finish();
     let pull_progress = Arc::new(PullProgress::new_with_totals(
         missing_entries.len() as u64,
@@ -257,7 +256,7 @@ fn collect_missing_entries(
     depth: &Option<i32>,
     skip_shared_hashes: bool,
     total_bytes: &mut u64,
-) -> Result<HashSet<Entry>, OxenError> {
+) -> Result<HashSet<CommitEntry>, OxenError> {
     let mut missing_entries = HashSet::new();
 
     // When skip_shared_hashes is true (e.g. --missing-files), start with an empty set
@@ -344,7 +343,7 @@ fn collect_missing_entries(
 fn collect_missing_entries_for_subtree(
     node: &MerkleTreeNode,
     current_path: &Path,
-    missing_entries: &mut HashSet<Entry>,
+    missing_entries: &mut HashSet<CommitEntry>,
     file_hashes_seen: &mut HashSet<MerkleHash>,
     total_bytes: &mut u64,
 ) -> Result<(), OxenError> {
@@ -356,9 +355,8 @@ fn collect_missing_entries_for_subtree(
             if file_hashes_seen.insert(file_hash) {
                 let mut commit_entry = CommitEntry::from_node(&node.node);
                 commit_entry.path = current_path.join(&commit_entry.path);
-                let entry = Entry::CommitEntry(commit_entry);
-                *total_bytes += entry.num_bytes();
-                missing_entries.insert(entry);
+                *total_bytes += commit_entry.num_bytes;
+                missing_entries.insert(commit_entry);
             }
         }
         MerkleTreeNodeType::Dir => {
@@ -566,7 +564,7 @@ async fn r_download_entries(
 
     if let EMerkleTreeNode::VNode(_) = &node.node {
         // Figure out which entries need to be downloaded
-        let mut missing_entries: Vec<Entry> = vec![];
+        let mut missing_entries: Vec<CommitEntry> = vec![];
         let missing_hashes = repositories::tree::list_missing_file_hashes(repo, &node.hash).await?;
 
         for child in &node.children {
@@ -575,14 +573,14 @@ async fn r_download_entries(
                     continue;
                 }
 
-                missing_entries.push(Entry::CommitEntry(CommitEntry {
+                missing_entries.push(CommitEntry {
                     commit_id: file_node.last_commit_id().to_string(),
                     path: directory.join(file_node.name()),
                     hash: child.hash.to_string(),
                     num_bytes: file_node.num_bytes(),
                     last_modified_seconds: file_node.last_modified_seconds(),
                     last_modified_nanoseconds: file_node.last_modified_nanoseconds(),
-                }));
+                });
             }
         }
 
@@ -604,7 +602,7 @@ async fn r_download_entries(
 pub async fn pull_entries_to_versions_dir(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    entries: &[Entry],
+    entries: &[CommitEntry],
     progress_bar: &Arc<PullProgress>,
 ) -> Result<(), OxenError> {
     log::debug!("entries.len() {}", entries.len());
@@ -624,16 +622,16 @@ pub async fn pull_entries_to_versions_dir(
     // Hence we chunk and send the big ones, and bundle and download the small ones
 
     // For files smaller than AVG_CHUNK_SIZE, we are going to group them, zip them up, and transfer them
-    let smaller_entries: Vec<Entry> = missing_entries
+    let smaller_entries: Vec<CommitEntry> = missing_entries
         .iter()
-        .filter(|e| e.num_bytes() <= AVG_CHUNK_SIZE)
+        .filter(|e| e.num_bytes <= AVG_CHUNK_SIZE)
         .map(|e| e.to_owned())
         .collect();
 
     // For files larger than AVG_CHUNK_SIZE, we are going break them into chunks and download the chunks in parallel
-    let larger_entries: Vec<Entry> = missing_entries
+    let larger_entries: Vec<CommitEntry> = missing_entries
         .iter()
-        .filter(|e| e.num_bytes() > AVG_CHUNK_SIZE)
+        .filter(|e| e.num_bytes > AVG_CHUNK_SIZE)
         .map(|e| e.to_owned())
         .collect();
 
@@ -662,14 +660,14 @@ pub async fn pull_entries_to_versions_dir(
 async fn pull_large_entries(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    entries: Vec<Entry>,
+    entries: Vec<CommitEntry>,
     progress_bar: &Arc<PullProgress>,
 ) -> Result<(), OxenError> {
     if entries.is_empty() {
         return Ok(());
     }
     // Pull the large entries in parallel
-    type PieceOfWork = (LocalRepository, RemoteRepository, Entry);
+    type PieceOfWork = (LocalRepository, RemoteRepository, CommitEntry);
     type TaskQueue = deadqueue::limited::Queue<PieceOfWork>;
 
     log::debug!("Chunking and sending {} larger files", entries.len());
@@ -696,21 +694,26 @@ async fn pull_large_entries(
         let progress_bar = Arc::clone(progress_bar);
         let handle: tokio::task::JoinHandle<Result<(), OxenError>> = tokio::spawn(async move {
             loop {
-                let Some((repo, remote_repo, entry)) = queue.try_pop() else {
+                let Some((repo, remote_repo, commit_entry)) = queue.try_pop() else {
                     // reached end of queue
                     break;
                 };
                 log::debug!("worker[{worker}] processing task...");
 
                 // Chunk and individual files
-                let remote_path = &entry.path();
+                let remote_path = &commit_entry.path;
 
                 // Download to the tmp path, then copy over to the entries dir
-                api::client::entries::pull_large_entry(&repo, &remote_repo, &remote_path, &entry)
-                    .await?;
+                api::client::entries::pull_large_entry(
+                    &repo,
+                    &remote_repo,
+                    remote_path,
+                    &commit_entry,
+                )
+                .await?;
 
                 log::debug!("Pulled large entry {remote_path:?} to versions dir");
-                progress_bar.add_bytes(entry.num_bytes());
+                progress_bar.add_bytes(commit_entry.num_bytes);
                 progress_bar.add_files(1);
             }
             Ok(())
@@ -734,14 +737,14 @@ async fn pull_large_entries(
 async fn pull_small_entries(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    entries: Vec<Entry>,
+    entries: Vec<CommitEntry>,
     progress_bar: &Arc<PullProgress>,
 ) -> Result<(), OxenError> {
     if entries.is_empty() {
         return Ok(());
     }
 
-    let total_size = repositories::entries::compute_generic_entries_size(&entries)?;
+    let total_size = repositories::entries::compute_entries_size(&entries)?;
 
     // Compute num chunks
     let num_chunks = ((total_size / AVG_CHUNK_SIZE) + 1) as usize;
@@ -767,7 +770,10 @@ async fn pull_small_entries(
     let chunks: Vec<PieceOfWork> = entries
         .chunks(chunk_size)
         .map(|chunk| {
-            let hashes = chunk.iter().map(|entry| entry.hash().to_string()).collect();
+            let hashes = chunk
+                .iter()
+                .map(|commit_entry| commit_entry.hash.clone())
+                .collect();
             (remote_repo.to_owned(), hashes, repo.to_owned())
         })
         .collect();
@@ -821,7 +827,7 @@ async fn pull_small_entries(
 // download entries to working dir
 pub async fn download_entries_to_working_dir(
     remote_repo: &RemoteRepository,
-    entries: &[Entry],
+    entries: &[CommitEntry],
     dst: &Path,
     progress_bar: &Arc<PullProgress>,
 ) -> Result<(), OxenError> {
@@ -845,16 +851,16 @@ pub async fn download_entries_to_working_dir(
     // Hence we chunk and send the big ones, and bundle and download the small ones
 
     // For files smaller than AVG_CHUNK_SIZE, we are going to group them, zip them up, and transfer them
-    let smaller_entries: Vec<Entry> = missing_entries
+    let smaller_entries: Vec<CommitEntry> = missing_entries
         .iter()
-        .filter(|e| e.num_bytes() <= AVG_CHUNK_SIZE)
+        .filter(|e| e.num_bytes <= AVG_CHUNK_SIZE)
         .map(|e| e.to_owned())
         .collect();
 
     // For files larger than AVG_CHUNK_SIZE, we are going break them into chunks and download the chunks in parallel
-    let larger_entries: Vec<Entry> = missing_entries
+    let larger_entries: Vec<CommitEntry> = missing_entries
         .iter()
-        .filter(|e| e.num_bytes() > AVG_CHUNK_SIZE)
+        .filter(|e| e.num_bytes > AVG_CHUNK_SIZE)
         .map(|e| e.to_owned())
         .collect();
 
@@ -885,7 +891,7 @@ pub async fn download_entries_to_working_dir(
 
 async fn download_large_entries(
     remote_repo: &RemoteRepository,
-    entries: Vec<Entry>,
+    entries: Vec<CommitEntry>,
     dst: impl AsRef<Path>,
     progress_bar: &Arc<PullProgress>,
 ) -> Result<(), OxenError> {
@@ -893,7 +899,7 @@ async fn download_large_entries(
         return Ok(());
     }
     // Pull the large entries in parallel
-    type PieceOfWork = (RemoteRepository, Entry, PathBuf, PathBuf);
+    type PieceOfWork = (RemoteRepository, CommitEntry, PathBuf, PathBuf);
     type TaskQueue = deadqueue::limited::Queue<PieceOfWork>;
 
     log::debug!("Chunking and sending {} larger files", entries.len());
@@ -930,26 +936,26 @@ async fn download_large_entries(
         let progress_bar = Arc::clone(progress_bar);
         let handle: tokio::task::JoinHandle<Result<(), OxenError>> = tokio::spawn(async move {
             loop {
-                let Some((remote_repo, entry, _dst, download_path)) = queue.try_pop() else {
+                let Some((remote_repo, commit_entry, _dst, download_path)) = queue.try_pop() else {
                     // reached end of queue
                     break;
                 };
                 log::debug!("worker[{worker}] processing task...");
 
                 // Chunk and individual files
-                let remote_path = &entry.path();
+                let remote_path = &commit_entry.path;
 
                 // Download to the tmp path, then copy over to the entries dir
                 api::client::entries::download_large_entry(
                     &remote_repo,
-                    &remote_path,
+                    remote_path,
                     &download_path,
-                    &entry.commit_id(),
-                    entry.num_bytes(),
+                    &commit_entry.commit_id,
+                    commit_entry.num_bytes,
                 )
                 .await?;
 
-                progress_bar.add_bytes(entry.num_bytes());
+                progress_bar.add_bytes(commit_entry.num_bytes);
                 progress_bar.add_files(1);
             }
             Ok(())
@@ -972,7 +978,7 @@ async fn download_large_entries(
 
 async fn download_small_entries(
     remote_repo: &RemoteRepository,
-    entries: Vec<Entry>,
+    entries: Vec<CommitEntry>,
     dst: impl AsRef<Path>,
     progress_bar: &Arc<PullProgress>,
 ) -> Result<(), OxenError> {
@@ -980,7 +986,7 @@ async fn download_small_entries(
         return Ok(());
     }
 
-    let total_size = repositories::entries::compute_generic_entries_size(&entries)?;
+    let total_size = repositories::entries::compute_entries_size(&entries)?;
 
     // Compute num chunks
     let num_chunks = ((total_size / AVG_CHUNK_SIZE) + 1) as usize;
@@ -1004,7 +1010,7 @@ async fn download_small_entries(
         .map(|chunk| {
             let mut content_ids: Vec<(String, PathBuf)> = vec![];
             for e in chunk {
-                content_ids.push((e.hash(), e.path().to_owned()));
+                content_ids.push((e.hash.clone(), e.path.clone()));
             }
             (remote_repo.to_owned(), content_ids, dst.as_ref().to_owned())
         })
@@ -1056,12 +1062,12 @@ async fn download_small_entries(
     Ok(())
 }
 
-fn get_missing_entries_for_download(entries: &[Entry], dst: &Path) -> Vec<Entry> {
-    let mut missing_entries: Vec<Entry> = vec![];
-    for entry in entries {
-        let working_path = dst.join(entry.path());
+fn get_missing_entries_for_download(entries: &[CommitEntry], dst: &Path) -> Vec<CommitEntry> {
+    let mut missing_entries: Vec<CommitEntry> = vec![];
+    for commit_entry in entries {
+        let working_path = dst.join(&commit_entry.path);
         if !working_path.exists() {
-            missing_entries.push(entry.to_owned())
+            missing_entries.push(commit_entry.to_owned())
         }
     }
     missing_entries
@@ -1069,23 +1075,23 @@ fn get_missing_entries_for_download(entries: &[Entry], dst: &Path) -> Vec<Entry>
 
 async fn get_missing_entries_for_pull(
     version_store: &Arc<dyn VersionStore>,
-    entries: &[Entry],
-) -> Result<Vec<Entry>, OxenError> {
-    let mut missing_entries: Vec<Entry> = vec![];
+    entries: &[CommitEntry],
+) -> Result<Vec<CommitEntry>, OxenError> {
+    let mut missing_entries: Vec<CommitEntry> = vec![];
     // TODO: parallelize for S3
-    for entry in entries {
-        if !version_store.version_exists(&entry.hash()).await? {
-            missing_entries.push(entry.to_owned())
+    for commit_entry in entries {
+        if !version_store.version_exists(&commit_entry.hash).await? {
+            missing_entries.push(commit_entry.to_owned())
         }
     }
 
     Ok(missing_entries)
 }
 
-fn working_dir_paths_from_large_entries(entries: &[Entry], dst: &Path) -> Vec<PathBuf> {
+fn working_dir_paths_from_large_entries(entries: &[CommitEntry], dst: &Path) -> Vec<PathBuf> {
     let mut paths: Vec<PathBuf> = vec![];
-    for entry in entries.iter() {
-        let working_path = dst.join(entry.path());
+    for commit_entry in entries.iter() {
+        let working_path = dst.join(&commit_entry.path);
         paths.push(working_path);
     }
     paths

--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -10,7 +10,6 @@ use crate::constants::AVG_CHUNK_SIZE;
 use crate::constants::DEFAULT_REMOTE_NAME;
 use crate::core::progress::push_progress::PushProgress;
 use crate::error::OxenError;
-use crate::model::entry::commit_entry::Entry;
 use crate::model::merkle_tree::node::MerkleTreeNode;
 use crate::model::{
     Branch, Commit, CommitEntry, LocalRepository, MerkleHash, MerkleTreeNodeType, RemoteRepository,
@@ -254,15 +253,11 @@ async fn list_and_push_missing_files(
     head_commit: &Commit,
 ) -> Result<(), OxenError> {
     let missing_files =
-        api::client::commits::list_missing_files(remote_repo, base_commit, &head_commit.id)
-            .await?
-            .iter()
-            .map(|e| Entry::CommitEntry(e.clone()))
-            .collect::<Vec<Entry>>();
+        api::client::commits::list_missing_files(remote_repo, base_commit, &head_commit.id).await?;
 
-    if let Some(entry) = missing_files.first() {
+    if let Some(commit_entry) = missing_files.first() {
         let version_store = repo.version_store()?;
-        if !version_store.version_exists(&entry.hash()).await? {
+        if !version_store.version_exists(&commit_entry.hash).await? {
             return Err(OxenError::CannotPushShallowClone {
                 commit_id: head_commit.id.clone(),
                 commit_message: head_commit.message.clone(),
@@ -271,7 +266,7 @@ async fn list_and_push_missing_files(
         }
     }
 
-    let total_bytes = missing_files.iter().map(|e| e.num_bytes()).sum();
+    let total_bytes = missing_files.iter().map(|e| e.num_bytes).sum();
 
     let progress = Arc::new(PushProgress::new_with_totals(
         missing_files.len() as u64,
@@ -328,7 +323,7 @@ async fn get_commit_missing_hashes(
         let mut unique_hashes = HashSet::new();
         let mut file_hashes_seen = HashSet::new();
 
-        let mut files: Vec<Entry> = Vec::new();
+        let mut files: Vec<CommitEntry> = Vec::new();
         let mut dir_nodes: HashSet<MerkleHash> = HashSet::new();
 
         for path in paths {
@@ -356,7 +351,7 @@ async fn get_commit_missing_hashes(
                     let file_hash = *node.node.hash();
                     // Only add files we haven't seen before (not in base_hashes or already collected)
                     if !base_hashes.contains(&file_hash) && file_hashes_seen.insert(file_hash) {
-                        files.push(Entry::CommitEntry(CommitEntry::from_node(&node.node)));
+                        files.push(CommitEntry::from_node(&node.node));
                     }
                 } else if !node.node.is_leaf() {
                     let hash = node.node.hash();
@@ -375,7 +370,7 @@ async fn get_commit_missing_hashes(
         dir_nodes.insert(commit.hash()?);
 
         log::debug!("push_commits dir nodes: {dir_nodes:?}");
-        let total_bytes = files.iter().map(|e| e.num_bytes()).sum();
+        let total_bytes = files.iter().map(|e| e.num_bytes).sum();
 
         let push_commit_info = PushCommitInfo {
             unique_dir_nodes: dir_nodes,
@@ -391,7 +386,7 @@ async fn get_commit_missing_hashes(
 #[derive(Debug, Clone)]
 struct PushCommitInfo {
     unique_dir_nodes: HashSet<MerkleHash>,
-    unique_file_hashes: Vec<Entry>,
+    unique_file_hashes: Vec<CommitEntry>,
     total_bytes: u64,
 }
 
@@ -443,8 +438,8 @@ async fn push_commits(
     // unique files will be present.
     let version_store = repo.version_store()?;
     for (commit, info) in &commits_with_info {
-        if let Some(entry) = info.unique_file_hashes.first()
-            && !version_store.version_exists(&entry.hash()).await?
+        if let Some(commit_entry) = info.unique_file_hashes.first()
+            && !version_store.version_exists(&commit_entry.hash).await?
         {
             return Err(OxenError::CannotPushShallowClone {
                 commit_id: commit.id.clone(),
@@ -543,7 +538,7 @@ async fn push_commits(
 pub async fn push_entries(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    entries: &[Entry],
+    entries: &[CommitEntry],
     commit: &Commit,
     progress: &Arc<PushProgress>,
 ) -> Result<(), OxenError> {
@@ -558,16 +553,16 @@ pub async fn push_entries(
     // since bodies will be too big. Hence we chunk and send the big ones, and bundle and send the small ones
 
     // For files smaller than AVG_CHUNK_SIZE, we are going to group them, zip them up, and transfer them
-    let smaller_entries: Vec<Entry> = entries
+    let smaller_entries: Vec<CommitEntry> = entries
         .iter()
-        .filter(|e| e.num_bytes() <= AVG_CHUNK_SIZE)
+        .filter(|e| e.num_bytes <= AVG_CHUNK_SIZE)
         .map(|e| e.to_owned())
         .collect();
 
     // For files larger than AVG_CHUNK_SIZE, we are going break them into chunks and send the chunks in parallel
-    let larger_entries: Vec<Entry> = entries
+    let larger_entries: Vec<CommitEntry> = entries
         .iter()
-        .filter(|e| e.num_bytes() > AVG_CHUNK_SIZE)
+        .filter(|e| e.num_bytes > AVG_CHUNK_SIZE)
         .map(|e| e.to_owned())
         .collect();
 
@@ -602,7 +597,7 @@ pub async fn push_entries(
 async fn chunk_and_send_large_entries(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    entries: Vec<Entry>,
+    entries: Vec<CommitEntry>,
     progress: &Arc<PushProgress>,
 ) -> Result<(), OxenError> {
     if entries.is_empty() {
@@ -610,7 +605,7 @@ async fn chunk_and_send_large_entries(
     }
 
     use tokio::time::sleep;
-    type PieceOfWork = (Entry, RemoteRepository);
+    type PieceOfWork = (CommitEntry, RemoteRepository);
     type TaskQueue = deadqueue::limited::Queue<PieceOfWork>;
 
     log::debug!("Chunking and sending {} larger files", entries.len());
@@ -648,12 +643,12 @@ async fn chunk_and_send_large_entries(
                     break;
                 }
 
-                let Some((entry, remote_repo)) = queue.try_pop() else {
+                let Some((commit_entry, remote_repo)) = queue.try_pop() else {
                     // reached end of queue
                     break;
                 };
 
-                let version_path = match version_store.get_version_path(&entry.hash()).await {
+                let version_path = match version_store.get_version_path(&commit_entry.hash).await {
                     Ok(path) => path,
                     Err(e) => {
                         log::error!("Failed to get version path: {e}");
@@ -669,7 +664,7 @@ async fn chunk_and_send_large_entries(
                     None::<PathBuf>,
                     None,
                     false,
-                    Some(entry.clone()),
+                    Some(commit_entry.clone()),
                     Some(&bar),
                 )
                 .await
@@ -678,14 +673,14 @@ async fn chunk_and_send_large_entries(
                         log::debug!(
                             "worker[{}] successfully uploaded {:?}",
                             worker,
-                            entry.path()
+                            commit_entry.path
                         );
                     }
                     Err(err) => {
                         log::error!(
                             "worker[{}] failed to upload {:?}: {}",
                             worker,
-                            entry.path(),
+                            commit_entry.path,
                             err
                         );
                         should_stop.store(true, Ordering::Relaxed);
@@ -721,7 +716,7 @@ async fn chunk_and_send_large_entries(
 async fn bundle_and_send_small_entries(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    entries: Vec<Entry>,
+    entries: Vec<CommitEntry>,
     commit: &Commit,
     avg_chunk_size: u64,
     progress: &Arc<PushProgress>,
@@ -731,7 +726,7 @@ async fn bundle_and_send_small_entries(
     }
 
     // Compute size for this subset of entries
-    let total_size = repositories::entries::compute_generic_entries_size(&entries)?;
+    let total_size = repositories::entries::compute_entries_size(&entries)?;
     let num_chunks = ((total_size / avg_chunk_size) + 1) as usize;
 
     let mut chunk_size = entries.len() / num_chunks;
@@ -745,7 +740,7 @@ async fn bundle_and_send_small_entries(
     // Split into chunks, zip up, and post to server
     use tokio::time::sleep;
     type PieceOfWork = (
-        Vec<Entry>,
+        Vec<CommitEntry>,
         LocalRepository,
         Commit,
         RemoteRepository,
@@ -800,7 +795,7 @@ async fn bundle_and_send_small_entries(
                     break;
                 };
 
-                let chunk_size = match repositories::entries::compute_generic_entries_size(&chunk) {
+                let chunk_size = match repositories::entries::compute_entries_size(&chunk) {
                     Ok(size) => size,
                     Err(e) => {
                         log::error!("Failed to compute entries size: {e}");

--- a/crates/lib/src/model/entry/commit_entry.rs
+++ b/crates/lib/src/model/entry/commit_entry.rs
@@ -1,80 +1,11 @@
-use crate::constants::VERSION_FILE_NAME;
+use crate::model::Commit;
 use crate::model::merkle_tree::node::{DirNode, EMerkleTreeNode, FileNode};
-use crate::model::{Commit, MerkleHash};
 
-use filetime::FileTime;
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use utoipa::ToSchema;
-
-#[derive(Clone, Debug)]
-pub enum Entry {
-    CommitEntry(CommitEntry),
-}
-
-impl Hash for Entry {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match self {
-            Entry::CommitEntry(entry) => entry.hash.hash(state),
-        }
-    }
-}
-
-impl PartialEq for Entry {
-    fn eq(&self, other: &Entry) -> bool {
-        self.hash() == other.hash()
-    }
-}
-
-impl Eq for Entry {}
-
-impl Entry {
-    pub fn commit_id(&self) -> String {
-        match self {
-            Entry::CommitEntry(entry) => entry.commit_id.clone(),
-        }
-    }
-
-    pub fn path(&self) -> PathBuf {
-        match self {
-            Entry::CommitEntry(entry) => entry.path.clone(),
-        }
-    }
-
-    pub fn hash(&self) -> String {
-        match self {
-            Entry::CommitEntry(entry) => entry.hash.clone(),
-        }
-    }
-
-    pub fn num_bytes(&self) -> u64 {
-        match self {
-            Entry::CommitEntry(entry) => entry.num_bytes,
-        }
-    }
-    pub fn extension(&self) -> String {
-        match self {
-            Entry::CommitEntry(entry) => entry.extension(),
-        }
-    }
-}
-
-// get a From for entry
-impl From<CommitEntry> for Entry {
-    fn from(entry: CommitEntry) -> Self {
-        Entry::CommitEntry(entry)
-    }
-}
-
-impl From<Entry> for CommitEntry {
-    fn from(entry: Entry) -> Self {
-        match entry {
-            Entry::CommitEntry(entry) => entry,
-        }
-    }
-}
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct CommitPath {
@@ -82,6 +13,11 @@ pub struct CommitPath {
     pub path: PathBuf,
 }
 
+/// Represents a file or directory entry at a specific commit.
+///
+/// `Hash` and `Eq` are based on the content hash field, so `HashSet<CommitEntry>`
+/// deduplicates by file content. This is used during fetch and push to avoid
+/// transferring the same content twice.
 #[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct CommitEntry {
     pub commit_id: String,
@@ -100,44 +36,21 @@ pub struct CompareEntry {
     pub path: PathBuf,
 }
 
-// Hash on the path field so we can quickly look up
 impl PartialEq for CommitEntry {
     fn eq(&self, other: &CommitEntry) -> bool {
-        self.hash == other.hash && self.path == other.path
+        self.hash == other.hash
     }
 }
 
 impl Eq for CommitEntry {}
+
 impl Hash for CommitEntry {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.path.hash(state);
+        self.hash.hash(state);
     }
 }
 
 impl CommitEntry {
-    // For HashSet search purposes
-    pub fn from_path<T: AsRef<Path>>(path: T) -> CommitEntry {
-        CommitEntry {
-            commit_id: String::from(""),
-            path: path.as_ref().to_path_buf(),
-            hash: String::from(""),
-            num_bytes: 0,
-            last_modified_seconds: 0,
-            last_modified_nanoseconds: 0,
-        }
-    }
-
-    pub fn from_merkle_hash(hash: &MerkleHash) -> CommitEntry {
-        CommitEntry {
-            commit_id: String::from(""),
-            path: PathBuf::from(""), //Should we do this?
-            hash: hash.to_string(),
-            num_bytes: 0,
-            last_modified_seconds: 0,
-            last_modified_nanoseconds: 0,
-        }
-    }
-
     pub fn from_node(node: &EMerkleTreeNode) -> CommitEntry {
         match node {
             EMerkleTreeNode::Directory(dir_node) => CommitEntry::from_dir_node(dir_node),
@@ -166,26 +79,5 @@ impl CommitEntry {
             last_modified_seconds: dir_node.last_modified_seconds(),
             last_modified_nanoseconds: dir_node.last_modified_nanoseconds(),
         }
-    }
-
-    pub fn filename(&self) -> PathBuf {
-        if self.extension() == "" {
-            PathBuf::from(VERSION_FILE_NAME)
-        } else {
-            PathBuf::from(format!("{}.{}", VERSION_FILE_NAME, self.extension()))
-        }
-    }
-
-    pub fn extension(&self) -> String {
-        if let Some(ext) = self.path.extension() {
-            String::from(ext.to_str().unwrap_or(""))
-        } else {
-            String::from("")
-        }
-    }
-
-    pub fn has_different_modification_time(&self, time: &FileTime) -> bool {
-        self.last_modified_nanoseconds != time.nanoseconds()
-            || self.last_modified_seconds != time.unix_seconds()
     }
 }

--- a/crates/lib/src/model/entry/unsynced_commit_entry.rs
+++ b/crates/lib/src/model/entry/unsynced_commit_entry.rs
@@ -1,8 +1,7 @@
-use crate::model::Commit;
-use crate::model::entry::commit_entry::Entry;
+use crate::model::{Commit, CommitEntry};
 
 #[derive(Debug)]
 pub struct UnsyncedCommitEntries {
     pub commit: Commit,
-    pub entries: Vec<Entry>,
+    pub entries: Vec<CommitEntry>,
 }

--- a/crates/lib/src/repositories/entries.rs
+++ b/crates/lib/src/repositories/entries.rs
@@ -4,7 +4,6 @@
 use crate::core;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::entry::commit_entry::Entry;
 use crate::model::merkle_tree::node::{DirNode, FileNode};
 use crate::opts::{PaginateOpts, SortOpts};
 use crate::repositories;
@@ -254,11 +253,6 @@ pub fn count_for_commit(repo: &LocalRepository, commit: &Commit) -> Result<usize
 /// Given a list of entries, compute the total in bytes size of all entries.
 pub fn compute_entries_size(entries: &[CommitEntry]) -> Result<u64, OxenError> {
     let total_size: u64 = entries.into_par_iter().map(|e| e.num_bytes).sum();
-    Ok(total_size)
-}
-
-pub fn compute_generic_entries_size(entries: &[Entry]) -> Result<u64, OxenError> {
-    let total_size: u64 = entries.into_par_iter().map(|e| e.num_bytes()).sum();
     Ok(total_size)
 }
 


### PR DESCRIPTION
After the recent [dead code removal](#449), the `Entry` type does nothing other than wrap the `CommitEntry` type. This PR removes the `Entry` type to use `CommitEntry` directly.

- Deleted the entire `Entry` type  from `commit_entry.rs`
- Pruned a bunch of dead code from `CommitEntry`
- Changed on `CommitEntry`:
  -  `Hash`/`PartialEq` now use the content hash field. That's what the `Entry` wrapper was doing which was used by the fetch command, and nothing used `CommitEntry`'s path-based hashing.