### PR TITLE
Replace unmaintained `dotenv` with `dotenvy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,10 +2936,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "duckdb"
@@ -5444,7 +5444,7 @@ dependencies = [
  "bytesize",
  "clap",
  "derive_more 1.0.0",
- "dotenv",
+ "dotenvy",
  "dunce",
  "flate2",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ derive_more = { version = "1.0.0", features = ["full"] }
 dialoguer = "0.11.0"
 difference = "2.0.0"
 dirs = "5.0.1"
-dotenv = "0.15.0"
+dotenvy = "0.15.7"
 duckdb = { package = "duckdb", version = "=1.10502.0", default-features = false, features = ["serde_json"] }
 dunce = "1.0.4"
 env_logger = "0.11.3"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -34,7 +34,7 @@ async_zip = { workspace = true }
 bytesize = { workspace = true }
 clap = { workspace = true }
 derive_more = { workspace = true }
-dotenv = { workspace = true }
+dotenvy = { workspace = true }
 dunce = { workspace = true }
 flate2 = { workspace = true }
 futures-util = { workspace = true }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,5 +1,5 @@
-use dotenv::dotenv;
-use dotenv::from_filename;
+use dotenvy::dotenv;
+use dotenvy::from_filename;
 use liboxen::config::UserConfig;
 use liboxen::constants::OXEN_VERSION;
 use liboxen::error::OxenError;


### PR DESCRIPTION
The `dotenv` crate has been unmaintained since 2020 (RUSTSEC-2021-0141: https://rustsec.org/advisories/RUSTSEC-2021-0141.html). Swap it for the maintained fork `dotenvy`, which preserves the same API.