### PR TITLE
Add mtime+size fast path to `oxen restore`

### DIFF
--- a/crates/lib/src/core/v_latest/index/restore.rs
+++ b/crates/lib/src/core/v_latest/index/restore.rs
@@ -1,5 +1,7 @@
 use rocksdb::{DBWithThreadMode, SingleThreaded, WriteBatch};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 use crate::constants::STAGED_DIR;
 use crate::core::db::{self};
@@ -10,7 +12,6 @@ use crate::opts::RestoreOpts;
 use crate::repositories;
 use crate::storage::version_store::VersionStore;
 use crate::util;
-use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct FileToRestore {
@@ -351,6 +352,14 @@ pub fn should_restore_file(
     Ok(true)
 }
 
+fn abs_duration_diff(a: SystemTime, b: SystemTime) -> Duration {
+    if a >= b {
+        a.duration_since(b).unwrap_or_default()
+    } else {
+        b.duration_since(a).unwrap_or_default()
+    }
+}
+
 pub async fn restore_file(
     repo: &LocalRepository,
     file_node: &FileNode,
@@ -363,6 +372,23 @@ pub async fn restore_file(
     let last_modified_nanoseconds = file_node.last_modified_nanoseconds();
 
     let working_path = repo.path.join(path);
+    let expected_mtime = SystemTime::UNIX_EPOCH
+        + Duration::from_secs(last_modified_seconds as u64)
+        + Duration::from_nanos(last_modified_nanoseconds as u64);
+
+    // Fast path: if the on-disk file already matches the target by size + mtime (within
+    // the filesystem's measured rounding), skip the copy entirely. Mirrors git's "stat
+    // index" heuristic. Tolerance comes from the version store's one-time-per-repo probe
+    // so we don't hard-code per-platform values and we catch cross-cutting cases like a
+    // FAT USB stick mounted on Linux.
+    if let Ok(meta) = tokio::fs::metadata(&working_path).await
+        && meta.len() == file_node.num_bytes()
+        && let Ok(actual_mtime) = meta.modified()
+        && abs_duration_diff(actual_mtime, expected_mtime) <= repo.mtime_tolerance().await
+    {
+        return Ok(());
+    }
+
     let parent = working_path.parent().unwrap();
     util::fs::create_dir_all(parent)?;
 
@@ -372,12 +398,9 @@ pub async fn restore_file(
         .copy_version_to_path(&hash_str, &working_path)
         .await?;
 
-    let last_modified = std::time::SystemTime::UNIX_EPOCH
-        + std::time::Duration::from_secs(last_modified_seconds as u64)
-        + std::time::Duration::from_nanos(last_modified_nanoseconds as u64);
     filetime::set_file_mtime(
         &working_path,
-        filetime::FileTime::from_system_time(last_modified),
+        filetime::FileTime::from_system_time(expected_mtime),
     )?;
     Ok(())
 }

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -13,8 +13,14 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::{Duration, SystemTime};
 use utoipa::ToSchema;
+
+/// Per-process cache of mtime round-trip tolerance, keyed by repo path. Probed at most
+/// once per repo per process via `probe_mtime_drift`.
+static MTIME_TOLERANCE_CACHE: LazyLock<Mutex<HashMap<PathBuf, Duration>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct LocalRepository {
@@ -508,6 +514,68 @@ impl LocalRepository {
             util::fs::remove_file(&shallow_flag_path)?;
         }
         Ok(())
+    }
+
+    /// Tolerance to allow when comparing an on-disk file's mtime against a value recorded
+    /// on a merkle-tree node (used by `restore`'s fast-path skip check, and available for
+    /// any other caller that needs to do mtime equality against a recorded value). The
+    /// working tree is always on the same filesystem as `.oxen/`, so we probe inside
+    /// `.oxen/` — same filesystem, guaranteed writable for a local repo, and already
+    /// hidden from `oxen status`.
+    ///
+    /// Returns `Duration::ZERO` if the filesystem round-trips nanosecond-precision
+    /// mtimes exactly (ext4 / APFS / NTFS), `Duration::from_secs(2)` if any drift is
+    /// detected (conservative upper bound covering FAT/exFAT's 2s rounding, HFS+'s 1s,
+    /// coarse NFS mounts, etc. — one probe isn't authoritative about the true max drift,
+    /// so we pick a safe ceiling). I/O errors also return `ZERO`.
+    ///
+    /// Probed at most once per repo per process; the result is memoized in a module-level
+    /// `HashMap` keyed by `self.path`.
+    pub async fn mtime_tolerance(&self) -> Duration {
+        if let Some(&t) = MTIME_TOLERANCE_CACHE
+            .lock()
+            .expect("mtime tolerance cache poisoned")
+            .get(&self.path)
+        {
+            return t;
+        }
+        let t = probe_mtime_drift(&self.path.join(constants::OXEN_HIDDEN_DIR)).await;
+        MTIME_TOLERANCE_CACHE
+            .lock()
+            .expect("mtime tolerance cache poisoned")
+            .insert(self.path.clone(), t);
+        t
+    }
+}
+
+/// Write a probe file inside `probe_dir`, set its mtime to a non-zero-nanosecond value,
+/// read the mtime back, and return a conservative tolerance. See `LocalRepository::mtime_tolerance`
+/// for the policy and rationale.
+async fn probe_mtime_drift(probe_dir: &Path) -> Duration {
+    let probe_path = probe_dir.join(".oxen-mtime-probe");
+    if tokio::fs::write(&probe_path, b"").await.is_err() {
+        return Duration::ZERO;
+    }
+    // 1970-01-01 00:00:01.123456789 — non-zero nanoseconds so any rounding is measurable.
+    let target = SystemTime::UNIX_EPOCH + Duration::new(1, 123_456_789);
+    let set_ok =
+        filetime::set_file_mtime(&probe_path, filetime::FileTime::from_system_time(target)).is_ok();
+    let drift_detected = if set_ok {
+        match tokio::fs::metadata(&probe_path).await {
+            Ok(meta) => meta
+                .modified()
+                .map(|actual| actual != target)
+                .unwrap_or(false),
+            Err(_) => false,
+        }
+    } else {
+        false
+    };
+    let _ = tokio::fs::remove_file(&probe_path).await;
+    if drift_detected {
+        Duration::from_secs(2)
+    } else {
+        Duration::ZERO
     }
 }
 

--- a/crates/lib/src/repositories/restore.rs
+++ b/crates/lib/src/repositories/restore.rs
@@ -349,6 +349,78 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_restore_fast_path_skips_when_mtime_and_size_match() -> Result<(), OxenError> {
+        // `restore_file` has a fast path that skips the copy when the on-disk file already
+        // matches the target by size + mtime (within the filesystem's measured rounding
+        // tolerance). We can observe that the fast path fired by setting up the state it
+        // checks for (matching size + matching mtime) with deliberately different content
+        // on disk, then asserting the content isn't rewritten.
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let filename = Path::new("annotations")
+                .join("train")
+                .join("annotations.txt");
+            let path = repo.path.join(&filename);
+
+            // Step 1: normal restore, capture the expected mtime.
+            repositories::restore::restore(&repo, RestoreOpts::from_path(&filename)).await?;
+            let meta = std::fs::metadata(&path)?;
+            let expected_mtime = meta.modified()?;
+            let size = meta.len();
+
+            // Step 2: overwrite with same-length garbage (distinct bytes).
+            let garbage: Vec<u8> = (0..size).map(|_| b'X').collect();
+            std::fs::write(&path, &garbage)?;
+
+            // Step 3: reset mtime to the recorded value.
+            filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(expected_mtime))?;
+
+            // Step 4: restore again — fast path should skip the copy.
+            repositories::restore::restore(&repo, RestoreOpts::from_path(&filename)).await?;
+
+            // Step 5: garbage should still be there.
+            let after = std::fs::read(&path).expect("read back after fast-path restore");
+            assert_eq!(
+                after, garbage,
+                "fast path should have skipped the copy, leaving garbage in place"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_restore_overwrites_when_mtime_differs_but_size_matches() -> Result<(), OxenError>
+    {
+        // Complement to the fast-path test above: if mtime doesn't match, restore should
+        // fall through to the full copy and fix the content even when size happens to match.
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let filename = Path::new("annotations")
+                .join("train")
+                .join("annotations.txt");
+            let path = repo.path.join(&filename);
+
+            let og_contents = util::fs::read_from_path(&path)?;
+            let size = std::fs::metadata(&path)?.len();
+
+            // Overwrite with same-length garbage and bump mtime to "now".
+            let garbage: Vec<u8> = (0..size).map(|_| b'X').collect();
+            std::fs::write(&path, &garbage)?;
+
+            repositories::restore::restore(&repo, RestoreOpts::from_path(&filename)).await?;
+
+            let after = util::fs::read_from_path(&path)?;
+            assert_eq!(
+                og_contents, after,
+                "restore should overwrite when mtime differs, even if size matches"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
     async fn test_restore_staged_file() -> Result<(), OxenError> {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             let bbox_file = Path::new("annotations")

--- a/crates/lib/src/repositories/restore.rs
+++ b/crates/lib/src/repositories/restore.rs
@@ -401,11 +401,25 @@ mod tests {
             let path = repo.path.join(&filename);
 
             let og_contents = util::fs::read_from_path(&path)?;
-            let size = std::fs::metadata(&path)?.len();
+            let og_meta = std::fs::metadata(&path)?;
+            let size = og_meta.len();
+            let recorded_mtime = og_meta.modified()?;
 
-            // Overwrite with same-length garbage and bump mtime to "now".
+            // Overwrite with same-length garbage.
             let garbage: Vec<u8> = (0..size).map(|_| b'X').collect();
             std::fs::write(&path, &garbage)?;
+
+            // Set the mtime explicitly outside the fast-path tolerance window so the
+            // fast path can't fire even on coarse filesystems. Without this, a coarse FS
+            // (e.g. FAT/exFAT or some NFS mounts) might round the post-write "now" back
+            // to the same second as the recorded mtime, leaving the diff inside the 2s
+            // tolerance and making the test flaky.
+            let tolerance = repo.mtime_tolerance().await;
+            let outside_tolerance = recorded_mtime + tolerance + std::time::Duration::from_secs(1);
+            filetime::set_file_mtime(
+                &path,
+                filetime::FileTime::from_system_time(outside_tolerance),
+            )?;
 
             repositories::restore::restore(&repo, RestoreOpts::from_path(&filename)).await?;
 


### PR DESCRIPTION
This PR drastically speeds up `oxen restore` operations where the majority of files don't need to be restored. The speedup comes by skipping the restore process for any file whose size and modification time match what we expect.

### Details

`restore_file` now short-circuits its `copy_version_to_path` + `set_file_mtime` when the on-disk file's size already matches `file_node.num_bytes()` and its mtime is within the repo's filesystem tolerance of the recorded `last_modified_{seconds,nanoseconds}`. Mirrors git's stat-based index check. Biggest wins: re-running `oxen restore .` on an already-clean tree, and recovery after a SIGTERM'd pull where most files already carry the target's content.

Adds `LocalRepository::mtime_tolerance()` as a cached per-repo probe. First call writes a probe file inside `.oxen/` (always on the same filesystem as the working tree), sets a nanosecond-precision mtime, reads it back, and returns `Duration::ZERO` when the round-trip is exact (ext4 / APFS / NTFS) or `Duration::from_secs(2)` if any drift is detected (conservative ceiling that covers FAT/exFAT's 2s rounding, HFS+'s 1s, coarse NFS mounts — one probe can't tell us the real max drift, so we pick a safe upper bound). Result is memoized in a module-private `HashMap<PathBuf, Duration>` keyed by repo path, so the probe runs at most once per repo per process. I/O errors fall back to `ZERO` (strict equality).

Fixes ENG-929