### PR TITLE
Install Python 3.11 only in rust-test CI job

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-        with:
-          ignore-nothing-to-cache: true
 
       - name: Bump version
         id: bump

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          ignore-nothing-to-cache: true
 
       - name: Bump version
         id: bump

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -82,7 +82,6 @@ jobs:
         uses: astral-sh/setup-uv@v8.0.0
         with:
           python-version: "3.11" # Test against the earliest supported Python version
-          ignore-nothing-to-cache: true
 
       - name: Install dependencies (macOS)
         if: matrix.platform == 'macos'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -82,6 +82,7 @@ jobs:
         uses: astral-sh/setup-uv@v8.0.0
         with:
           python-version: "3.11" # Test against the earliest supported Python version
+          ignore-nothing-to-cache: true
 
       - name: Install dependencies (macOS)
         if: matrix.platform == 'macos'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -78,8 +78,8 @@ jobs:
           cache-all-crates: true
           cache-on-failure: true
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+      - name: Install Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11" # Test against the earliest supported Python version
 


### PR DESCRIPTION
The rust-test CI job needs Python 3.11 in order to build the `oxen-py` crate and
for its pyO3 dependencies. However, it doesn't use `uv` at all and the post uv install
step was sometimes failing in CI for verison-bump builds.

This PR changes to use the `actions/setup-python` step to install py 3.11 instead.