### PR TITLE
Add mtime tolerance to fast-forward merges

### DIFF
--- a/crates/lib/src/core/v_latest/index/restore.rs
+++ b/crates/lib/src/core/v_latest/index/restore.rs
@@ -254,6 +254,7 @@ pub async fn should_restore_partial_node(
             if repo
                 .mtime_matches(file_last_modified, node_last_modified)
                 .await
+                && file_size == file_node.num_bytes()
             {
                 return Ok(true);
             }
@@ -296,6 +297,7 @@ pub async fn should_restore_file(
             if repo
                 .mtime_matches(file_last_modified, node_last_modified)
                 .await
+                && meta.len() == base_node.num_bytes()
             {
                 return Ok(true);
             }
@@ -338,6 +340,7 @@ pub async fn should_restore_file(
             if repo
                 .mtime_matches(file_last_modified, node_last_modified)
                 .await
+                && meta.len() == file_node.num_bytes()
             {
                 return Ok(true);
             }

--- a/crates/lib/src/core/v_latest/index/restore.rs
+++ b/crates/lib/src/core/v_latest/index/restore.rs
@@ -201,7 +201,7 @@ async fn restore_dir(
     Ok(())
 }
 
-pub fn should_restore_partial_node(
+pub async fn should_restore_partial_node(
     repo: &LocalRepository,
     base_node: Option<PartialNode>,
     file_node: &FileNode,
@@ -222,7 +222,11 @@ pub fn should_restore_partial_node(
             let node_last_modified = base_node.last_modified;
             let node_size = base_node.size;
 
-            if file_last_modified == node_last_modified && file_size == node_size {
+            if repo
+                .mtime_matches(file_last_modified, node_last_modified)
+                .await
+                && file_size == node_size
+            {
                 return Ok(true);
             }
 
@@ -247,7 +251,10 @@ pub fn should_restore_partial_node(
             let node_last_modified =
                 filetime::FileTime::from_system_time(node_modified_nanoseconds);
 
-            if file_last_modified == node_last_modified {
+            if repo
+                .mtime_matches(file_last_modified, node_last_modified)
+                .await
+            {
                 return Ok(true);
             }
 
@@ -262,7 +269,7 @@ pub fn should_restore_partial_node(
     Ok(true)
 }
 
-pub fn should_restore_file(
+pub async fn should_restore_file(
     repo: &LocalRepository,
     base_node: Option<FileNode>,
     file_node: &FileNode,
@@ -286,7 +293,10 @@ pub fn should_restore_file(
             let node_last_modified =
                 filetime::FileTime::from_system_time(node_modified_nanoseconds);
 
-            if file_last_modified == node_last_modified {
+            if repo
+                .mtime_matches(file_last_modified, node_last_modified)
+                .await
+            {
                 return Ok(true);
             }
 
@@ -325,7 +335,10 @@ pub fn should_restore_file(
             let node_last_modified =
                 filetime::FileTime::from_system_time(node_modified_nanoseconds);
 
-            if file_last_modified == node_last_modified {
+            if repo
+                .mtime_matches(file_last_modified, node_last_modified)
+                .await
+            {
                 return Ok(true);
             }
 

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -724,14 +724,14 @@ async fn walk_merge_commit<'a>(
                         path: file_path.clone(),
                     });
                 } else if let Some(base_file_node) = base_files.get(&file_path) {
-                    let should_restore = restore::should_restore_partial_node(
-                        repo,
-                        Some(base_file_node.clone()),
-                        merge_file_node,
-                        &file_path,
-                    )
-                    .await?;
                     if node.hash != base_file_node.hash {
+                        let should_restore = restore::should_restore_partial_node(
+                            repo,
+                            Some(base_file_node.clone()),
+                            merge_file_node,
+                            &file_path,
+                        )
+                        .await?;
                         if should_restore {
                             results.entries_to_restore.push(FileToRestore {
                                 file_node: merge_file_node.clone(),
@@ -741,12 +741,9 @@ async fn walk_merge_commit<'a>(
                             results.cannot_overwrite_entries.push(file_path.clone());
                         }
                     } else {
-                        log::debug!(
-                            "Merge entry has not changed, but still !restore: {file_path:?}"
-                        );
-                        if !should_restore {
-                            results.cannot_overwrite_entries.push(file_path.clone());
-                        }
+                        // Merge target matches base for this path — nothing to apply, so a
+                        // locally modified working copy is not an overwrite conflict.
+                        log::debug!("Merge entry has not changed: {file_path:?}");
                     }
                 } else if restore::should_restore_file(repo, None, merge_file_node, &file_path)
                     .await?

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -31,10 +31,10 @@ use super::index::restore;
 use super::index::restore::FileToRestore;
 
 // entries_to_restore: files that ought to be restored from the currently traversed tree
-// I.e., In r_ff_merge_commit, it contains merge commit files that are not present in or have changed from the base tree
+// I.e., In walk_merge_commit, it contains merge commit files that are not present in or have changed from the base tree
 // cannot_overwrite_entries: files that would be restored, but are modified from the from_tree, and thus would erase work if overwritten
 
-// for r_ff_base_dir, the 'entries to restore' are actually entries being removed
+// for walk_base_dir, the 'entries to restore' are actually entries being removed
 struct MergeResult {
     pub entries_to_restore: Vec<FileToRestore>,
     pub cannot_overwrite_entries: Vec<PathBuf>,
@@ -644,19 +644,8 @@ async fn fast_forward_merge(
     };
 
     // Stop early if there are conflicts
-    let mut merge_tree_results = MergeResult::new();
-    let mut seen_files = HashSet::new();
-
-    r_ff_merge_commit(
-        repo,
-        &merge_tree,
-        PathBuf::from(""),
-        &mut merge_tree_results,
-        &mut partial_nodes,
-        &mut shared_hashes,
-        &mut seen_files,
-        is_resume,
-    )?;
+    let (merge_tree_results, seen_files) =
+        walk_merge_commit(repo, &merge_tree, &partial_nodes, &shared_hashes, is_resume).await?;
 
     if !merge_tree_results.cannot_overwrite_entries.is_empty() {
         return Err(OxenError::cannot_overwrite_files(
@@ -664,17 +653,8 @@ async fn fast_forward_merge(
         ));
     }
 
-    let mut base_tree_results = MergeResult::new();
-
-    r_ff_base_dir(
-        repo,
-        &base_tree,
-        PathBuf::from(""),
-        &mut base_tree_results,
-        &mut shared_hashes,
-        &mut seen_files,
-        is_resume,
-    )?;
+    let base_tree_results =
+        walk_base_dir(repo, &base_tree, &shared_hashes, &seen_files, is_resume).await?;
 
     // If there are no conflicts, restore the entries
     // Grouping the processing of merge_tree_results and base_tree_results like this ensures no files are modified if the merge doesn't complete
@@ -710,217 +690,168 @@ async fn fast_forward_merge(
     Ok(Some(merge_commit.clone()))
 }
 
-#[allow(clippy::too_many_arguments)]
-fn r_ff_merge_commit(
+/// Walk the merge tree and decide, file by file, whether each entry can be safely restored
+/// from the version store or whether the working copy looks like a local edit we shouldn't
+/// stomp on. Returns the populated `MergeResult` plus the set of paths actually seen on the
+/// merge side, which `walk_base_dir` consumes to find files HEAD has but the merge target
+/// doesn't (i.e., deletions to apply).
+async fn walk_merge_commit<'a>(
     repo: &LocalRepository,
-    merge_node: &MerkleTreeNode,
-    path: impl AsRef<Path>,
-    results: &mut MergeResult,
-    base_files: &mut HashMap<PathBuf, PartialNode>,
-    shared_hashes: &mut HashSet<MerkleHash>,
-    seen_files: &mut HashSet<PathBuf>,
+    root: &'a MerkleTreeNode,
+    base_files: &HashMap<PathBuf, PartialNode>,
+    shared_hashes: &HashSet<MerkleHash>,
     is_resume: bool,
-) -> Result<(), OxenError> {
-    let path = path.as_ref();
-    match &merge_node.node {
-        EMerkleTreeNode::File(merge_file_node) => {
-            let file_path = path.join(merge_file_node.name());
-            seen_files.insert(file_path.clone());
-            // log::debug!("r_ff_merge_commit file_path {:?}", file_path);
-            // log::debug!("merge_node {}", merge_node);
-            // log::debug!("merge_file_node {}", merge_file_node);
+) -> Result<(MergeResult, HashSet<PathBuf>), OxenError> {
+    let mut results = MergeResult::new();
+    let mut seen_files: HashSet<PathBuf> = HashSet::new();
+    let mut stack: Vec<(PathBuf, &'a MerkleTreeNode)> = vec![(PathBuf::new(), root)];
 
-            // If file_path found in base_tree, get the corresponding PartialNode
-            // A PartialNode is the minimal representation of a file necessary to determine whether it should be restored
-            // To properly handle moved files, the partial nodes are associated with their path in the base tree
-            // I.e., if a file has been moved in the merge tree, this code will find that it shouldn't be restored
+    while let Some((path, node)) = stack.pop() {
+        match &node.node {
+            EMerkleTreeNode::File(merge_file_node) => {
+                let file_path = path.join(merge_file_node.name());
+                seen_files.insert(file_path.clone());
 
-            if is_resume {
-                // Resuming an interrupted merge targeting this same commit:
-                // trust the target and force-restore every file the merge
-                // wants, regardless of working-tree state.
-                results.entries_to_restore.push(FileToRestore {
-                    file_node: merge_file_node.clone(),
-                    path: file_path.clone(),
-                });
-            } else if base_files.contains_key(&file_path) {
-                // if found, use to determine whether the file should be restored
-                let base_file_node = &base_files[&file_path];
-
-                // determine if file should be restored from its hash and last modified time
-                let should_restore = restore::should_restore_partial_node(
-                    repo,
-                    Some(base_file_node.clone()),
-                    merge_file_node,
-                    &file_path,
-                )?;
-                if merge_node.hash != base_file_node.hash {
-                    if should_restore {
-                        results.entries_to_restore.push(FileToRestore {
-                            file_node: merge_file_node.clone(),
-                            path: file_path.clone(),
-                        });
+                // If file_path is found in the base tree, look up the corresponding PartialNode —
+                // the minimal representation needed to decide whether to restore. PartialNodes are
+                // keyed by base-tree path so that a file moved between base and merge is correctly
+                // detected as "shouldn't restore".
+                if is_resume {
+                    // Resuming an interrupted merge targeting this same commit: trust the target
+                    // and force-restore every file the merge wants, regardless of working-tree state.
+                    results.entries_to_restore.push(FileToRestore {
+                        file_node: merge_file_node.clone(),
+                        path: file_path.clone(),
+                    });
+                } else if let Some(base_file_node) = base_files.get(&file_path) {
+                    let should_restore = restore::should_restore_partial_node(
+                        repo,
+                        Some(base_file_node.clone()),
+                        merge_file_node,
+                        &file_path,
+                    )
+                    .await?;
+                    if node.hash != base_file_node.hash {
+                        if should_restore {
+                            results.entries_to_restore.push(FileToRestore {
+                                file_node: merge_file_node.clone(),
+                                path: file_path.clone(),
+                            });
+                        } else {
+                            results.cannot_overwrite_entries.push(file_path.clone());
+                        }
                     } else {
-                        results.cannot_overwrite_entries.push(file_path.clone());
+                        log::debug!(
+                            "Merge entry has not changed, but still !restore: {file_path:?}"
+                        );
+                        if !should_restore {
+                            results.cannot_overwrite_entries.push(file_path.clone());
+                        }
                     }
+                } else if restore::should_restore_file(repo, None, merge_file_node, &file_path)
+                    .await?
+                {
+                    results.entries_to_restore.push(FileToRestore {
+                        file_node: merge_file_node.clone(),
+                        path: file_path.clone(),
+                    });
                 } else {
-                    log::debug!("Merge entry has not changed, but still !restore: {file_path:?}");
-                    if !should_restore {
-                        results.cannot_overwrite_entries.push(file_path.clone());
-                    }
+                    results.cannot_overwrite_entries.push(file_path.clone());
                 }
-            } else if restore::should_restore_file(repo, None, merge_file_node, &file_path)? {
-                results.entries_to_restore.push(FileToRestore {
-                    file_node: merge_file_node.clone(),
-                    path: file_path.clone(),
-                });
-            } else {
-                results.cannot_overwrite_entries.push(file_path.clone());
             }
-        }
-        EMerkleTreeNode::Directory(dir_node) => {
-            let dir_path = path.join(dir_node.name());
-            // Early exit if the directory is the same in the from and target trees
-            if shared_hashes.contains(&merge_node.hash) {
-                return Ok(());
-            };
-            let merge_children = {
-                // Get vnodes for the from dir node
-                let dir_vnodes = &merge_node.children;
-
-                // Only iterate through vnodes not shared between the trees
-                let mut unique_nodes = Vec::new();
-                for vnode in dir_vnodes {
+            EMerkleTreeNode::Directory(dir_node) => {
+                // Early exit if the directory is the same in the from and target trees.
+                if shared_hashes.contains(&node.hash) {
+                    continue;
+                }
+                let dir_path = path.join(dir_node.name());
+                // Only enqueue children of vnodes not shared between the trees.
+                for vnode in &node.children {
                     if !shared_hashes.contains(&vnode.hash) {
-                        unique_nodes.extend(vnode.children.iter().cloned());
+                        for child in &vnode.children {
+                            log::debug!("walk_merge_commit child_path {child}");
+                            stack.push((dir_path.clone(), child));
+                        }
                     }
                 }
-
-                unique_nodes
-            };
-
-            for child in merge_children.iter() {
-                log::debug!("r_ff_merge_commit child_path {child}");
-                r_ff_merge_commit(
-                    repo,
-                    child,
-                    &dir_path,
-                    results,
-                    base_files,
-                    shared_hashes,
-                    seen_files,
-                    is_resume,
-                )?;
             }
-        }
-        EMerkleTreeNode::Commit(_) => {
-            // If we get a commit node, we need to skip to the root directory
-            let root_dir = repositories::tree::get_root_dir(merge_node)?;
-            r_ff_merge_commit(
-                repo,
-                root_dir,
-                path,
-                results,
-                base_files,
-                shared_hashes,
-                seen_files,
-                is_resume,
-            )?;
-        }
-        _ => {
-            return Err(OxenError::basic_str(
-                "Got an unexpected node type during checkout",
-            ));
+            EMerkleTreeNode::Commit(_) => {
+                // Skip the commit wrapper to its root directory.
+                let root_dir = repositories::tree::get_root_dir(node)?;
+                stack.push((path, root_dir));
+            }
+            _ => {
+                return Err(OxenError::basic_str(
+                    "Got an unexpected node type during checkout",
+                ));
+            }
         }
     }
 
-    Ok(())
+    Ok((results, seen_files))
 }
 
-fn r_ff_base_dir(
+/// Walk the base (HEAD) tree to find files that exist in HEAD but not in the merge target —
+/// those are deletions the FF merge must apply on disk. Same iterative async depth-first
+/// search shape as `walk_merge_commit`. `merge_files` is the set of paths the merge walker
+/// visited.
+async fn walk_base_dir<'a>(
     repo: &LocalRepository,
-    base_node: &MerkleTreeNode,
-    path: impl AsRef<Path>,
-    results: &mut MergeResult,
-    shared_hashes: &mut HashSet<MerkleHash>,
-    merge_files: &mut HashSet<PathBuf>,
+    root: &'a MerkleTreeNode,
+    shared_hashes: &HashSet<MerkleHash>,
+    merge_files: &HashSet<PathBuf>,
     is_resume: bool,
-) -> Result<(), OxenError> {
-    let path = path.as_ref();
-    match &base_node.node {
-        EMerkleTreeNode::File(base_file_node) => {
-            let file_path = path.join(base_file_node.name());
-            // Remove all entries that are in HEAD but not in merge entries
-            if !merge_files.contains(&file_path) {
-                // Here, we don't need partial node representation, as we're only concerned with restoring files that aren't in the merge tree
-                let path = repo.path.join(file_path.clone());
-                if path.exists() {
-                    if is_resume
-                        || restore::should_restore_file(repo, None, base_file_node, &file_path)?
-                    {
-                        results.entries_to_restore.push(FileToRestore {
-                            file_node: base_file_node.clone(),
-                            path: path.clone(),
-                        });
-                    } else {
-                        results.cannot_overwrite_entries.push(file_path);
+) -> Result<MergeResult, OxenError> {
+    let mut results = MergeResult::new();
+    let mut stack: Vec<(PathBuf, &'a MerkleTreeNode)> = vec![(PathBuf::new(), root)];
+
+    while let Some((path, node)) = stack.pop() {
+        match &node.node {
+            EMerkleTreeNode::File(base_file_node) => {
+                let file_path = path.join(base_file_node.name());
+                // Only consider paths in HEAD that aren't also in the merge tree — those are
+                // the deletions to apply.
+                if !merge_files.contains(&file_path) {
+                    let full_path = repo.path.join(&file_path);
+                    if full_path.exists() {
+                        if is_resume
+                            || restore::should_restore_file(repo, None, base_file_node, &file_path)
+                                .await?
+                        {
+                            results.entries_to_restore.push(FileToRestore {
+                                file_node: base_file_node.clone(),
+                                path: full_path,
+                            });
+                        } else {
+                            results.cannot_overwrite_entries.push(file_path);
+                        }
                     }
                 }
             }
-        }
-        EMerkleTreeNode::Directory(dir_node) => {
-            let dir_path = path.join(dir_node.name());
-
-            if shared_hashes.contains(&base_node.hash) {
-                return Ok(());
-            };
-
-            let base_children = {
-                // Get vnodes for the from dir node
-                let dir_vnodes = &base_node.children;
-
-                // Only iterate through vnodes not shared between the trees
-                let mut unique_nodes = Vec::new();
-                for vnode in dir_vnodes {
+            EMerkleTreeNode::Directory(dir_node) => {
+                if shared_hashes.contains(&node.hash) {
+                    continue;
+                }
+                let dir_path = path.join(dir_node.name());
+                for vnode in &node.children {
                     if !shared_hashes.contains(&vnode.hash) {
-                        unique_nodes.extend(vnode.children.iter().cloned());
+                        for child in &vnode.children {
+                            stack.push((dir_path.clone(), child));
+                        }
                     }
                 }
-
-                unique_nodes
-            };
-
-            for child in base_children.iter() {
-                //log::debug!("r_ff_base_dir child_path {}", child);
-                r_ff_base_dir(
-                    repo,
-                    child,
-                    &dir_path,
-                    results,
-                    shared_hashes,
-                    merge_files,
-                    is_resume,
-                )?;
             }
-        }
-        EMerkleTreeNode::Commit(_) => {
-            // If we get a commit node, we need to skip to the root directory
-            let root_dir = repositories::tree::get_root_dir(base_node)?;
-            r_ff_base_dir(
-                repo,
-                root_dir,
-                path,
-                results,
-                shared_hashes,
-                merge_files,
-                is_resume,
-            )?;
-        }
-        _ => {
-            log::debug!("r_ff_base_dir unknown node type");
+            EMerkleTreeNode::Commit(_) => {
+                let root_dir = repositories::tree::get_root_dir(node)?;
+                stack.push((path, root_dir));
+            }
+            _ => {
+                log::debug!("walk_base_dir unknown node type");
+            }
         }
     }
-    Ok(())
+
+    Ok(results)
 }
 
 /// Perform a merge between commits.
@@ -1238,7 +1169,8 @@ pub async fn find_merge_conflicts(
                                 Some(base_file_node.clone()),
                                 merge_file_node,
                                 entry_path,
-                            )?
+                            )
+                            .await?
                         {
                             entries_to_restore.push(FileToRestore {
                                 file_node: merge_file_node.clone(),
@@ -1299,7 +1231,8 @@ pub async fn find_merge_conflicts(
                             base_file_node,
                             merge_file_node,
                             entry_path,
-                        )?
+                        )
+                        .await?
                     {
                         entries_to_restore.push(FileToRestore {
                             file_node: merge_file_node.clone(),
@@ -1325,7 +1258,8 @@ pub async fn find_merge_conflicts(
                 entries.push((entry_path.clone(), merge_file_node.clone(), Added));
                 if write_to_disk {
                     if is_resume
-                        || restore::should_restore_file(repo, None, merge_file_node, entry_path)?
+                        || restore::should_restore_file(repo, None, merge_file_node, entry_path)
+                            .await?
                     {
                         entries_to_restore.push(FileToRestore {
                             file_node: merge_file_node.clone(),

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -546,6 +546,43 @@ impl LocalRepository {
             .insert(self.path.clone(), t);
         t
     }
+
+    /// Compare two filesystem mtimes for equality, allowing for this repo's filesystem-rounding
+    /// tolerance. Used by the merge / restore code paths so the conflict check (`should_restore_*`)
+    /// agrees with `restore_file`'s fast-path skip — without this, a file whose mtime drifts
+    /// inside the tolerance window on coarse-mtime mounts (FAT/exFAT, HFS+, some NFS) is treated
+    /// as a no-op by one and as a unique local edit by the other, which is the bug behind a
+    /// spurious `cannot_overwrite_files` from `oxen pull` after `oxen restore .`.
+    pub async fn mtime_matches(&self, disk: filetime::FileTime, node: filetime::FileTime) -> bool {
+        if disk == node {
+            return true;
+        }
+        let tolerance = self.mtime_tolerance().await;
+        if tolerance.is_zero() {
+            return false;
+        }
+        let disk =
+            SystemTime::UNIX_EPOCH + Duration::new(disk.unix_seconds() as u64, disk.nanoseconds());
+        let node =
+            SystemTime::UNIX_EPOCH + Duration::new(node.unix_seconds() as u64, node.nanoseconds());
+        let diff = if disk >= node {
+            disk.duration_since(node).unwrap_or_default()
+        } else {
+            node.duration_since(disk).unwrap_or_default()
+        };
+        diff <= tolerance
+    }
+
+    /// Override the mtime tolerance for this repo path in the per-process cache. Test-only
+    /// hook for simulating coarse-mtime filesystems (FAT/HFS+/NFS) on hosts whose real FS
+    /// round-trips nanosecond mtimes exactly.
+    #[cfg(test)]
+    pub fn set_mtime_tolerance_for_test(&self, tolerance: Duration) {
+        MTIME_TOLERANCE_CACHE
+            .lock()
+            .expect("mtime tolerance cache poisoned")
+            .insert(self.path.clone(), tolerance);
+    }
 }
 
 /// Write a probe file inside `probe_dir`, set its mtime to a non-zero-nanosecond value,
@@ -581,10 +618,56 @@ async fn probe_mtime_drift(probe_dir: &Path) -> Duration {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use filetime::FileTime;
+
     use crate::error::OxenError;
     use crate::model::{LocalRepository, RepoNew};
     use crate::test;
     use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_mtime_matches_honors_tolerance() -> Result<(), OxenError> {
+        // Regression for ENG-94X: on coarse-mtime mounts (FAT/exFAT, HFS+, some NFS) a file's
+        // disk mtime can drift inside the FS-rounding window relative to the value recorded on
+        // a merkle node. `restore_file`'s fast path skips inside that window; the merge-side
+        // conflict check (`should_restore_*`) must agree, or `oxen pull` after `oxen restore .`
+        // surfaces a spurious `cannot_overwrite_files`. `mtime_matches` is the single point
+        // they both consult, so unit-test it directly here.
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let a = FileTime::from_unix_time(1_000_000, 500_000_000);
+            let b = FileTime::from_unix_time(1_000_000, 500_000_000);
+            let one_sec_off = FileTime::from_unix_time(1_000_001, 500_000_000);
+            let three_sec_off = FileTime::from_unix_time(1_000_003, 500_000_000);
+
+            // Default tolerance on the test host's FS is ZERO (APFS/ext4 round-trip nanos), so
+            // anything but exact equality is rejected.
+            repo.set_mtime_tolerance_for_test(Duration::ZERO);
+            assert!(
+                repo.mtime_matches(a, b).await,
+                "exact equality always matches"
+            );
+            assert!(
+                !repo.mtime_matches(a, one_sec_off).await,
+                "1 s drift must not match when tolerance is zero",
+            );
+
+            // Simulate a coarse-mtime mount.
+            repo.set_mtime_tolerance_for_test(Duration::from_secs(2));
+            assert!(
+                repo.mtime_matches(a, one_sec_off).await,
+                "1 s drift is inside the 2 s tolerance window",
+            );
+            assert!(
+                !repo.mtime_matches(a, three_sec_off).await,
+                "3 s drift is outside the 2 s tolerance window",
+            );
+
+            Ok(())
+        })
+        .await
+    }
 
     #[test]
     fn test_get_dirname_from_url() -> Result<(), OxenError> {

--- a/crates/lib/src/repositories/pull.rs
+++ b/crates/lib/src/repositories/pull.rs
@@ -1810,7 +1810,7 @@ mod tests {
 
                 // Pull should succeed because we did not modify README on remote
                 let result = repositories::pull(&user_a_repo).await;
-                assert!(result.is_err());
+                assert!(result.is_ok());
 
                 // Make sure that the local changes are not overwritten
                 let content = util::fs::read_from_path(&modified_file_path)?;
@@ -1818,7 +1818,7 @@ mod tests {
 
                 // Pull again
                 let result = repositories::pull(&user_a_repo).await;
-                assert!(result.is_err());
+                assert!(result.is_ok());
 
                 // Make sure that the local changes are still not overwritten
                 let content = util::fs::read_from_path(&modified_file_path)?;


### PR DESCRIPTION
This PR adds mtime tolerance to fast-forward merges, which affects `oxen merge` and `oxen pull`. In #485 we added mtime tolerance to `oxen restore`. We need to add the same mtime tolerance to the remaining places that compare mtimes.

- This diff _looks_ scary because, in order to use the `async` mtime stuff, I needed to convert some recursive helper functions to iterative `async` functions. Even though the diff is large, the conversion is pretty mechanical (adding a Vec to use as a stack, then looping and pushing to the stack, rather than making recursive calls). 
- The consequential changes are:
  - Adding the `mtime_matches` method to the `LocalRepository` struct in [`local_repository.rs:556-574`](https://github.com/Oxen-AI/Oxen/pull/492/changes#diff-54874de6772880d4d055a3dbb4d744047c2ea20231e90c3d5111a848205a82c1R556-R574)
  - Calling the `mtime_matches` method from within `should_restore_partial_node` and `should_restore_file ` in [`restore.rs`](https://github.com/Oxen-AI/Oxen/pull/492/changes#diff-6a2183e0ba4007a9f864185f1e6f9857bcc45d4f14c5c56712e246dc8d5f4a12)

Closes ENG-986.