### PR TITLE
Delete unused `open_read_write_if_not_exists`

### DIFF
--- a/crates/lib/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/lib/src/core/db/merkle_node/merkle_node_db.rs
@@ -254,23 +254,6 @@ impl MerkleNodeDB {
         Self::open(path, true)
     }
 
-    pub fn open_read_write_if_not_exists<N: TMerkleTreeNode>(
-        repo: &LocalRepository,
-        node: &N,
-        parent_id: Option<MerkleHash>,
-    ) -> Result<Option<Self>, OxenError> {
-        if Self::exists(repo, &node.hash()) {
-            let db_path = node_db_path(repo, &node.hash());
-            log::debug!(
-                "open_read_write_if_not_exists skipping existing merkle node db at {}",
-                db_path.display()
-            );
-            Ok(None)
-        } else {
-            Ok(Some(Self::open_read_write(repo, node, parent_id)?))
-        }
-    }
-
     pub fn open_read_write<N: TMerkleTreeNode>(
         repo: &LocalRepository,
         node: &N,

--- a/crates/lib/src/repositories/commits/commit_writer.rs
+++ b/crates/lib/src/repositories/commits/commit_writer.rs
@@ -883,13 +883,6 @@ fn r_create_dir_node(
         //     vnode.entries.len()
         // );
 
-        // Maybe because we don't need to overwrite vnode dbs that already exist,
-        // but still need to recurse and create the children
-        // let mut maybe_vnode_db = MerkleNodeDB::open_read_write_if_not_exists(
-        //     repo,
-        //     &vnode_obj,
-        //     maybe_dir_db.as_ref().map(|db| db.node_id),
-        // )?;
         let mut vnode_db = MerkleNodeDB::open_read_write(
             repo,
             &vnode_obj,
@@ -918,14 +911,6 @@ fn r_create_dir_node(
                             &dir_node,
                             Some(vnode.id),
                         )?);
-                        // } else {
-                        //     // Otherwise, check if the dir is new before opening a new db
-                        //     MerkleNodeDB::open_read_write_if_not_exists(
-                        //         repo,
-                        //         &dir_node,
-                        //         Some(vnode.id),
-                        //     )?
-                        // };
 
                         r_create_dir_node(
                             repo,


### PR DESCRIPTION
Function `MerkleDbNode::open_read_write_if_not_exists` is unused.
Functionality can be recovered using a `MerkleDbNode::exists` check
before and a `MerkleDbNode::open_read_write` call.