### PR TITLE
Speed up CI's production build job

### DIFF
--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -43,7 +43,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-          workspaces: "."
+          prefix-key: rust-production
+          cache-all-crates: true
+          cache-on-failure: true
 
       - name: Install FFmpeg dev libraries
         run: |


### PR DESCRIPTION
The `Production Build` CI job is [often](https://github.com/Oxen-AI/Oxen/actions/runs/25078086319?pr=495) [abnormally](https://github.com/Oxen-AI/Oxen/actions/runs/25070811695) [slow](https://github.com/Oxen-AI/Oxen/actions/runs/25077264947) compared to the other similar jobs that have slightly less features enabled. I think the main culprit is the lack of `prefix-key` setting on the cache so that it gets exactly its own cach back, rather than matching on some other cache that was produced on the same operating system. The lack of the other cache settings that we use may also be contributing factors.

Since the cache only saves once merged into `main,` we won't see the benefit of this change until this PR is merged to `main`, its CI runs, it caches the run, and a new PR _with these changes merged in_ runs CI.

Closes ENG-982.