### PR TITLE
Add `oxen clean` command to remove untracked files and directories

### DIFF
--- a/bin/otel-metrics-test
+++ b/bin/otel-metrics-test
@@ -293,7 +293,9 @@ if [ -z "$METRICS_OUTPUT" ]; then
   did_fail=true
 else
   echo "--- Prometheus /metrics sample ---"
-  echo "$METRICS_OUTPUT" | head -30
+  # Use a here-string so `head` closing after 30 lines doesn't SIGPIPE `echo` and
+  # trip `set -euo pipefail`, which was killing this test on long metrics output.
+  head -30 <<< "$METRICS_OUTPUT"
 
   # Check for HTTP request counters with non-zero values
   # Lines look like: http_requests_total{method="GET",path="...",status="200"} 5

--- a/crates/cli/src/cmd.rs
+++ b/crates/cli/src/cmd.rs
@@ -12,6 +12,9 @@ pub use branch::BranchCmd;
 pub mod checkout;
 pub use checkout::CheckoutCmd;
 
+pub mod clean;
+pub use clean::CleanCmd;
+
 pub mod clone;
 pub use clone::CloneCmd;
 

--- a/crates/cli/src/cmd/clean.rs
+++ b/crates/cli/src/cmd/clean.rs
@@ -1,0 +1,82 @@
+use async_trait::async_trait;
+use clap::{Arg, ArgMatches, Command};
+use std::path::PathBuf;
+
+use liboxen::error::OxenError;
+use liboxen::model::LocalRepository;
+use liboxen::opts::CleanOpts;
+use liboxen::repositories;
+
+use crate::cmd::RunCmd;
+use crate::helpers::check_repo_migration_needed;
+use crate::util;
+
+pub const NAME: &str = "clean";
+pub struct CleanCmd;
+
+#[async_trait]
+impl RunCmd for CleanCmd {
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn args(&self) -> Command {
+        Command::new(NAME)
+            .about("Remove untracked files and directories from the working tree")
+            .long_about(
+                "Remove untracked files and directories from the working tree.\n\n\
+                 Without `-f`, runs as a dry-run and prints what would be removed.\n\
+                 Pass `-f` to actually delete.\n\n\
+                 `.oxenignore`-matched files are always preserved.",
+            )
+            .arg(
+                Arg::new("force")
+                    .long("force")
+                    .short('f')
+                    .help("Actually remove the files. Without this flag, clean runs as a dry-run.")
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("paths")
+                    .num_args(0..)
+                    .help("Scope cleanup to these paths. Defaults to the whole working tree."),
+            )
+    }
+
+    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+        let repository = LocalRepository::from_current_dir()?;
+        check_repo_migration_needed(&repository)?;
+
+        let paths: Vec<PathBuf> = args
+            .get_many::<String>("paths")
+            .map(|vals| {
+                vals.map(|p| -> Result<PathBuf, OxenError> {
+                    let current_dir = std::env::current_dir()?;
+                    let joined = current_dir.join(p);
+                    util::fs::canonicalize(&joined).or_else(|_| Ok(joined))
+                })
+                .collect::<Result<Vec<PathBuf>, OxenError>>()
+            })
+            .transpose()?
+            .unwrap_or_default();
+
+        let opts = CleanOpts {
+            paths,
+            force: args.get_flag("force"),
+        };
+
+        let result = repositories::clean::clean(&repository, &opts).await?;
+
+        if result.files.is_empty() && result.dirs.is_empty() {
+            println!("Nothing to clean.");
+        } else if !result.applied {
+            println!(
+                "\nDry run: {} file(s), {} dir(s) would be removed. Re-run with -f to apply.",
+                result.files.len(),
+                result.dirs.len()
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -58,6 +58,7 @@ async fn async_main() -> ExitCode {
         Box::new(cmd::AddCmd),
         Box::new(cmd::BranchCmd),
         Box::new(cmd::CheckoutCmd),
+        Box::new(cmd::CleanCmd),
         Box::new(cmd::CloneCmd),
         Box::new(cmd::CommitCmd),
         Box::new(cmd::ConfigCmd),

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -50,6 +50,7 @@ async-std = { workspace = true }
 async-tar = { workspace = true }
 async-tempfile = { workspace = true }
 async-trait = { workspace = true }
+async-walkdir = { workspace = true }
 aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }
 aws-smithy-runtime-api = { workspace = true }
@@ -139,7 +140,6 @@ xxhash-rust = { workspace = true }
 zip = { workspace = true }
 
 [dev-dependencies]
-async-walkdir = { workspace = true }
 criterion = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }

--- a/crates/lib/src/core/v_latest.rs
+++ b/crates/lib/src/core/v_latest.rs
@@ -3,6 +3,7 @@
 
 pub mod add;
 pub mod branches;
+pub mod clean;
 pub mod clone;
 pub mod commits;
 pub mod data_frames;

--- a/crates/lib/src/core/v_latest/clean.rs
+++ b/crates/lib/src/core/v_latest/clean.rs
@@ -5,6 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
+use async_walkdir::WalkDir;
 use futures::{StreamExt, TryStreamExt, stream};
 
 use crate::constants::OXEN_HIDDEN_DIR;
@@ -57,32 +58,48 @@ pub async fn clean(repo: &LocalRepository, opts: &CleanOpts) -> Result<CleanResu
         .collect();
     dirs.sort();
 
-    // Calculate total bytes of files and directories to be cleaned
-    let mut total_bytes = 0u64;
-    for f in &files {
-        if let Ok(meta) = util::fs::metadata(repo.path.join(f)) {
-            total_bytes = total_bytes.saturating_add(meta.len());
-        }
-    }
+    // Calculate total bytes of files and directories to be cleaned. Top-level files are
+    // stat'd in parallel. Directory walks are processed one dir at a time, but within
+    // each walk the per-entry file_type + metadata lookups run concurrently — so we cap
+    // peak in-flight IO at ~32 per stage instead of multiplying across nested layers.
+    const STAT_CONCURRENCY: usize = 32;
+    let file_bytes: u64 = stream::iter(files.clone())
+        .map(|f| async move {
+            tokio::fs::metadata(repo.path.join(&f))
+                .await
+                .map(|m| m.len())
+                .unwrap_or(0)
+        })
+        .buffer_unordered(STAT_CONCURRENCY)
+        .fold(0u64, |acc, b| async move { acc.saturating_add(b) })
+        .await;
+
+    let mut dir_bytes: u64 = 0;
     for d in &dirs {
-        let abs = repo.path.join(d);
-        for entry in jwalk::WalkDir::new(&abs).into_iter().filter_map(|e| e.ok()) {
-            if entry.file_type().is_file()
-                && let Ok(meta) = entry.metadata()
-            {
-                total_bytes = total_bytes.saturating_add(meta.len());
-            }
-        }
+        let walk_total: u64 = WalkDir::new(repo.path.join(d))
+            .map(|res| async move {
+                let entry = res.ok()?;
+                let meta = entry.metadata().await.ok()?;
+                meta.is_file().then_some(meta.len())
+            })
+            .buffer_unordered(STAT_CONCURRENCY)
+            .filter_map(|x| async move { x })
+            .fold(0u64, |acc, b| async move { acc.saturating_add(b) })
+            .await;
+        dir_bytes = dir_bytes.saturating_add(walk_total);
     }
 
+    let total_bytes = file_bytes.saturating_add(dir_bytes);
+
     // Clean up files and directories
+    const DELETE_CONCURRENCY: usize = 10;
     if opts.force {
         stream::iter(files.clone())
             .map(|f| async move {
                 println!("Removing {}", f.display());
                 tokio::fs::remove_file(repo.path.join(&f)).await
             })
-            .buffer_unordered(10)
+            .buffer_unordered(DELETE_CONCURRENCY)
             .try_collect::<Vec<()>>()
             .await?;
         stream::iter(dirs.clone())
@@ -90,7 +107,7 @@ pub async fn clean(repo: &LocalRepository, opts: &CleanOpts) -> Result<CleanResu
                 println!("Removing {}/", d.display());
                 tokio::fs::remove_dir_all(repo.path.join(&d)).await
             })
-            .buffer_unordered(10)
+            .buffer_unordered(DELETE_CONCURRENCY)
             .try_collect::<Vec<()>>()
             .await?;
     } else {

--- a/crates/lib/src/core/v_latest/clean.rs
+++ b/crates/lib/src/core/v_latest/clean.rs
@@ -1,0 +1,114 @@
+//! # oxen clean (v_latest)
+//!
+//! Remove untracked files and directories from the working tree. See the `clean` module
+//! docs in `crates/lib/src/repositories/clean.rs` for behavior and the user-facing contract.
+
+use std::path::{Path, PathBuf};
+
+use crate::constants::OXEN_HIDDEN_DIR;
+use crate::error::OxenError;
+use crate::model::LocalRepository;
+use crate::model::staged_data::StagedDataOpts;
+use crate::opts::CleanOpts;
+use crate::repositories;
+use crate::util;
+
+/// Outcome of a `clean` invocation.
+///
+/// In dry-run mode (`applied == false`) the `files` and `dirs` lists describe what *would*
+/// be removed. In apply mode (`applied == true`) they describe what actually was removed.
+#[derive(Debug, Clone, Default)]
+pub struct CleanResult {
+    pub files: Vec<PathBuf>,
+    pub dirs: Vec<PathBuf>,
+    pub total_bytes: u64,
+    pub applied: bool,
+}
+
+pub async fn clean(repo: &LocalRepository, opts: &CleanOpts) -> Result<CleanResult, OxenError> {
+    // Resolve scoping paths to repo-relative. Empty scope == whole working tree.
+    let scope = opts
+        .paths
+        .iter()
+        .map(|p| util::fs::path_relative_to_dir(p, &repo.path))
+        .collect::<Result<Vec<PathBuf>, _>>()?;
+
+    // Trust `status` to filter `.oxenignore` and `.oxen/` — see core::v_latest::status. The
+    // explicit `.oxen/` guard below is defense-in-depth in case that ever regresses.
+    let status = repositories::status::status_from_opts(repo, &StagedDataOpts::default())?;
+
+    let mut files: Vec<PathBuf> = status
+        .untracked_files
+        .iter()
+        .filter(|p| !is_inside_oxen(p))
+        .filter(|p| path_in_scope(p, &scope))
+        .cloned()
+        .collect();
+    files.sort();
+
+    let mut dirs: Vec<PathBuf> = status
+        .untracked_dirs
+        .iter()
+        .map(|(p, _)| p.clone())
+        .filter(|p| !is_inside_oxen(p))
+        .filter(|p| path_in_scope(p, &scope))
+        .collect();
+    dirs.sort();
+
+    // Calculate total bytes of files and directories to be cleaned
+    let mut total_bytes = 0u64;
+    for f in &files {
+        if let Ok(meta) = util::fs::metadata(repo.path.join(f)) {
+            total_bytes = total_bytes.saturating_add(meta.len());
+        }
+    }
+    for d in &dirs {
+        let abs = repo.path.join(d);
+        for entry in jwalk::WalkDir::new(&abs).into_iter().filter_map(|e| e.ok()) {
+            if entry.file_type().is_file()
+                && let Ok(meta) = entry.metadata()
+            {
+                total_bytes = total_bytes.saturating_add(meta.len());
+            }
+        }
+    }
+
+    // Clean up files and directories
+    if opts.force {
+        for f in &files {
+            println!("Removing {}", f.display());
+            util::fs::remove_file(repo.path.join(f))?;
+        }
+        for d in &dirs {
+            println!("Removing {}/", d.display());
+            util::fs::remove_dir_all(repo.path.join(d))?;
+        }
+    } else {
+        for f in &files {
+            println!("Would remove {}", f.display());
+        }
+        for d in &dirs {
+            println!("Would remove {}/", d.display());
+        }
+    }
+
+    Ok(CleanResult {
+        files,
+        dirs,
+        total_bytes,
+        applied: opts.force,
+    })
+}
+
+fn is_inside_oxen(p: &Path) -> bool {
+    p.starts_with(OXEN_HIDDEN_DIR)
+}
+
+fn path_in_scope(candidate: &Path, scope: &[PathBuf]) -> bool {
+    if scope.is_empty() {
+        return true;
+    }
+    scope
+        .iter()
+        .any(|s| s.as_os_str().is_empty() || candidate == s.as_path() || candidate.starts_with(s))
+}

--- a/crates/lib/src/core/v_latest/clean.rs
+++ b/crates/lib/src/core/v_latest/clean.rs
@@ -5,6 +5,8 @@
 
 use std::path::{Path, PathBuf};
 
+use futures::{StreamExt, TryStreamExt, stream};
+
 use crate::constants::OXEN_HIDDEN_DIR;
 use crate::error::OxenError;
 use crate::model::LocalRepository;
@@ -75,14 +77,22 @@ pub async fn clean(repo: &LocalRepository, opts: &CleanOpts) -> Result<CleanResu
 
     // Clean up files and directories
     if opts.force {
-        for f in &files {
-            println!("Removing {}", f.display());
-            util::fs::remove_file(repo.path.join(f))?;
-        }
-        for d in &dirs {
-            println!("Removing {}/", d.display());
-            util::fs::remove_dir_all(repo.path.join(d))?;
-        }
+        stream::iter(files.clone())
+            .map(|f| async move {
+                println!("Removing {}", f.display());
+                tokio::fs::remove_file(repo.path.join(&f)).await
+            })
+            .buffer_unordered(10)
+            .try_collect::<Vec<()>>()
+            .await?;
+        stream::iter(dirs.clone())
+            .map(|d| async move {
+                println!("Removing {}/", d.display());
+                tokio::fs::remove_dir_all(repo.path.join(&d)).await
+            })
+            .buffer_unordered(10)
+            .try_collect::<Vec<()>>()
+            .await?;
     } else {
         for f in &files {
             println!("Would remove {}", f.display());

--- a/crates/lib/src/opts.rs
+++ b/crates/lib/src/opts.rs
@@ -2,6 +2,7 @@
 //!
 
 pub mod add_opts;
+pub mod clean_opts;
 pub mod clone_opts;
 pub mod count_lines_opts;
 pub mod df_opts;
@@ -23,6 +24,7 @@ pub mod storage_opts;
 pub mod upload_opts;
 
 pub use crate::opts::add_opts::AddOpts;
+pub use crate::opts::clean_opts::CleanOpts;
 pub use crate::opts::clone_opts::CloneOpts;
 pub use crate::opts::count_lines_opts::CountLinesOpts;
 pub use crate::opts::df_opts::DFOpts;

--- a/crates/lib/src/opts/clean_opts.rs
+++ b/crates/lib/src/opts/clean_opts.rs
@@ -1,0 +1,10 @@
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, Default)]
+pub struct CleanOpts {
+    /// Scope the cleanup to these paths (relative to cwd or absolute).
+    /// Empty means the whole working tree.
+    pub paths: Vec<PathBuf>,
+    /// Without `force`, `clean` runs as a dry-run and makes no filesystem changes.
+    pub force: bool,
+}

--- a/crates/lib/src/repositories.rs
+++ b/crates/lib/src/repositories.rs
@@ -25,6 +25,7 @@ use std::sync::LazyLock;
 pub mod add;
 pub mod branches;
 pub mod checkout;
+pub mod clean;
 pub mod clone;
 pub mod commits;
 pub mod data_frames;

--- a/crates/lib/src/repositories/clean.rs
+++ b/crates/lib/src/repositories/clean.rs
@@ -1,0 +1,293 @@
+//! # oxen clean
+//!
+//! Remove untracked files and directories from the working tree. Analogous to `git clean -fd`.
+//!
+//! Without `opts.force` the command is a dry run: it reports what *would* be removed but makes
+//! no filesystem changes. Pass `force = true` to actually delete.
+//!
+//! Invariants:
+//!
+//! - Never touches `.oxen/`.
+//! - Never touches tracked files (candidates come only from `StagedData.untracked_*`).
+//! - Never touches files matched by `.oxenignore` (inherited via `oxen status`'s existing
+//!   filter; `clean` does not re-filter).
+//! - An untracked directory is only removed whole when its entire subtree is untracked —
+//!   `oxen status` already classifies partially-tracked directories differently.
+
+use crate::core;
+use crate::core::v_latest::clean::CleanResult;
+use crate::core::versions::MinOxenVersion;
+use crate::error::OxenError;
+use crate::model::LocalRepository;
+use crate::opts::CleanOpts;
+
+/// Remove untracked files and directories from `repo`'s working tree.
+///
+/// See the module-level docs for the full behavior contract.
+pub async fn clean(repo: &LocalRepository, opts: &CleanOpts) -> Result<CleanResult, OxenError> {
+    match repo.min_version() {
+        MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
+        _ => core::v_latest::clean::clean(repo, opts).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::error::OxenError;
+    use crate::opts::CleanOpts;
+    use crate::repositories;
+    use crate::test;
+    use crate::util;
+
+    fn opts_force() -> CleanOpts {
+        CleanOpts {
+            paths: vec![],
+            force: true,
+        }
+    }
+
+    fn opts_dry_run() -> CleanOpts {
+        CleanOpts {
+            paths: vec![],
+            force: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_clean_force_removes_untracked_file() -> Result<(), OxenError> {
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let scratch = repo.path.join("scratch.txt");
+            util::fs::write_to_path(&scratch, "hello")?;
+
+            let result = repositories::clean::clean(&repo, &opts_force()).await?;
+
+            assert!(result.applied);
+            assert!(!scratch.exists());
+            assert!(result.files.contains(&PathBuf::from("scratch.txt")));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_clean_default_is_dry_run() -> Result<(), OxenError> {
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let scratch = repo.path.join("scratch.txt");
+            util::fs::write_to_path(&scratch, "hello")?;
+
+            let result = repositories::clean::clean(&repo, &opts_dry_run()).await?;
+
+            assert!(!result.applied);
+            assert!(scratch.exists(), "dry-run must not delete anything");
+            assert!(result.files.contains(&PathBuf::from("scratch.txt")));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_clean_force_removes_untracked_dir() -> Result<(), OxenError> {
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let junk_dir = repo.path.join("junk");
+            util::fs::create_dir_all(&junk_dir)?;
+            util::fs::write_to_path(junk_dir.join("a.txt"), "a")?;
+            util::fs::write_to_path(junk_dir.join("b.txt"), "b")?;
+
+            let result = repositories::clean::clean(&repo, &opts_force()).await?;
+
+            assert!(result.applied);
+            assert!(!junk_dir.exists(), "untracked dir should be removed");
+            assert!(result.dirs.contains(&PathBuf::from("junk")));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_clean_preserves_tracked_files() -> Result<(), OxenError> {
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            // labels.txt is tracked by the training_data helper.
+            let tracked = repo.path.join("labels.txt");
+            assert!(tracked.exists(), "sanity: tracked file should be present");
+
+            let untracked = repo.path.join("scratch.txt");
+            util::fs::write_to_path(&untracked, "hello")?;
+
+            repositories::clean::clean(&repo, &opts_force()).await?;
+
+            assert!(tracked.exists(), "tracked files must survive clean");
+            assert!(!untracked.exists(), "untracked file must be removed");
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_clean_preserves_oxen_dir() -> Result<(), OxenError> {
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let oxen_dir = repo.path.join(".oxen");
+            assert!(oxen_dir.exists(), "sanity: .oxen/ should exist");
+
+            let untracked = repo.path.join("scratch.txt");
+            util::fs::write_to_path(&untracked, "hello")?;
+
+            repositories::clean::clean(&repo, &opts_force()).await?;
+
+            assert!(oxen_dir.exists(), ".oxen/ must never be removed");
+            assert!(oxen_dir.join("HEAD").exists() || oxen_dir.join("config.toml").exists());
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_clean_respects_oxenignore() -> Result<(), OxenError> {
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let ignored_name = "ignored_scratch.txt";
+            util::fs::write_to_path(repo.path.join(ignored_name), "should stay")?;
+            util::fs::write_to_path(repo.path.join(".oxenignore"), ignored_name)?;
+
+            let result = repositories::clean::clean(&repo, &opts_force()).await?;
+
+            assert!(
+                repo.path.join(ignored_name).exists(),
+                ".oxenignore-matched file must not be removed"
+            );
+            assert!(
+                !result.files.iter().any(|p| p == Path::new(ignored_name)),
+                "CleanResult must not list ignored files"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_clean_path_scoping() -> Result<(), OxenError> {
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            util::fs::create_dir_all(repo.path.join("subtree_a"))?;
+            util::fs::create_dir_all(repo.path.join("subtree_b"))?;
+            util::fs::write_to_path(repo.path.join("subtree_a").join("x.txt"), "x")?;
+            util::fs::write_to_path(repo.path.join("subtree_b").join("y.txt"), "y")?;
+
+            let opts = CleanOpts {
+                paths: vec![repo.path.join("subtree_a"), repo.path.join(".oxen")],
+                force: true,
+            };
+            repositories::clean::clean(&repo, &opts).await?;
+
+            assert!(
+                !repo.path.join("subtree_a").exists(),
+                "subtree_a should be removed (in scope)"
+            );
+            assert!(
+                repo.path.join("subtree_b").join("y.txt").exists(),
+                "subtree_b should survive (out of scope)"
+            );
+            assert!(
+                repo.path.join(".oxen").exists(),
+                ".oxen should always survive, even if the user tries to clean it"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_clean_partially_untracked_dir_not_removed_wholesale() -> Result<(), OxenError> {
+        // `annotations/train/` is tracked; adding an untracked sibling file inside it
+        // should leave the tracked content alone and only remove the untracked file.
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let train_dir = repo.path.join("annotations").join("train");
+            let tracked = train_dir.join("bounding_box.csv");
+            assert!(tracked.exists(), "sanity: tracked file must exist");
+
+            let untracked = train_dir.join("scratch.txt");
+            util::fs::write_to_path(&untracked, "temp")?;
+
+            repositories::clean::clean(&repo, &opts_force()).await?;
+
+            assert!(train_dir.exists(), "partially-tracked dir must survive");
+            assert!(tracked.exists(), "tracked file must survive");
+            assert!(!untracked.exists(), "untracked file must be removed");
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_clean_result_counts() -> Result<(), OxenError> {
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            util::fs::write_to_path(repo.path.join("a.txt"), "12345")?; // 5 bytes
+            util::fs::write_to_path(repo.path.join("b.txt"), "hi")?; // 2 bytes
+
+            let junk_dir = repo.path.join("junk");
+            util::fs::create_dir_all(&junk_dir)?;
+            util::fs::write_to_path(junk_dir.join("c.txt"), "xyz")?; // 3 bytes
+
+            let result = repositories::clean::clean(&repo, &opts_dry_run()).await?;
+
+            assert_eq!(result.files.len(), 2, "two top-level untracked files");
+            assert_eq!(result.dirs.len(), 1, "one untracked directory");
+            assert_eq!(result.total_bytes, 10, "5 + 2 + 3 bytes across candidates");
+
+            // Dry-run: nothing removed.
+            assert!(repo.path.join("a.txt").exists());
+            assert!(repo.path.join("b.txt").exists());
+            assert!(junk_dir.exists());
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_clean_recovers_from_partial_pull_state() -> Result<(), OxenError> {
+        // Integration test mirroring the ENG-888 recovery flow: an interrupted pull leaves
+        // behind untracked files/dirs (from the target commit) plus modified tracked files.
+        // `oxen restore` handles the modifications, then `oxen clean -f` removes the
+        // untracked leftovers, leaving `oxen status` clean.
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            // Simulate modified tracked file left over from a partial pull.
+            let tracked = repo.path.join("labels.txt");
+            let original = util::fs::read_from_path(&tracked)?;
+            util::fs::write_to_path(&tracked, "partial write from interrupted pull\n")?;
+
+            // Simulate untracked leftovers: both a loose file and a new directory.
+            util::fs::write_to_path(repo.path.join("leftover.txt"), "stale")?;
+            util::fs::create_dir_all(repo.path.join("leftover_dir"))?;
+            util::fs::write_to_path(repo.path.join("leftover_dir").join("a.txt"), "a")?;
+
+            // Step 1: restore the modified tracked file.
+            repositories::restore::restore(
+                &repo,
+                crate::opts::RestoreOpts::from_path("labels.txt"),
+            )
+            .await?;
+            assert_eq!(util::fs::read_from_path(&tracked)?, original);
+
+            // Step 2: clean the untracked leftovers.
+            repositories::clean::clean(&repo, &opts_force()).await?;
+
+            // Working tree should now be clean.
+            let status = repositories::status::status(&repo)?;
+            assert!(
+                status.is_clean(),
+                "working tree should be clean after restore + clean; got {status:?}"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+}


### PR DESCRIPTION
Adds a first-class equivalent of `git clean -fd` scoped to Oxen working trees. Two drivers:

- ENG-888 recovery: an interrupted `oxen pull` leaves untracked files the next pull refuses to merge over, and customers currently work around this with a custom bash script. `oxen clean -f` replaces the script.
- ENG-924 recently removed a silent-deletion side effect from `oxen restore <dir>`, which left Oxen with no supported way to remove untracked content. `oxen clean` is the sanctioned home for that operation.

Behavior:

- `oxen clean` with no flags is a dry-run — prints `Would remove <path>` per candidate and makes no filesystem changes. `oxen clean -f` actually removes.
- Untracked directories are always included (no `-d` flag). `oxen status` already classifies a directory as "untracked" only when its whole subtree is untracked, so this is safe by construction.
- `.oxen/` is never touched — a defense-in-depth check on top of status's own exclusion.
- `.oxenignore`-matched files are always preserved; the filter is inherited from status rather than reapplied.
- Optional positional `[paths...]` scope the operation.

Fixes ENG-925.