### PR TITLE
Share `reqwest::Client` instead of rebuilding per request

### DIFF
--- a/crates/lib/src/api/client.rs
+++ b/crates/lib/src/api/client.rs
@@ -97,7 +97,7 @@ fn new_for_host(host: String, should_add_user_agent: bool) -> Result<Client, Oxe
     // Double-check under the write lock; another thread may have inserted while we built.
     let mut cache = CLIENT_CACHE
         .write()
-        .map_err(|_| OxenError::client_cache_poisoned())?;
+        .map_err(|_| OxenError::ClientCachePoisoned)?;
     Ok(cache.entry(key).or_insert(client).clone())
 }
 

--- a/crates/lib/src/api/client.rs
+++ b/crates/lib/src/api/client.rs
@@ -12,6 +12,8 @@ use crate::view::http;
 pub use reqwest::Url;
 use reqwest::retry;
 use reqwest::{Client, ClientBuilder, header};
+use std::collections::HashMap;
+use std::sync::{LazyLock, RwLock};
 use std::time;
 
 pub mod branches;
@@ -49,8 +51,20 @@ pub fn get_scheme_and_host_from_url(url: &str) -> Result<(String, String), OxenE
     Ok((parsed_url.scheme().to_owned(), host_str))
 }
 
-// TODO: we probably want to create a pool of clients instead of constructing a
-// new one for each request so we can take advantage of keep-alive
+// Process-wide cache keyed by (host, with_user_agent) so reqwest's internal
+// connection pool, TLS session resumption, and HTTP/2 multiplexing actually
+// kick in. Auth token and UA string are read once per key during the first
+// build and then baked into the client — they're not part of the key, so a
+// mid-process auth or runtime-config change won't invalidate the cache.
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+struct ClientCacheKey {
+    host: String,
+    with_user_agent: bool,
+}
+
+static CLIENT_CACHE: LazyLock<RwLock<HashMap<ClientCacheKey, Client>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
 pub fn new_for_url(url: &str) -> Result<Client, OxenError> {
     let (_scheme, host) = get_scheme_and_host_from_url(url)?;
     new_for_host(host, true)
@@ -62,13 +76,29 @@ pub fn new_for_url_no_user_agent(url: &str) -> Result<Client, OxenError> {
 }
 
 fn new_for_host(host: String, should_add_user_agent: bool) -> Result<Client, OxenError> {
-    match builder_for_host(host, should_add_user_agent)?
-        .timeout(time::Duration::from_secs(constants::timeout()))
-        .build()
+    let key = ClientCacheKey {
+        host: host.clone(),
+        with_user_agent: should_add_user_agent,
+    };
+
+    // Fast path: read lock, return a clone if already built.
+    if let Ok(cache) = CLIENT_CACHE.read()
+        && let Some(client) = cache.get(&key)
     {
-        Ok(client) => Ok(client),
-        Err(reqwest_err) => Err(OxenError::HTTP(reqwest_err)),
+        return Ok(client.clone());
     }
+
+    // Slow path: build outside the write lock so concurrent first-time callers
+    // for *different* hosts don't serialize on one mutex.
+    let client = builder_for_host(host, should_add_user_agent)?
+        .timeout(time::Duration::from_secs(constants::timeout()))
+        .build()?;
+
+    // Double-check under the write lock; another thread may have inserted while we built.
+    let mut cache = CLIENT_CACHE
+        .write()
+        .map_err(|_| OxenError::client_cache_poisoned())?;
+    Ok(cache.entry(key).or_insert(client).clone())
 }
 
 pub fn new_for_remote_repo(remote_repo: &RemoteRepository) -> Result<Client, OxenError> {
@@ -76,14 +106,14 @@ pub fn new_for_remote_repo(remote_repo: &RemoteRepository) -> Result<Client, Oxe
     new_for_host(host, true)
 }
 
-pub fn builder_for_remote_repo(remote_repo: &RemoteRepository) -> Result<ClientBuilder, OxenError> {
-    let (_scheme, host) = get_scheme_and_host_from_url(remote_repo.url())?;
-    builder_for_host(host, true)
-}
-
 pub fn builder_for_url(url: &str) -> Result<ClientBuilder, OxenError> {
     let (_scheme, host) = get_scheme_and_host_from_url(url)?;
     builder_for_host(host, true)
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+pub fn cache_len_for_test() -> usize {
+    CLIENT_CACHE.read().map(|c| c.len()).unwrap_or(0)
 }
 
 fn builder_for_host(host: String, should_add_user_agent: bool) -> Result<ClientBuilder, OxenError> {
@@ -285,4 +315,33 @@ pub async fn handle_non_json_response(
     // If the response was an error, try to handle it as a standard json response.
     // We assume it's an error here because we checked the success status above.
     Err(parse_json_body(url, res).await.unwrap_err())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_for_url_reuses_cached_client_per_host_and_ua_flag() {
+        // Two calls with the same (host, with_user_agent) should add at most one entry
+        // to the cache regardless of how many times we call.
+        let before = cache_len_for_test();
+        let _c1 = new_for_url("http://eng938-test.invalid:9999/foo").unwrap();
+        let _c2 = new_for_url("http://eng938-test.invalid:9999/bar").unwrap();
+        let _c3 = new_for_url("http://eng938-test.invalid:9999/baz").unwrap();
+        let after_ua = cache_len_for_test();
+        assert!(
+            after_ua - before <= 1,
+            "expected same (host, with_user_agent=true) to dedup; before={before} after={after_ua}"
+        );
+
+        // Flipping the user-agent flag is a different cache key, so one more entry
+        // is allowed (but still bounded).
+        let _c4 = new_for_url_no_user_agent("http://eng938-test.invalid:9999/qux").unwrap();
+        let after_no_ua = cache_len_for_test();
+        assert!(
+            after_no_ua - before <= 2,
+            "expected at most two entries for both UA variants; before={before} after={after_no_ua}"
+        );
+    }
 }

--- a/crates/lib/src/api/client/versions.rs
+++ b/crates/lib/src/api/client/versions.rs
@@ -309,7 +309,7 @@ async fn upload_chunks(
     max_retries: usize,
     progress: Option<&Arc<PushProgress>>,
 ) -> Result<Vec<HashMap<String, String>>, OxenError> {
-    let client = Arc::new(api::client::builder_for_remote_repo(remote_repo)?.build()?);
+    let client = Arc::new(api::client::new_for_remote_repo(remote_repo)?);
 
     // Figure out how many parts we need to upload
     let file_size = upload.size;

--- a/crates/lib/src/api/client/workspaces/files.rs
+++ b/crates/lib/src/api/client/workspaces/files.rs
@@ -474,7 +474,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
     }
 
     // Create a client for uploading batches
-    let client = Arc::new(api::client::builder_for_remote_repo(remote_repo)?.build()?);
+    let client = Arc::new(api::client::new_for_remote_repo(remote_repo)?);
 
     // For individual files
     let err_files: Arc<Mutex<Vec<ErrorFileInfo>>> = Arc::new(Mutex::new(vec![]));

--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -735,7 +735,7 @@ async fn bundle_and_send_small_entries(
     }
 
     // Create a client for uploading chunks
-    let client = Arc::new(api::client::builder_for_remote_repo(remote_repo)?.build()?);
+    let client = Arc::new(api::client::new_for_remote_repo(remote_repo)?);
 
     // Split into chunks, zip up, and post to server
     use tokio::time::sleep;

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -598,11 +598,6 @@ impl OxenError {
         OxenError::InternalError(StringError::from(s.as_ref()))
     }
 
-    /// Make a new OxenError::ClientCachePoisoned error.
-    pub fn client_cache_poisoned() -> Self {
-        OxenError::ClientCachePoisoned
-    }
-
     //
     // OxenError::Basic constructors
     //

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -370,6 +370,11 @@ pub enum OxenError {
     #[error("Lock poisoned: {0}")]
     LockPoisoned(StringError),
 
+    /// The process-wide HTTP client cache's `RwLock` was found poisoned. Indicates a panic
+    /// occurred while another thread held the write lock; should not occur in normal operation.
+    #[error("Internal error: HTTP client cache lock poisoned")]
+    ClientCachePoisoned,
+
     #[error(
         "Cannot push commit '{commit_id}' (\"{commit_message}\"): file data is not available locally.\nThis usually means the repository was cloned without full history.\n{help}"
     )]
@@ -591,6 +596,11 @@ impl OxenError {
     /// Make a new OxenError::InternalError error.
     pub fn internal_error(s: impl AsRef<str>) -> Self {
         OxenError::InternalError(StringError::from(s.as_ref()))
+    }
+
+    /// Make a new OxenError::ClientCachePoisoned error.
+    pub fn client_cache_poisoned() -> Self {
+        OxenError::ClientCachePoisoned
     }
 
     //


### PR DESCRIPTION
Every API helper in `liboxen` was building a fresh `reqwest::Client` for every request, so reqwest's connection pool, TLS session resumption, (and possibly in the future, HTTP/2 multiplexing) never got a chance to kick in. Every request established its own new connection and went through the whole handshake process.

It was pretty straightforward to switch to reuse a cached client per host/user-agent combination.

Closes ENG-938.