### PR TITLE
Add mtime tolerance to `oxen-status`

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -136,6 +136,8 @@ oxen push origin main               # Push to remote
 - When updating a dependency, prefer updating to the latest stable version.
 - Any new or changed Rust code that touches IO (file system, network, etc.) should be async code. Instead of std::io or std::fs, use equivalents from tokio. When an external dependency doesn't support async, use tokio's spawn_blocking functionality.
 - oxen-server operations should never touch a local checkout on disk when doing operations initiated by its API.
+- Always use `metadata.is_dir()` instead of `path.is_dir()`. `path.is_dir()` follows symlinks, which Oxen does not track — using it risks descending into directories outside the working tree (or into cycles via cyclic links).
+- Oxen does not track symlinks. New code that traverses the working tree should check `metadata.is_symlink()` and skip rather than resolve, follow, or record symlinks.
 
 # Testing Rules
 - Use the test helpers in `crates/lib/src/test.rs` (e.g., `run_empty_local_repo_test`) for unit tests in the lib code.

--- a/crates/cli/src/cmd/commit.rs
+++ b/crates/cli/src/cmd/commit.rs
@@ -54,7 +54,7 @@ impl RunCmd for CommitCmd {
         println!("Committing with message: {message}");
 
         if allow_empty {
-            repositories::commits::commit_allow_empty(&repo, &message)?;
+            repositories::commits::commit_allow_empty(&repo, &message).await?;
         } else {
             repositories::commit(&repo, &message)?;
         }

--- a/crates/cli/src/cmd/rm.rs
+++ b/crates/cli/src/cmd/rm.rs
@@ -70,7 +70,7 @@ impl RunCmd for RmCmd {
 
         for path in paths {
             let path_opts = RmOpts::from_path_opts(&path, &opts);
-            repositories::rm(&repository, &path_opts)?;
+            repositories::rm(&repository, &path_opts).await?;
         }
 
         Ok(())

--- a/crates/cli/src/cmd/status.rs
+++ b/crates/cli/src/cmd/status.rs
@@ -93,7 +93,7 @@ impl RunCmd for StatusCmd {
         };
         log::debug!("status opts: {opts:?}");
 
-        let repo_status = repositories::status::status_from_opts(&repository, &opts)?;
+        let repo_status = repositories::status::status_from_opts(&repository, &opts).await?;
 
         if let Some(current_branch) = repositories::branches::current_branch(&repository)? {
             println!(

--- a/crates/lib/src/api/client/diff.rs
+++ b/crates/lib/src/api/client/diff.rs
@@ -1002,7 +1002,7 @@ who won the game?,The packers beat up on the bears,packers
             util::fs::remove_file(&repo_filepath)?;
 
             let rm_opts = RmOpts::from_path(Path::new("images").join("cats").join("cat_2.jpg"));
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
             repositories::commit(&repo, "Remove and modify some cats")?;
 
             // Set the proper remote
@@ -1140,7 +1140,7 @@ who won the game?,The packers beat up on the bears,packers
                 staged: false,
                 recursive: true,
             };
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
             repositories::commit(&repo, "Removing cat images")?;
 
             // Set the proper remote
@@ -1257,7 +1257,7 @@ who won the game?,The packers beat up on the bears,packers
                 recursive: true,
                 ..Default::default()
             };
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
             repositories::commit(&repo, "Removing cat images")?;
 
             // Set the proper remote
@@ -1760,7 +1760,7 @@ who won the game?,The packers beat up on the bears,packers
                 recursive: true,
                 ..Default::default()
             };
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
             repositories::commit(&repo, "Removing cat images")?;
 
             // Set the proper remote
@@ -1868,7 +1868,7 @@ who won the game?,The packers beat up on the bears,packers
             let repo_filepath = PathBuf::from("images").join("dog_1.jpg");
 
             let rm_opts = RmOpts::from_path(repo_filepath);
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
             repositories::commit(&repo, "Removing dog")?;
 
             // Add dwight howard and vince carter

--- a/crates/lib/src/api/client/workspaces/files.rs
+++ b/crates/lib/src/api/client/workspaces/files.rs
@@ -89,7 +89,7 @@ pub async fn add_with_opts(
         walk_dirs: true,
     };
 
-    let expanded_paths = util::glob::parse_glob_paths(&glob_opts, local_repo.as_ref())?;
+    let expanded_paths = util::glob::parse_glob_paths(&glob_opts, local_repo.as_ref()).await?;
     let expanded_paths: Vec<PathBuf> = expanded_paths.iter().cloned().collect();
     // TODO: add a progress bar
 
@@ -1058,7 +1058,7 @@ pub async fn rm_files(
     };
 
     let expanded_paths: HashSet<PathBuf> =
-        util::glob::parse_glob_paths(&glob_opts, Some(local_repo))?;
+        util::glob::parse_glob_paths(&glob_opts, Some(local_repo)).await?;
 
     // Convert to relative paths
     let repo_path = &local_repo.path;

--- a/crates/lib/src/core/v_latest/add.rs
+++ b/crates/lib/src/core/v_latest/add.rs
@@ -94,7 +94,7 @@ pub async fn add<T: AsRef<Path>>(
             walk_dirs: false,
         };
 
-        let matching_paths = util::glob::parse_glob_paths(&glob_opts, Some(repo))?;
+        let matching_paths = util::glob::parse_glob_paths(&glob_opts, Some(repo)).await?;
 
         expanded_paths.extend(matching_paths);
 
@@ -234,7 +234,7 @@ pub async fn add_files(
     // TODO: Make rm_with_staged_db return the stats of the files it removes
     if !paths_to_remove.is_empty() {
         log::trace!("removing paths: {:?}", paths_to_remove);
-        core::v_latest::rm::rm_with_staged_db(&paths_to_remove, repo, &rm_opts, &staged_db)?;
+        core::v_latest::rm::rm_with_staged_db(&paths_to_remove, repo, &rm_opts, &staged_db).await?;
     }
 
     // Stop the timer, and round the duration to the nearest second
@@ -1289,7 +1289,7 @@ mod tests {
 
             add(&repo, vec![Path::new(&repo.path)]).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
 
             // The normal file should be staged
             assert!(
@@ -1344,7 +1344,7 @@ mod tests {
 
             add(&repo, vec![&repo.path]).await?;
 
-            let status = repositories::status(&repo);
+            let status = repositories::status(&repo).await;
             assert!(status.is_ok());
             let status = status.unwrap();
 
@@ -1410,7 +1410,7 @@ mod tests {
 
             add(&repo, vec![Path::new(&repo.path)]).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
 
             // Files in normal_dir should be staged
             assert!(

--- a/crates/lib/src/core/v_latest/add.rs
+++ b/crates/lib/src/core/v_latest/add.rs
@@ -720,7 +720,7 @@ pub async fn determine_file_status(
 
         previous_oxen_metadata = file_node.metadata();
         if repo
-            .is_modified_from_node_with_metadata(data_path, file_node, Ok(metadata))
+            .is_modified_from_node_with_metadata(data_path, file_node, &metadata)
             .await?
         {
             (

--- a/crates/lib/src/core/v_latest/clean.rs
+++ b/crates/lib/src/core/v_latest/clean.rs
@@ -45,7 +45,7 @@ pub async fn clean(repo: &LocalRepository, opts: &CleanOpts) -> Result<CleanResu
     } else {
         StagedDataOpts::from_paths(&opts.paths)
     };
-    let status = repositories::status::status_from_opts(repo, &status_opts)?;
+    let status = repositories::status::status_from_opts(repo, &status_opts).await?;
 
     let mut files: Vec<PathBuf> = status
         .untracked_files

--- a/crates/lib/src/core/v_latest/commits.rs
+++ b/crates/lib/src/core/v_latest/commits.rs
@@ -57,14 +57,14 @@ pub fn commit_with_user(
     repositories::commits::commit_writer::commit_with_user(repo, message, user)
 }
 
-pub fn commit_allow_empty(
+pub async fn commit_allow_empty(
     repo: &LocalRepository,
     message: impl AsRef<str>,
 ) -> Result<Commit, OxenError> {
     let message = message.as_ref();
 
     // Check if there are staged changes
-    let status = crate::core::v_latest::status::status(repo)?;
+    let status = crate::core::v_latest::status::status(repo).await?;
     let has_changes = !status.staged_files.is_empty() || !status.staged_dirs.is_empty();
 
     if has_changes {

--- a/crates/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/crates/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -1222,7 +1222,7 @@ mod tests {
 
             // Write data to the repo
             add_n_files_m_dirs(&repo, 10, 3).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Commit the data

--- a/crates/lib/src/core/v_latest/restore.rs
+++ b/crates/lib/src/core/v_latest/restore.rs
@@ -17,7 +17,7 @@ pub async fn restore(repo: &LocalRepository, restore_opts: RestoreOpts) -> Resul
         walk_dirs: false,
     };
 
-    let expanded_paths = util::glob::parse_glob_paths(&glob_opts, Some(repo))?;
+    let expanded_paths = util::glob::parse_glob_paths(&glob_opts, Some(repo)).await?;
 
     let mut restore_opts = restore_opts.clone();
     restore_opts.paths = expanded_paths;

--- a/crates/lib/src/core/v_latest/rm.rs
+++ b/crates/lib/src/core/v_latest/rm.rs
@@ -39,7 +39,7 @@ use rocksdb::{DBWithThreadMode, MultiThreaded};
 
 use std::sync::Arc;
 
-pub fn rm(
+pub async fn rm(
     paths: &HashSet<PathBuf>,
     repo: &LocalRepository,
     opts: &RmOpts,
@@ -49,16 +49,16 @@ pub fn rm(
     let staged_db: DBWithThreadMode<MultiThreaded> =
         DBWithThreadMode::open(&db_opts, dunce::simplified(&db_path))?;
 
-    rm_with_staged_db(paths, repo, opts, &staged_db)
+    rm_with_staged_db(paths, repo, opts, &staged_db).await
 }
 
-pub fn rm_with_staged_db(
+pub async fn rm_with_staged_db(
     paths: &HashSet<PathBuf>,
     repo: &LocalRepository,
     opts: &RmOpts,
     staged_db: &DBWithThreadMode<MultiThreaded>,
 ) -> Result<(), OxenError> {
-    if has_modified_files(repo, paths)? {
+    if !list_modified_files(repo, paths).await?.is_empty() {
         let error = "There are modified files in the working directory.\n\tUse `oxen status` to see the modified files.".to_string();
         return Err(OxenError::basic_str(error));
     }
@@ -118,18 +118,13 @@ fn remove_staged_recursively_inner(
     Ok(())
 }
 
-fn has_modified_files(repo: &LocalRepository, paths: &HashSet<PathBuf>) -> Result<bool, OxenError> {
-    let modified = list_modified_files(repo, paths)?;
-    Ok(!modified.is_empty())
-}
-
-fn list_modified_files(
+async fn list_modified_files(
     repo: &LocalRepository,
     paths: &HashSet<PathBuf>,
 ) -> Result<Vec<PathBuf>, OxenError> {
     let paths_vec: Vec<PathBuf> = paths.iter().map(|p| repo.path.join(p)).collect();
     let opts = StagedDataOpts::from_paths(&paths_vec);
-    let status = repositories::status::status_from_opts(repo, &opts)?;
+    let status = repositories::status::status_from_opts(repo, &opts).await?;
     log::debug!("status modified_files: {:?}", status.modified_files);
     log::debug!("paths: {paths:?}");
     let modified: Vec<PathBuf> = status

--- a/crates/lib/src/core/v_latest/status.rs
+++ b/crates/lib/src/core/v_latest/status.rs
@@ -692,7 +692,7 @@ async fn walk_status(
                         current.untracked.all_untracked = false;
                         if let EMerkleTreeNode::File(file_node) = &node.node {
                             let is_modified = repo
-                                .is_modified_from_node_with_metadata(&path, file_node, Ok(metadata))
+                                .is_modified_from_node_with_metadata(&path, file_node, &metadata)
                                 .await?;
                             log::debug!("is_modified {is_modified} {relative_path:?}");
                             if is_modified {
@@ -708,7 +708,7 @@ async fn walk_status(
                         {
                             found_file = true;
                             if repo
-                                .is_modified_from_node_with_metadata(&path, file_node, Ok(metadata))
+                                .is_modified_from_node_with_metadata(&path, file_node, &metadata)
                                 .await?
                             {
                                 current.modified.insert(relative_path.clone());

--- a/crates/lib/src/core/v_latest/status.rs
+++ b/crates/lib/src/core/v_latest/status.rs
@@ -28,11 +28,11 @@ use crate::core::v_latest::index::CommitMerkleTree;
 use crate::model::merkle_tree::node::EMerkleTreeNode;
 use crate::model::merkle_tree::node::MerkleTreeNode;
 
-pub fn status(repo: &LocalRepository) -> Result<StagedData, OxenError> {
-    status_from_dir(repo, &repo.path)
+pub async fn status(repo: &LocalRepository) -> Result<StagedData, OxenError> {
+    status_from_dir(repo, &repo.path).await
 }
 
-pub fn status_from_dir(
+pub async fn status_from_dir(
     repo: &LocalRepository,
     dir: impl AsRef<Path>,
 ) -> Result<StagedData, OxenError> {
@@ -40,10 +40,10 @@ pub fn status_from_dir(
         paths: vec![dir.as_ref().to_path_buf()],
         ..StagedDataOpts::default()
     };
-    status_from_opts(repo, &opts)
+    status_from_opts(repo, &opts).await
 }
 
-pub fn status_from_opts(
+pub async fn status_from_opts(
     repo: &LocalRepository,
     opts: &StagedDataOpts,
 ) -> Result<StagedData, OxenError> {
@@ -63,7 +63,8 @@ pub fn status_from_opts(
         MissingClassification::AsRemoved,
         &dir_hashes,
         &read_progress,
-    )?;
+    )
+    .await?;
 
     log::debug!("status_from_opts untracked: {:?}", out.untracked);
     log::debug!("status_from_opts modified: {:?}", out.modified);
@@ -103,7 +104,7 @@ pub fn status_from_opts(
 }
 
 // Get status with pre-existing staged data
-pub fn status_from_opts_and_staged_data(
+pub async fn status_from_opts_and_staged_data(
     repo: &LocalRepository,
     opts: &StagedDataOpts,
     staged_data: &mut StagedData,
@@ -123,7 +124,8 @@ pub fn status_from_opts_and_staged_data(
         MissingClassification::AsUnsynced,
         &dir_hashes,
         &read_progress,
-    )?;
+    )
+    .await?;
 
     log::debug!(
         "status_from_opts_and_staged_data untracked: {:?}",
@@ -597,7 +599,7 @@ enum WalkItem {
 /// in (1) which staged source they consult and (2) where they record paths that are in
 /// the merkle tree but missing on disk; both knobs are passed in.
 #[allow(clippy::too_many_arguments)]
-fn walk_status(
+async fn walk_status(
     repo: &LocalRepository,
     opts: &StagedDataOpts,
     starting_path: &Path,
@@ -615,7 +617,13 @@ fn walk_status(
         match item {
             WalkItem::EnterDir(search_node_path) => {
                 let full_path = repo.path.join(&search_node_path);
-                let is_dir = full_path.is_dir();
+                // Use `metadata.is_dir()` rather than `full_path.is_dir()` to avoid
+                // following symlinks — Oxen does not track symlinks, and a symlink-to-dir
+                // at the walker root would otherwise be silently followed.
+                let is_dir = tokio::fs::symlink_metadata(&full_path)
+                    .await
+                    .map(|m| m.is_dir())
+                    .unwrap_or(false);
                 log::debug!(
                     "walk_status search_node_path: {search_node_path:?} full_path: {full_path:?}"
                 );
@@ -683,11 +691,9 @@ fn walk_status(
                         // either way, this directory is not all_untracked.
                         current.untracked.all_untracked = false;
                         if let EMerkleTreeNode::File(file_node) = &node.node {
-                            let is_modified = util::fs::is_modified_from_node_with_metadata(
-                                &path,
-                                file_node,
-                                Ok(metadata),
-                            )?;
+                            let is_modified = repo
+                                .is_modified_from_node_with_metadata(&path, file_node, Ok(metadata))
+                                .await?;
                             log::debug!("is_modified {is_modified} {relative_path:?}");
                             if is_modified {
                                 current.modified.insert(relative_path.clone());
@@ -701,11 +707,10 @@ fn walk_status(
                             && let EMerkleTreeNode::File(file_node) = &search_node.node
                         {
                             found_file = true;
-                            if util::fs::is_modified_from_node_with_metadata(
-                                &path,
-                                file_node,
-                                Ok(metadata),
-                            )? {
+                            if repo
+                                .is_modified_from_node_with_metadata(&path, file_node, Ok(metadata))
+                                .await?
+                            {
                                 current.modified.insert(relative_path.clone());
                             }
                         }
@@ -888,7 +893,7 @@ fn walk_status(
 /// Walk every path in `opts.paths` through [`walk_status`] and aggregate the results.
 /// Shared between `status_from_opts` (which uses `StagedSource::Db` + `AsRemoved`) and
 /// `status_from_opts_and_staged_data` (which uses `StagedSource::Data` + `AsUnsynced`).
-fn walk_paths(
+async fn walk_paths(
     repo: &LocalRepository,
     opts: &StagedDataOpts,
     staged: StagedSource<'_>,
@@ -911,7 +916,8 @@ fn walk_paths(
             &gitignore,
             progress,
             &mut total_entries,
-        )?;
+        )
+        .await?;
         out.merge(sub);
     }
     Ok(out)

--- a/crates/lib/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
+++ b/crates/lib/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
@@ -620,7 +620,7 @@ mod tests {
 
             // Write data to the repo
             add_n_files_m_dirs(&repo, 10, 3).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Commit the data

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -575,19 +575,20 @@ impl LocalRepository {
     }
 
     /// Async, tolerance-aware modification check. Routes the mtime comparison through
-    /// [`Self::mtime_matches`] so it agrees with `restore_file`'s fast-path skip on
-    /// coarse-mtime mounts (FAT/exFAT, HFS+, some NFS). Use this from any caller that has
-    /// access to a `&LocalRepository` and is in an async context.
-    ///
-    /// `oxen status` and its sync chain still use the strict-mtime free function in
-    /// [`crate::util::fs::is_modified_from_node`]; when that path goes async, the free
-    /// functions can be removed in favor of these methods.
+    /// [`Self::mtime_matches`] so callers (`oxen status`, `oxen restore`, `oxen checkout`,
+    /// `oxen pull`'s overwrite check, etc.) agree with `restore_file`'s fast-path skip on
+    /// coarse-mtime mounts (FAT/exFAT, HFS+, some NFS). The previous strict-mtime free
+    /// functions in `util::fs` were retired once `oxen status`'s walker went async.
     pub async fn is_modified_from_node(
         &self,
         path: &Path,
         node: &FileNode,
     ) -> Result<bool, OxenError> {
-        self.is_modified_from_node_with_metadata(path, node, util::fs::metadata(path))
+        let metadata = tokio::fs::symlink_metadata(path).await.map_err(|err| {
+            log::debug!("symlink_metadata {path:?} {err}");
+            OxenError::file_metadata_error(path, err)
+        });
+        self.is_modified_from_node_with_metadata(path, node, metadata)
             .await
     }
 
@@ -598,11 +599,12 @@ impl LocalRepository {
         node: &FileNode,
         metadata: Result<std::fs::Metadata, OxenError>,
     ) -> Result<bool, OxenError> {
-        if !path.exists() {
-            log::debug!("is_modified_from_node found non-existent path {path:?}. Returning false");
+        let Ok(metadata) = metadata else {
+            log::debug!(
+                "is_modified_from_node_with_metadata: missing or unreadable metadata for {path:?}, returning false"
+            );
             return Ok(false);
-        }
-        let metadata = metadata?;
+        };
         let file_last_modified = filetime::FileTime::from_last_modification_time(&metadata);
         let node_last_modified = util::fs::last_modified_time(
             node.last_modified_seconds(),

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -592,24 +592,20 @@ impl LocalRepository {
             }
             Err(err) => return Err(OxenError::file_metadata_error(path, err)),
         };
-        self.is_modified_from_node_with_metadata(path, node, Ok(metadata))
+        self.is_modified_from_node_with_metadata(path, node, &metadata)
             .await
     }
 
-    /// Pre-fetched-metadata variant of [`Self::is_modified_from_node`].
+    /// Pre-fetched-metadata variant of [`Self::is_modified_from_node`]. Callers that
+    /// don't already have the metadata in hand should use the no-arg variant instead;
+    /// this one trusts that the metadata corresponds to `path` and is up-to-date.
     pub async fn is_modified_from_node_with_metadata(
         &self,
         path: &Path,
         node: &FileNode,
-        metadata: Result<std::fs::Metadata, OxenError>,
+        metadata: &std::fs::Metadata,
     ) -> Result<bool, OxenError> {
-        let Ok(metadata) = metadata else {
-            log::debug!(
-                "is_modified_from_node_with_metadata: missing or unreadable metadata for {path:?}, returning false"
-            );
-            return Ok(false);
-        };
-        let file_last_modified = filetime::FileTime::from_last_modification_time(&metadata);
+        let file_last_modified = filetime::FileTime::from_last_modification_time(metadata);
         let node_last_modified = util::fs::last_modified_time(
             node.last_modified_seconds(),
             node.last_modified_nanoseconds(),
@@ -617,7 +613,7 @@ impl LocalRepository {
         let mtime_matched = self
             .mtime_matches(file_last_modified, node_last_modified)
             .await;
-        util::fs::classify_modified_from_node_with_metadata(path, node, &metadata, mtime_matched)
+        util::fs::classify_modified_from_node_with_metadata(path, node, metadata, mtime_matched)
     }
 
     /// Override the mtime tolerance for this repo path in the per-process cache. Test-only

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -584,11 +584,15 @@ impl LocalRepository {
         path: &Path,
         node: &FileNode,
     ) -> Result<bool, OxenError> {
-        let metadata = tokio::fs::symlink_metadata(path).await.map_err(|err| {
-            log::debug!("symlink_metadata {path:?} {err}");
-            OxenError::file_metadata_error(path, err)
-        });
-        self.is_modified_from_node_with_metadata(path, node, metadata)
+        let metadata = match tokio::fs::symlink_metadata(path).await {
+            Ok(m) => m,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                log::debug!("is_modified_from_node: missing path {path:?}, returning false");
+                return Ok(false);
+            }
+            Err(err) => return Err(OxenError::file_metadata_error(path, err)),
+        };
+        self.is_modified_from_node_with_metadata(path, node, Ok(metadata))
             .await
     }
 

--- a/crates/lib/src/repositories/add.rs
+++ b/crates/lib/src/repositories/add.rs
@@ -88,7 +88,7 @@ mod tests {
                 repositories::add(&local_repo, &hello_file).await?;
 
                 // Get the status and make sure the file is staged
-                let status = repositories::status(&local_repo)?;
+                let status = repositories::status(&local_repo).await?;
                 assert_eq!(status.staged_files.len(), 1);
                 assert!(
                     status
@@ -128,7 +128,7 @@ A: Oxen.ai
                 repositories::add(&local_repo, &readme_file).await?;
 
                 // Get the status and make sure the file is staged
-                let status = repositories::status(&local_repo)?;
+                let status = repositories::status(&local_repo).await?;
                 assert_eq!(status.staged_files.len(), 1);
                 assert!(
                     status
@@ -157,7 +157,7 @@ A: Oxen.ai
             // Track the file
             repositories::add(&repo, &hello_file).await?;
             // Get status and make sure it is removed from the untracked, and added to the tracked
-            let repo_status = repositories::status(&repo)?;
+            let repo_status = repositories::status(&repo).await?;
             // TODO: v0_10_0 logic should have 0 staged_dirs
             // We stage the parent dir, so should have 1 staged_dir
             assert_eq!(repo_status.staged_dirs.len(), 1);
@@ -177,18 +177,18 @@ A: Oxen.ai
             let one_shot_path = repo.path.join("annotations/train/one_shot.csv");
             let file_contents = "file,label\ntrain/cat_1.jpg,0";
             test::modify_txt_file(one_shot_path, file_contents)?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             println!("status: {status:?}");
             status.print();
             assert_eq!(status.modified_files.len(), 1);
             // Add the top level directory, and make sure the modified file gets added
             let annotation_dir_path = repo.path.join("annotations");
             repositories::add(&repo, annotation_dir_path).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             assert_eq!(status.staged_files.len(), 1);
             repositories::commit(&repo, "Changing one shot")?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert!(status.is_clean());
 
             Ok(())
@@ -210,7 +210,7 @@ A: Oxen.ai
             util::fs::remove_file(&file_to_remove)?;
 
             // We should recognize it as missing now
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.removed_files.len(), 1);
 
             Ok(())
@@ -251,7 +251,7 @@ A: Oxen.ai
             repositories::add(&repo, &repo.path).await?;
 
             // The new file should be staged as removed
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             assert_eq!(status.staged_files.len(), 1);
             assert!(!hello_file.exists());
@@ -278,7 +278,7 @@ A: Oxen.ai
             repositories::add(&repo, &repo.path).await?;
 
             // All files should be staged
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_files.len(), 3);
 
             repositories::commit(&repo, "Adding 3 files")?;
@@ -291,7 +291,7 @@ A: Oxen.ai
             repositories::add(&repo, &repo.path).await?;
 
             // The modified and removed files should be staged
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_files.len(), 2);
 
             Ok(())
@@ -326,7 +326,7 @@ A: Oxen.ai
             // Try to merge in the changes
             repositories::merge::merge(&repo, branch_name).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.merge_conflicts.len(), 1);
 
             // Assume that we fixed the conflict and added the file
@@ -335,7 +335,7 @@ A: Oxen.ai
             repositories::add(&repo, fullpath).await?;
 
             // Adding should add to added files
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
 
             assert_eq!(status.staged_files.len(), 1);
 
@@ -354,7 +354,7 @@ A: Oxen.ai
             let repo_dir = repo.path.join(dir);
             repositories::add(&repo, repo_dir).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Should add all the sub dirs
@@ -380,16 +380,16 @@ A: Oxen.ai
             let one_shot_path = repo.path.join("annotations/train/one_shot.csv");
             let file_contents = "file,label\ntrain/cat_1.jpg,0";
             test::modify_txt_file(one_shot_path, file_contents)?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.modified_files.len(), 1);
             // Add the top level directory, and make sure the modified file gets added
             let annotation_dir_path = repo.path.join("annotations/*");
             repositories::add(&repo, annotation_dir_path).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             assert_eq!(status.staged_files.len(), 1);
             repositories::commit(&repo, "Changing one shot")?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert!(status.is_clean());
 
             Ok(())
@@ -404,7 +404,7 @@ A: Oxen.ai
             let repo_dir = repo.path.join(dir);
             repositories::add(&repo, repo_dir).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Should add all the sub dirs
@@ -422,7 +422,7 @@ A: Oxen.ai
             let repo_nlp_dir = repo.path.join(dir);
             std::fs::remove_dir_all(repo_nlp_dir)?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // status.removed_files currently is files and dirs,
@@ -434,7 +434,7 @@ A: Oxen.ai
             // Add the removed nlp dir with a wildcard
             repositories::add(&repo, "nlp/*").await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_dirs.len(), 1);
             assert_eq!(status.staged_files.len(), 2);
 
@@ -450,7 +450,7 @@ A: Oxen.ai
             let repo_dir = repo.path.join(dir);
             repositories::add(&repo, repo_dir).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Should add all the sub dirs
@@ -474,7 +474,7 @@ A: Oxen.ai
             let empty_dir = repo.path.join("empty_dir");
             util::fs::create_dir_all(&empty_dir)?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Should find the untracked dir
@@ -488,7 +488,7 @@ A: Oxen.ai
             // Add the empty dir
             repositories::add(&repo, &empty_dir).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Should find the untracked dir
@@ -525,7 +525,7 @@ A: Oxen.ai
             let sub_file_2 = test::add_txt_file_to_dir(&sub_dir, "Hello 2")?;
             let sub_file_3 = test::add_txt_file_to_dir(&sub_dir, "Hello 3")?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             let dirs = status.untracked_dirs;
 
             // There is one directory
@@ -537,7 +537,7 @@ A: Oxen.ai
             repositories::add(&repo, &sub_file_3).await?;
 
             // There now there are no untracked directories
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             println!("status after add: {status:?}");
             status.print();
             let dirs = status.untracked_dirs;
@@ -572,7 +572,7 @@ A: Oxen.ai
             repositories::add(&repo, &annotations_dir).await?;
 
             // List dirs
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             let dirs = status.staged_dirs;
 
@@ -601,7 +601,7 @@ A: Oxen.ai
             repositories::add(&repo, &hello_file).await?;
 
             // make sure we don't have it added again, because the hash hadn't changed since last commit
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_files.len(), 0);
 
             Ok(())
@@ -622,7 +622,7 @@ A: Oxen.ai
 
             let file_contents = "file,label\ntrain/cat_1.jpg,0\n";
             let one_shot_path = test::modify_txt_file(one_shot_path, file_contents)?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             assert_eq!(status.modified_files.len(), 1);
             assert!(
@@ -632,7 +632,7 @@ A: Oxen.ai
             );
 
             repositories::add(&repo, &one_shot_path).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             assert_eq!(status.staged_files.len(), 1);
             assert_eq!(status.modified_files.len(), 0);
@@ -656,13 +656,13 @@ A: Oxen.ai
 
             // Add only the cats
             repositories::add(&repo, "train/cat_*.jpg").await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
 
             assert_eq!(status.staged_files.len(), 3);
 
             // Add the dogs
             repositories::add(&repo, "train/dog_*.jpg").await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
 
             // Should stage all 7 files now
             assert_eq!(status.staged_files.len(), 7);
@@ -887,18 +887,24 @@ A: Oxen.ai
             let file = Path::new("file.txt");
 
             create_and_stage(&repo, file, "hello").await;
-            let status = repositories::status(&repo).expect("oxen status failed");
+            let status = repositories::status(&repo)
+                .await
+                .expect("oxen status failed");
             expect_staged(&status, 1, 0, 0);
             commit_staged(&repo, "added", file);
 
             expect_filesystem(&repo.path, &[file], &[".oxen"]).await;
 
             remove_and_stage(&repo, file).await;
-            let status = repositories::status(&repo).expect("oxen status failed");
+            let status = repositories::status(&repo)
+                .await
+                .expect("oxen status failed");
             expect_staged(&status, 0, 1, 0);
             commit_staged(&repo, "removed", file);
 
-            let status = repositories::status(&repo).expect("oxen status failed");
+            let status = repositories::status(&repo)
+                .await
+                .expect("oxen status failed");
             expect_staged(&status, 0, 0, 0);
             assert!(status.staged_dirs.is_empty());
             expect_filesystem(&repo.path, &[], &[".oxen"]).await;
@@ -918,18 +924,24 @@ A: Oxen.ai
             let file = dir.join("file.txt");
 
             create_and_stage(&repo, &file, "hello world!").await;
-            let status = repositories::status(&repo).expect("oxen status failed");
+            let status = repositories::status(&repo)
+                .await
+                .expect("oxen status failed");
             expect_staged(&status, 1, 0, 0);
             commit_staged(&repo, "added", &file);
 
             expect_filesystem(&repo.path, &[&dir, &file], &[".oxen"]).await;
 
             remove_and_stage(&repo, &dir).await;
-            let status = repositories::status(&repo).expect("oxen status failed");
+            let status = repositories::status(&repo)
+                .await
+                .expect("oxen status failed");
             expect_staged(&status, 0, 1, 0);
             commit_staged(&repo, "removed dir + contents", &dir);
 
-            let status = repositories::status(&repo).expect("oxen status failed");
+            let status = repositories::status(&repo)
+                .await
+                .expect("oxen status failed");
             expect_staged(&status, 0, 0, 0);
             assert!(status.staged_dirs.is_empty());
             expect_filesystem(&repo.path, &[], &[".oxen"]).await;
@@ -952,18 +964,24 @@ A: Oxen.ai
             let file = dir_3.join("file.txt");
 
             create_and_stage(&repo, &file, "hello world!").await;
-            let status = repositories::status(&repo).expect("oxen status failed");
+            let status = repositories::status(&repo)
+                .await
+                .expect("oxen status failed");
             expect_staged(&status, 1, 0, 0);
             commit_staged(&repo, "added", &file);
 
             expect_filesystem(&repo.path, &[&dir_1, &dir_2, &dir_3, &file], &[".oxen"]).await;
 
             remove_and_stage(&repo, &dir_1).await;
-            let status = repositories::status(&repo).expect("oxen status failed");
+            let status = repositories::status(&repo)
+                .await
+                .expect("oxen status failed");
             expect_staged(&status, 0, 1, 0);
             commit_staged(&repo, "removed dir + contents", &dir_1);
 
-            let status = repositories::status(&repo).expect("oxen status failed");
+            let status = repositories::status(&repo)
+                .await
+                .expect("oxen status failed");
             expect_staged(&status, 0, 0, 0);
             assert!(status.staged_dirs.is_empty());
             expect_filesystem(&repo.path, &[], &[".oxen"]).await;

--- a/crates/lib/src/repositories/checkout.rs
+++ b/crates/lib/src/repositories/checkout.rs
@@ -256,7 +256,7 @@ mod tests {
             assert!(!world_file.exists());
 
             // // Check status
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert!(status.is_clean());
 
             Ok(())
@@ -310,7 +310,7 @@ mod tests {
             assert!(!world_file.exists());
 
             // Check status
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert!(status.is_clean());
 
             // Checkout branch again
@@ -668,11 +668,11 @@ mod tests {
 
             let file_contents = "file,label\ntrain/cat_1.jpg,0\n";
             let one_shot_path = test::modify_txt_file(one_shot_path, file_contents)?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.modified_files.len(), 1);
             status.print();
             repositories::add(&repo, &one_shot_path).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             repositories::commit(&repo, "Changing one shot")?;
 
@@ -711,15 +711,15 @@ mod tests {
 
             let file_contents = "file,label\ntrain/cat_1.jpg,0\n";
             let one_shot_path = test::modify_txt_file(one_shot_path, file_contents)?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.modified_files.len(), 1);
             repositories::add(&repo, &one_shot_path).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             assert_eq!(status.modified_files.len(), 0);
             assert_eq!(status.staged_files.len(), 1);
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             repositories::commit(&repo, "Changing one shot")?;
 

--- a/crates/lib/src/repositories/clean.rs
+++ b/crates/lib/src/repositories/clean.rs
@@ -280,7 +280,7 @@ mod tests {
             repositories::clean::clean(&repo, &opts_force()).await?;
 
             // Working tree should now be clean.
-            let status = repositories::status::status(&repo)?;
+            let status = repositories::status::status(&repo).await?;
             assert!(
                 status.is_clean(),
                 "working tree should be clean after restore + clean; got {status:?}"

--- a/crates/lib/src/repositories/clone.rs
+++ b/crates/lib/src/repositories/clone.rs
@@ -142,7 +142,7 @@ mod tests {
                 assert!(repository.is_ok());
 
                 let repository = repository.unwrap();
-                let status = repositories::status(&repository)?;
+                let status = repositories::status(&repository).await?;
                 assert!(status.is_clean());
 
                 // Cleanup
@@ -167,7 +167,7 @@ mod tests {
 
                 api::client::repositories::delete(&remote_repo).await?;
 
-                repositories::status(&local_repo)?;
+                repositories::status(&local_repo).await?;
 
                 let new_path = dir.join("new_path");
 
@@ -176,7 +176,7 @@ mod tests {
                 util::fs::rename(&local_repo.path, &new_path)?;
 
                 let new_repo = LocalRepository::from_dir(&new_path)?;
-                repositories::status(&new_repo)?;
+                repositories::status(&new_repo).await?;
                 assert_eq!(new_repo.path, new_path);
 
                 Ok(())
@@ -583,7 +583,7 @@ mod tests {
                 )
                 .await?;
 
-                let status = repositories::status(&cloned_repo);
+                let status = repositories::status(&cloned_repo).await;
                 assert!(status.is_ok());
 
                 Ok(())
@@ -608,7 +608,7 @@ mod tests {
                 )
                 .await?;
 
-                let status = repositories::status(&cloned_repo);
+                let status = repositories::status(&cloned_repo).await;
                 assert!(status.is_ok());
 
                 // Add a file to the cloned repo

--- a/crates/lib/src/repositories/commits.rs
+++ b/crates/lib/src/repositories/commits.rs
@@ -59,10 +59,13 @@ pub fn commit_with_user(
 ///
 /// Allows creating a commit even when there are no staged changes.
 /// This reuses the existing create_empty_commit infrastructure.
-pub fn commit_allow_empty(repo: &LocalRepository, message: &str) -> Result<Commit, OxenError> {
+pub async fn commit_allow_empty(
+    repo: &LocalRepository,
+    message: &str,
+) -> Result<Commit, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::commits::commit_allow_empty(repo, message),
+        _ => core::v_latest::commits::commit_allow_empty(repo, message).await,
     }
 }
 
@@ -419,7 +422,7 @@ mod tests {
             assert_eq!(commit.message, "My message");
 
             // Get status and make sure it is removed from the untracked and added
-            let repo_status = repositories::status(&repo)?;
+            let repo_status = repositories::status(&repo).await?;
             assert_eq!(repo_status.staged_dirs.len(), 0);
             assert_eq!(repo_status.staged_files.len(), 0);
             assert_eq!(repo_status.untracked_files.len(), 0);
@@ -477,7 +480,7 @@ mod tests {
             // Commit the file
             let commit = repositories::commit(&repo, "Adding training data")?;
 
-            let repo_status = repositories::status(&repo)?;
+            let repo_status = repositories::status(&repo).await?;
             repo_status.print();
             assert_eq!(repo_status.staged_dirs.len(), 0);
             assert_eq!(repo_status.staged_files.len(), 0);
@@ -506,7 +509,7 @@ mod tests {
             repositories::add(&repo, annotations_dir).await?;
             repositories::commit(&repo, "Adding annotations data dir, which has two levels")?;
 
-            let repo_status = repositories::status(&repo)?;
+            let repo_status = repositories::status(&repo).await?;
             repo_status.print();
 
             assert_eq!(repo_status.staged_dirs.len(), 0);
@@ -575,7 +578,7 @@ mod tests {
             repositories::add(&repo, &dir_to_remove).await?;
 
             // Make sure we have the correct amount of files tagged as removed
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_files.len(), og_file_count);
             assert_eq!(
                 status.staged_files.iter().next().unwrap().1.status,
@@ -620,7 +623,7 @@ mod tests {
             repositories::merge::merge(&repo, branch_name).await?;
 
             // We should have a conflict
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.merge_conflicts.len(), 1);
 
             // Assume that we fixed the conflict and added the file
@@ -658,7 +661,7 @@ mod tests {
             // Modify the text file
             util::fs::write_to_path(&text_path, "Goodbye, world!")?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // There should be nothing to commit since the file is untracked
@@ -688,7 +691,7 @@ mod tests {
                 util::hasher::hash_file_contents(&text_path)?.parse::<MerkleHash>()?;
             repositories::add(&repo, &text_path).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Note v10 did not have this line, and we didn't copy to the versions dir on add
@@ -753,7 +756,7 @@ mod tests {
             assert_eq!(commit_history.len(), 1);
 
             // Check that the files are no longer staged
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             let files = status.staged_files;
             let dirs = status.staged_dirs;
             assert_eq!(files.len(), 0);
@@ -932,7 +935,7 @@ mod tests {
             assert!(result.is_err());
 
             // Create an empty commit with --allow-empty (should succeed)
-            let empty_commit = commit_allow_empty(&repo, "Empty commit")?;
+            let empty_commit = commit_allow_empty(&repo, "Empty commit").await?;
             assert_eq!(empty_commit.message, "Empty commit");
             assert_eq!(empty_commit.parent_ids, vec![first_commit.id.clone()]);
 
@@ -975,7 +978,7 @@ mod tests {
             repositories::add(&repo, &goodbye_file).await?;
 
             // commit_allow_empty should commit the staged changes normally
-            let commit = commit_allow_empty(&repo, "Add goodbye")?;
+            let commit = commit_allow_empty(&repo, "Add goodbye").await?;
             assert_eq!(commit.message, "Add goodbye");
 
             // Verify both files are in the tree
@@ -1035,7 +1038,7 @@ mod tests {
             let empty_dir = repo.path.join("empty_dir");
             util::fs::create_dir_all(&empty_dir)?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Should find the untracked dir
@@ -1049,7 +1052,7 @@ mod tests {
             // Add the empty dir
             repositories::add(&repo, &empty_dir).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             let commit = repositories::commit(&repo, "adding empty dir")?;
@@ -1065,7 +1068,7 @@ mod tests {
                 ..Default::default()
             };
 
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
             let commit_2 = repositories::commit(&repo, "removing empty dir")?;
 
             let tree_2 = repositories::tree::get_root_with_children(&repo, &commit_2)?.unwrap();
@@ -1355,7 +1358,7 @@ A: Oxen.ai
             assert_eq!(second_commit.message, "Add hello.txt");
 
             // Verify the file is in the commit
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert!(status.is_clean());
 
             Ok(())
@@ -1381,7 +1384,7 @@ A: Oxen.ai
             let _c2 = repositories::commit(&repo, "c2: modify data/a.txt")?;
 
             // Commit 3: Empty commit (no changes)
-            let _c3 = commit_allow_empty(&repo, "c3: empty commit")?;
+            let _c3 = commit_allow_empty(&repo, "c3: empty commit").await?;
 
             // Commit 4: Add src/c.txt
             let src_c = repo.path.join("src").join("c.txt");
@@ -1390,7 +1393,7 @@ A: Oxen.ai
             let _c4 = repositories::commit(&repo, "c4: add src/c.txt")?;
 
             // Commit 5: Empty commit (no tree changes, should not appear in any path history)
-            let _c5 = commit_allow_empty(&repo, "c5: another empty commit")?;
+            let _c5 = commit_allow_empty(&repo, "c5: another empty commit").await?;
 
             // Commit 6: Add root-level other.txt
             let other = repo.path.join("other.txt");

--- a/crates/lib/src/repositories/commits/commit_writer.rs
+++ b/crates/lib/src/repositories/commits/commit_writer.rs
@@ -1259,7 +1259,7 @@ mod tests {
 
             // Write data to the repo
             add_n_files_m_dirs(&repo, 10, 2).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Commit the data
@@ -1349,7 +1349,7 @@ mod tests {
             util::fs::write_to_path(&new_file, "New file")?;
             repositories::add(&repo, &repo.path).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Commit the data
@@ -1379,7 +1379,7 @@ mod tests {
             util::fs::write_to_path(&new_file, "New file")?;
             repositories::add(&repo, &new_file).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Commit the data
@@ -1405,7 +1405,7 @@ mod tests {
 
             // Write data to the repo
             add_n_files_m_dirs(&repo, 10, 3).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Commit the data
@@ -1461,7 +1461,7 @@ mod tests {
 
             // Write data to the repo
             add_n_files_m_dirs(&repo, 10, 3).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Commit the data
@@ -1585,7 +1585,7 @@ mod tests {
 
             // Write data to the repo, 23 files in 2 dirs
             add_n_files_m_dirs(&repo, 23, 2).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Commit the data
@@ -1664,7 +1664,7 @@ mod tests {
 
             // Write data to the repo, 20 files in 1 dir
             add_n_files_m_dirs(&repo, 20, 1).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Commit the data
@@ -1732,7 +1732,7 @@ mod tests {
 
             // Write data to the repo
             add_n_files_m_dirs(&repo, 10, 3).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Commit the data
@@ -1832,7 +1832,7 @@ mod tests {
 
             // remove a directory
             let rm_opts = RmOpts::from_path_recursive(Path::new("train"));
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
             let third_commit = super::commit(&repo, "Removing train dir")?;
 
             let third_tree = CommitMerkleTree::from_commit(&repo, &third_commit)?;

--- a/crates/lib/src/repositories/data_frames/schemas.rs
+++ b/crates/lib/src/repositories/data_frames/schemas.rs
@@ -214,7 +214,7 @@ mod tests {
     async fn test_stage_and_commit_schema() -> Result<(), OxenError> {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             // Make sure no schemas are staged
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_schemas.len(), 0);
 
             // Schema should be staged when added
@@ -225,7 +225,7 @@ mod tests {
             repositories::add(&repo, bbox_file).await?;
 
             // Make sure it is staged
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_schemas.len(), 1);
             for (path, schema) in status.staged_schemas.iter() {
                 println!("GOT SCHEMA {path:?} -> {schema:?}");
@@ -235,7 +235,7 @@ mod tests {
             let commit = repositories::commit(&repo, "Adding bounding box schema")?;
 
             // Make sure no schemas are staged after commit
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_schemas.len(), 0);
             let path = PathBuf::from("annotations")
                 .join("train")
@@ -268,7 +268,7 @@ mod tests {
     async fn test_copy_schemas_from_parent() -> Result<(), OxenError> {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             // Make sure no schemas are staged
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_schemas.len(), 0);
 
             // Schema should be staged when added
@@ -279,7 +279,7 @@ mod tests {
             repositories::add(&repo, bbox_file).await?;
 
             // Make sure it is staged
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_schemas.len(), 1);
             for (path, schema) in status.staged_schemas.iter() {
                 println!("GOT SCHEMA {path:?} -> {schema:?}");
@@ -523,7 +523,7 @@ mod tests {
             // Stage the file
             repositories::add(&repo, &bbox_path).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             println!("status: {status:?}");
             status.print();
 

--- a/crates/lib/src/repositories/diffs.rs
+++ b/crates/lib/src/repositories/diffs.rs
@@ -170,7 +170,7 @@ pub async fn diff_uncommitted(
     opts: &DiffOpts,
 ) -> Result<Vec<DiffResult>, OxenError> {
     let status_opts = StagedDataOpts::from_paths(&[path_1.to_path_buf()]);
-    let status = repositories::status::status_from_opts(repo, &status_opts)?;
+    let status = repositories::status::status_from_opts(repo, &status_opts).await?;
     let unstaged_files = status.unstaged_files();
     log::debug!("unstaged_files: {unstaged_files:?}");
     let commit_1 = repositories::revisions::get(repo, rev_1)?
@@ -1634,7 +1634,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             util::fs::remove_file(bbox_file)?;
 
             let opts = RmOpts::from_path(&bbox_filename);
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
             let head_commit = repositories::commit(&repo, "Removing a the training data file")?;
             let entries = repositories::diffs::list_diff_entries(
                 &repo,
@@ -1721,7 +1721,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             util::fs::remove_file(bbox_file)?;
 
             let opts = RmOpts::from_path(&bbox_filename);
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
             let head_commit = repositories::commit(&repo, "Removing a the training data file")?;
 
             let entries = repositories::diffs::list_diff_entries(
@@ -1790,7 +1790,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             util::fs::remove_file(bbox_file)?;
 
             let opts = RmOpts::from_path(&bbox_filename);
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
             repositories::add(&repo, &repo.path).await?;
             let head_commit = repositories::commit(&repo, "Removing a the training data file")?;
             let entries = repositories::diffs::list_diff_entries(
@@ -1885,7 +1885,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             util::fs::remove_file(bbox_file)?;
 
             let opts = RmOpts::from_path(&bbox_filename);
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
             let head_commit = repositories::commit(&repo, "Removing a the training data file")?;
             let entries = repositories::diffs::list_diff_entries(
                 &repo,

--- a/crates/lib/src/repositories/load.rs
+++ b/crates/lib/src/repositories/load.rs
@@ -144,7 +144,7 @@ mod tests {
                 assert!(!hydrated_repo.path.join("hello.txt").exists());
 
                 // Should have `hello.txt` in removed files bc it's in commits db but not working dir
-                let status = repositories::status(&hydrated_repo)?;
+                let status = repositories::status(&hydrated_repo).await?;
 
                 assert_eq!(status.removed_files.len(), 1);
 

--- a/crates/lib/src/repositories/merge.rs
+++ b/crates/lib/src/repositories/merge.rs
@@ -796,7 +796,7 @@ mod tests {
 
             // We should have a conflict....
             println!("status plz");
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.merge_conflicts.len(), 1);
 
             println!("checkout theirs plz");
@@ -847,7 +847,7 @@ mod tests {
             repositories::merge::merge(&repo, branch_name).await?;
 
             // We should have a conflict....
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.merge_conflicts.len(), 1);
 
             // Run repositories::checkout::checkout_theirs() and make sure their changes get kept
@@ -900,7 +900,7 @@ mod tests {
             repositories::merge::merge(&repo, branch_name).await?;
 
             // We should have a conflict....
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.merge_conflicts.len(), 1);
 
             // Run repositories::checkout::checkout_theirs() and make sure we cannot

--- a/crates/lib/src/repositories/pull.rs
+++ b/crates/lib/src/repositories/pull.rs
@@ -138,7 +138,7 @@ mod tests {
                 assert_eq!(repo_commits.len(), cloned_commits.len());
 
                 // Make sure we updated the dbs properly
-                let status = repositories::status(&cloned_repo)?;
+                let status = repositories::status(&cloned_repo).await?;
                 assert!(status.is_clean());
 
                 // Have this side add a file, and send it back over
@@ -154,7 +154,7 @@ mod tests {
 
                 // Pull back from the OG Repo
                 repositories::pull(&repo).await?;
-                let old_repo_status = repositories::status(&repo)?;
+                let old_repo_status = repositories::status(&repo).await?;
                 old_repo_status.print();
                 // Make sure we don't modify the timestamps or anything of the OG data
                 assert!(!old_repo_status.has_modified_entries());
@@ -856,7 +856,7 @@ mod tests {
                 assert!(!user_b_repo.path.join("train").exists());
 
                 // Check for merge conflict
-                let status = repositories::status(&user_b_repo)?;
+                let status = repositories::status(&user_b_repo).await?;
                 assert!(!status.merge_conflicts.is_empty());
                 status.print();
 
@@ -940,7 +940,7 @@ mod tests {
                 assert!(!user_b_repo.path.join("train").exists());
 
                 // Check for merge conflict
-                let status = repositories::status(&user_b_repo)?;
+                let status = repositories::status(&user_b_repo).await?;
                 status.print();
                 assert!(!status.merge_conflicts.is_empty());
                 assert_eq!(status.merge_conflicts.len(), 1);
@@ -1016,7 +1016,7 @@ mod tests {
                     assert!(result.is_err());
 
                     // Check for merge conflict
-                    let status = repositories::status(&user_b_repo)?;
+                    let status = repositories::status(&user_b_repo).await?;
                     assert!(!status.merge_conflicts.is_empty());
                     status.print();
 
@@ -1310,7 +1310,7 @@ mod tests {
                 assert_eq!(cloned_contents, og_contents);
 
                 // Status should be empty too
-                let status = repositories::status(&cloned_repo)?;
+                let status = repositories::status(&cloned_repo).await?;
                 status.print();
                 assert!(status.is_clean());
 
@@ -1373,7 +1373,7 @@ mod tests {
                 println!("Cloned {filename:?} {cloned_df}");
 
                 // Status should be empty too
-                let status = repositories::status(&cloned_repo)?;
+                let status = repositories::status(&cloned_repo).await?;
                 status.print();
                 assert!(status.is_clean());
 
@@ -1860,7 +1860,7 @@ mod tests {
                         path: PathBuf::from("README.md"),
                         ..Default::default()
                     };
-                    repositories::rm(&user_b_repo, &rm_opts)?;
+                    repositories::rm(&user_b_repo, &rm_opts).await?;
                     repositories::commit(&user_b_repo, "Removing the README.md on the remote")?;
 
                     // Push the remote

--- a/crates/lib/src/repositories/push.rs
+++ b/crates/lib/src/repositories/push.rs
@@ -911,7 +911,7 @@ mod tests {
                     assert!(result.is_err());
 
                     // There should be conflicts
-                    let status = repositories::status(&user_b_repo)?;
+                    let status = repositories::status(&user_b_repo).await?;
                     assert!(status.has_merge_conflicts());
                     println!("passed has_merge_conflicts");
                     status.print();
@@ -1166,7 +1166,7 @@ mod tests {
                 recursive: true,
             };
 
-            repositories::rm(&local_repo, &rm_opts)?;
+            repositories::rm(&local_repo, &rm_opts).await?;
             let commit =
                 repositories::commit(&local_repo, "Moved all the train image files to images/")?;
             repositories::push(&local_repo).await?;
@@ -1222,7 +1222,7 @@ mod tests {
 
             repositories::add(&local_repo, new_path).await?;
             let rm_opts = RmOpts::from_path("README.md");
-            repositories::rm(&local_repo, &rm_opts)?;
+            repositories::rm(&local_repo, &rm_opts).await?;
             let commit = repositories::commit(&local_repo, "Moved the readme")?;
             repositories::push(&local_repo).await?;
 
@@ -1704,7 +1704,7 @@ A: Checkout Oxen.ai
                 );
 
                 // Verify we have merge conflicts
-                let status = repositories::status(&original_repo)?;
+                let status = repositories::status(&original_repo).await?;
                 assert!(status.has_merge_conflicts(), "Should have merge conflicts");
 
                 // Verify we can't push

--- a/crates/lib/src/repositories/remote_mode/restore.rs
+++ b/crates/lib/src/repositories/remote_mode/restore.rs
@@ -22,7 +22,7 @@ pub async fn restore(
         walk_dirs: false,
     };
 
-    let expanded_paths = util::glob::parse_glob_paths(&glob_opts, Some(repo))?;
+    let expanded_paths = util::glob::parse_glob_paths(&glob_opts, Some(repo)).await?;
 
     for entry_path in expanded_paths.iter().collect::<Vec<&PathBuf>>() {
         let relative_path = util::fs::path_relative_to_dir(entry_path, &repo_path)?;

--- a/crates/lib/src/repositories/remote_mode/status.rs
+++ b/crates/lib/src/repositories/remote_mode/status.rs
@@ -72,7 +72,7 @@ pub async fn status(
         ignore: None,
     };
 
-    status_from_opts_and_staged_data(local_repository, &local_opts, &mut status)?;
+    status_from_opts_and_staged_data(local_repository, &local_opts, &mut status).await?;
 
     Ok(status)
 }

--- a/crates/lib/src/repositories/restore.rs
+++ b/crates/lib/src/repositories/restore.rs
@@ -152,7 +152,7 @@ mod tests {
             util::fs::remove_file(&file_to_remove)?;
 
             // We should recognize it as missing now
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.removed_files.len(), 1);
 
             // Commit removed file
@@ -308,7 +308,7 @@ mod tests {
             let restored_contents = util::fs::read_from_path(&bbox_path)?;
             assert_eq!(og_contents, restored_contents);
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.modified_files.len(), 0);
             assert!(status.is_clean());
 
@@ -339,7 +339,7 @@ mod tests {
             let restored_contents = util::fs::read_from_path(&bbox_path)?;
             assert_eq!(og_contents, restored_contents);
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.modified_files.len(), 0);
             assert!(status.is_clean());
 
@@ -446,7 +446,7 @@ mod tests {
             repositories::add(&repo, bbox_path).await?;
 
             // Make sure is staged
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_files.len(), 1);
             status.print();
 
@@ -454,7 +454,7 @@ mod tests {
             repositories::restore::restore(&repo, RestoreOpts::from_staged_path(bbox_file)).await?;
 
             // Make sure is unstaged
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_files.len(), 0);
 
             Ok(())
@@ -551,7 +551,7 @@ mod tests {
             repositories::add(&repo, annotations_dir).await?;
 
             // Make sure is staged
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_dirs.len(), 3);
             assert_eq!(status.staged_files.len(), 6);
             status.print();
@@ -561,7 +561,7 @@ mod tests {
                 .await?;
 
             // Make sure is unstaged
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_dirs.len(), 0);
             assert_eq!(status.staged_files.len(), 0);
 
@@ -577,7 +577,7 @@ mod tests {
             let repo_dir = repo.path.join(dir);
             repositories::add(&repo, repo_dir).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Should add all the sub dirs
@@ -605,13 +605,13 @@ mod tests {
             let repo_nlp_dir = repo.path.join(dir);
             std::fs::remove_dir_all(repo_nlp_dir)?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.removed_files.len(), 1);
             assert_eq!(status.staged_files.len(), 0);
             // Add the removed nlp dir with a wildcard
             repositories::add(&repo, "nlp/*").await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_dirs.len(), 1);
             assert_eq!(status.staged_files.len(), 2);
 
@@ -653,10 +653,10 @@ mod tests {
                 ..Default::default()
             };
 
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
 
             // Should now have 7 staged for removal
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_files.len(), 7);
             assert_eq!(status.removed_files.len(), 0);
 
@@ -673,7 +673,7 @@ mod tests {
 
             repositories::restore::restore(&repo, restore_opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
 
             // Should now have unstaged the 7 ommissions, moving them to removed_files
             assert_eq!(status.removed_files.len(), 7);
@@ -690,7 +690,7 @@ mod tests {
             };
             repositories::restore::restore(&repo, restore_opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
 
             // Should now have restored the 7 files to the working directory, no staged changes
             assert_eq!(status.removed_files.len(), 0);
@@ -709,9 +709,9 @@ mod tests {
                 path: PathBuf::from("train/*"),
                 ..Default::default()
             };
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_files.len(), 7); // 3 cats, 4 dogs
 
             let mut paths = HashSet::new();
@@ -726,7 +726,7 @@ mod tests {
             };
             repositories::restore::restore(&repo, restore_opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
 
             assert_eq!(status.staged_files.len(), 3); // 3 cats should still be staged
             assert_eq!(status.removed_files.len(), 4); // 4 dogs back in working dir
@@ -771,7 +771,7 @@ mod tests {
             // Add both files
             repositories::add(&repo, &new_annotations_dir).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_files.len(), 2);
             assert_eq!(status.staged_schemas.len(), 2);
 
@@ -788,7 +788,7 @@ mod tests {
 
             repositories::restore::restore(&repo, restore_opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_files.len(), 0);
             assert_eq!(status.staged_schemas.len(), 0);
 

--- a/crates/lib/src/repositories/rm.rs
+++ b/crates/lib/src/repositories/rm.rs
@@ -13,7 +13,7 @@ use crate::{core, util};
 use std::path::PathBuf;
 
 /// Removes the path from the index
-pub fn rm(repo: &LocalRepository, opts: &RmOpts) -> Result<(), OxenError> {
+pub async fn rm(repo: &LocalRepository, opts: &RmOpts) -> Result<(), OxenError> {
     log::debug!("Rm with opts: {opts:?}");
 
     let path = &opts.path;
@@ -26,19 +26,23 @@ pub fn rm(repo: &LocalRepository, opts: &RmOpts) -> Result<(), OxenError> {
         walk_dirs: false,
     };
 
-    let expanded_paths = util::glob::parse_glob_paths(&glob_opts, Some(repo))?;
+    let expanded_paths = util::glob::parse_glob_paths(&glob_opts, Some(repo)).await?;
 
-    p_rm(&expanded_paths, repo, opts)?;
+    p_rm(&expanded_paths, repo, opts).await?;
 
     Ok(())
 }
 
-fn p_rm(paths: &HashSet<PathBuf>, repo: &LocalRepository, opts: &RmOpts) -> Result<(), OxenError> {
+async fn p_rm(
+    paths: &HashSet<PathBuf>,
+    repo: &LocalRepository,
+    opts: &RmOpts,
+) -> Result<(), OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => {
             log::debug!("Version found: V0_19_0");
-            core::v_latest::rm::rm(paths, repo, opts)?;
+            core::v_latest::rm::rm(paths, repo, opts).await?;
         }
     }
     Ok(())
@@ -82,10 +86,10 @@ mod tests {
                 recursive: true,
                 staged: false,
             };
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
 
             // Make sure we staged these removals
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             assert_eq!(num_files, status.staged_files.len());
             for (path, entry) in status.staged_files.iter() {
@@ -102,7 +106,7 @@ mod tests {
             repositories::restore::restore(&repo, opts).await?;
 
             // This should have removed all the staged files, but not restored from disk yet.
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             assert_eq!(0, status.staged_files.len());
             // One removed dir (rolled up)
@@ -112,7 +116,7 @@ mod tests {
             let opts = RestoreOpts::from_path(&rm_dir);
             repositories::restore::restore(&repo, opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             let num_restored = util::fs::rcount_files_in_dir(&full_path);
@@ -247,7 +251,7 @@ mod tests {
                     ..Default::default()
                 };
 
-                repositories::rm(&cloned_repo, &rm_opts)?;
+                repositories::rm(&cloned_repo, &rm_opts).await?;
                 repositories::commit(&cloned_repo, "Removing phi-4")?;
 
                 // Push it to the remote
@@ -301,7 +305,7 @@ mod tests {
                 recursive: true,
                 ..Default::default()
             };
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
             let commit = repositories::commit(&repo, "Removing cat images")?;
 
             for i in 1..=3 {
@@ -395,7 +399,7 @@ mod tests {
 
             repositories::add(&repo, &images_dir).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             assert_eq!(status.staged_dirs.len(), 7);
@@ -416,7 +420,7 @@ mod tests {
                 ..Default::default()
             };
 
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
             let commit = repositories::commit(&repo, "Removing cat images and sub_directories")?;
 
             // None of these files should exist after rm -r
@@ -520,7 +524,7 @@ mod tests {
             let repo_filepath = PathBuf::from("images").join("dog_1.jpg");
 
             let rm_opts = RmOpts::from_path(repo_filepath);
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
             let _commit = repositories::commit(&repo, "Removing dog")?;
 
             // Add dwight howard and vince carter
@@ -557,7 +561,7 @@ mod tests {
             let repo_dir = repo.path.join(dir);
             repositories::add(&repo, repo_dir).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Should add all the sub dirs
@@ -576,7 +580,7 @@ mod tests {
             let repo_nlp_dir = repo.path.join(dir);
             std::fs::remove_dir_all(repo_nlp_dir)?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
 
             // status.removed_files currently is files and dirs,
             // we roll up the dirs into the parent dir, so len should be 1
@@ -590,7 +594,7 @@ mod tests {
             repositories::add(&repo, "nlp/*").await?;
             status.print();
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // There is one rolled up dir
@@ -638,7 +642,7 @@ mod tests {
             std::fs::remove_file(repo.path.join("images").join("cat_2.jpg"))?;
             std::fs::remove_file(repo.path.join("images").join("dog_1.jpg"))?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             assert_eq!(status.removed_files.len(), 3);
             assert_eq!(status.staged_files.len(), 0);
@@ -649,9 +653,9 @@ mod tests {
                 ..Default::default()
             };
 
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             // Should now have 7 staged for removal
             assert_eq!(status.staged_files.len(), 7);
@@ -664,8 +668,8 @@ mod tests {
                 ..Default::default()
             };
 
-            repositories::rm(&repo, &rm_opts)?;
-            let status = repositories::status(&repo)?;
+            repositories::rm(&repo, &rm_opts).await?;
+            let status = repositories::status(&repo).await?;
             log::debug!("status: {status:?}");
             status.print();
 
@@ -690,7 +694,7 @@ mod tests {
 
             // Remove the file and commit
             let opts = RmOpts::from_path(&path);
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
             repositories::commit(&repo, "commit_message")?;
 
             // Add the file again. This should err, but not panic
@@ -709,13 +713,13 @@ mod tests {
             let path = Path::new("README.md");
             repositories::add(&repo, repo.path.join(path)).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.staged_files.len(), 1);
             assert!(status.staged_files.contains_key(path));
             let opts = RmOpts::from_staged_path(path);
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             log::debug!("status: {status:?}");
             assert_eq!(status.staged_files.len(), 0);
 
@@ -731,7 +735,7 @@ mod tests {
             let path = Path::new("train");
             repositories::add(&repo, repo.path.join(path)).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             // 2: train
             assert_eq!(status.staged_dirs.len(), 1);
@@ -741,7 +745,7 @@ mod tests {
                 staged: true,
                 recursive: false, // This should be an error
             };
-            let result = repositories::rm(&repo, &opts);
+            let result = repositories::rm(&repo, &opts).await;
             assert!(result.is_err());
 
             Ok(())
@@ -756,7 +760,7 @@ mod tests {
             let path = Path::new("annotations").join("train");
             repositories::add(&repo, repo.path.join(&path)).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             // 1: annotations/train
             assert_eq!(status.staged_dirs.len(), 1);
@@ -766,9 +770,9 @@ mod tests {
                 staged: true,
                 recursive: true, // make sure to pass in recursive
             };
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             assert_eq!(status.staged_dirs.len(), 0);
@@ -786,7 +790,7 @@ mod tests {
             let path = Path::new("train");
             repositories::add(&repo, repo.path.join(path)).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             // 1: train
             assert_eq!(status.staged_dirs.len(), 1);
@@ -796,9 +800,9 @@ mod tests {
                 staged: true,
                 recursive: true, // make sure to pass in recursive
             };
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             assert_eq!(status.staged_dirs.len(), 0);
@@ -816,7 +820,7 @@ mod tests {
             let path = Path::new("train/");
             repositories::add(&repo, repo.path.join(path)).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             // 1: train dir
             assert_eq!(status.staged_dirs.len(), 1);
 
@@ -825,10 +829,10 @@ mod tests {
                 staged: true,
                 recursive: true, // make sure to pass in recursive
             };
-            let result = repositories::rm(&repo, &opts);
+            let result = repositories::rm(&repo, &opts).await;
             assert!(result.is_ok());
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             assert_eq!(status.staged_dirs.len(), 0);
@@ -846,9 +850,9 @@ mod tests {
             let path = Path::new("README.md");
 
             let opts = RmOpts::from_path(path);
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             assert_eq!(status.staged_files.len(), 1);
@@ -874,7 +878,7 @@ mod tests {
                 recursive: false, // This should be an error
             };
 
-            let result = repositories::rm(&repo, &opts);
+            let result = repositories::rm(&repo, &opts).await;
             assert!(result.is_err());
 
             Ok(())
@@ -894,7 +898,7 @@ mod tests {
                 recursive: true, // Need to specify recursive
             };
 
-            let result = repositories::rm(&repo, &opts);
+            let result = repositories::rm(&repo, &opts).await;
             assert!(result.is_err());
 
             Ok(())
@@ -930,7 +934,7 @@ mod tests {
             )?;
 
             // There should be one modified file
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             assert_eq!(
                 status.modified_files.len(),
@@ -939,7 +943,7 @@ mod tests {
                 status.modified_files
             );
 
-            let result = repositories::rm(&repo, &opts);
+            let result = repositories::rm(&repo, &opts).await;
             assert!(result.is_err(), "{result:?}");
 
             Ok(())
@@ -960,9 +964,9 @@ mod tests {
                 staged: false,
                 recursive: true, // Must pass in recursive = true
             };
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             assert_eq!(status.staged_files.len(), og_num_files);
@@ -995,9 +999,9 @@ mod tests {
                 staged: false,
                 recursive: true, // Must pass in recursive = true
             };
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             assert_eq!(status.staged_files.len(), og_num_files);
@@ -1022,9 +1026,9 @@ mod tests {
                 staged: false,
                 recursive: true, // Must pass in recursive = true
             };
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             assert_eq!(status.staged_files.len(), og_num_files);
@@ -1066,7 +1070,7 @@ mod tests {
                 staged: false,
                 recursive: true,
             };
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
 
             // Verify that .oxen directory still exists after rm operation
             assert!(
@@ -1075,7 +1079,7 @@ mod tests {
             );
 
             // Verify that the test files were staged for removal
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Should have staged the test files for removal but not .oxen
@@ -1104,7 +1108,7 @@ mod tests {
                 staged: false,
                 recursive: true,
             };
-            let err = repositories::rm(&repo, &direct_oxen_opts);
+            let err = repositories::rm(&repo, &direct_oxen_opts).await;
 
             assert!(err.is_err());
 
@@ -1132,9 +1136,9 @@ mod tests {
                 path: PathBuf::from("annotations/test/*"),
                 ..Default::default()
             };
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
 
             assert_eq!(status.staged_files.len(), 1);
             assert_eq!(
@@ -1179,10 +1183,10 @@ mod tests {
                 recursive: true,
                 staged: false,
             };
-            repositories::rm(&repo, &rm_opts)?;
+            repositories::rm(&repo, &rm_opts).await?;
 
             // Should have staged the file for removal
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             let has_staged_removal = status
                 .staged_files
                 .iter()
@@ -1193,7 +1197,7 @@ mod tests {
             repositories::commit(&repo, "remove dir")?;
 
             // Status should be clean — no removed files
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert!(
                 status.removed_files.is_empty(),
                 "status should be clean after committing removal, but got removed_files: {:?}",
@@ -1253,7 +1257,7 @@ mod tests {
             repositories::add(&repo, &repo.path).await?;
 
             // Should have staged the file for removal
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             let has_staged_removal = status
                 .staged_files
                 .iter()
@@ -1267,7 +1271,7 @@ mod tests {
             repositories::commit(&repo, "remove dir")?;
 
             // Status should be clean
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert!(
                 status.removed_files.is_empty(),
                 "status should be clean after committing removal, but got removed_files: {:?}",
@@ -1329,7 +1333,7 @@ mod tests {
             repositories::add(&repo, &repo.path).await?;
 
             // Should have staged the file for removal
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             let has_staged_removal = status
                 .staged_files
                 .iter()
@@ -1343,7 +1347,7 @@ mod tests {
             repositories::commit(&repo, "remove file")?;
 
             // Status should be clean
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert!(
                 status.removed_files.is_empty(),
                 "status should be clean after committing removal, but got removed_files: {:?}",

--- a/crates/lib/src/repositories/status.rs
+++ b/crates/lib/src/repositories/status.rs
@@ -26,7 +26,7 @@ use crate::model::{LocalRepository, StagedData};
 /// // Initialize empty repo
 /// let repo = repositories::init(&base_dir)?;
 /// // Get status on repo
-/// let status = repositories::status(&repo)?;
+/// let status = repositories::status(&repo).await?;
 /// assert!(status.is_clean());
 /// ```
 ///
@@ -44,33 +44,33 @@ use crate::model::{LocalRepository, StagedData};
 /// util::fs::write_to_path(&hello_file, "Hello World");
 ///
 /// // Get status on repo
-/// let status = repositories::status(&repo)?;
+/// let status = repositories::status(&repo).await?;
 /// assert_eq!(status.untracked_files.len(), 1);
 /// ```
-pub fn status(repo: &LocalRepository) -> Result<StagedData, OxenError> {
+pub async fn status(repo: &LocalRepository) -> Result<StagedData, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::status::status(repo),
+        _ => core::v_latest::status::status(repo).await,
     }
 }
 
-pub fn status_from_opts(
+pub async fn status_from_opts(
     repo: &LocalRepository,
     opts: &StagedDataOpts,
 ) -> Result<StagedData, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v10 not supported"),
-        _ => core::v_latest::status::status_from_opts(repo, opts),
+        _ => core::v_latest::status::status_from_opts(repo, opts).await,
     }
 }
 
-pub fn status_from_dir(
+pub async fn status_from_dir(
     repo: &LocalRepository,
     dir: impl AsRef<Path>,
 ) -> Result<StagedData, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::status::status_from_dir(repo, dir),
+        _ => core::v_latest::status::status_from_dir(repo, dir).await,
     }
 }
 
@@ -92,8 +92,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_command_status_empty() -> Result<(), OxenError> {
-        test::run_empty_local_repo_test(|repo| {
-            let repo_status = repositories::status(&repo)?;
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let repo_status = repositories::status(&repo).await?;
 
             assert_eq!(repo_status.staged_dirs.len(), 0);
             assert_eq!(repo_status.staged_files.len(), 0);
@@ -102,12 +102,13 @@ mod tests {
 
             Ok(())
         })
+        .await
     }
 
     #[tokio::test]
     async fn test_command_status_nothing_staged_full_directory() -> Result<(), OxenError> {
-        test::run_training_data_repo_test_no_commits(|repo| {
-            let repo_status = repositories::status(&repo)?;
+        test::run_training_data_repo_test_no_commits_async(|repo| async move {
+            let repo_status = repositories::status(&repo).await?;
 
             assert_eq!(repo_status.staged_dirs.len(), 0);
             assert_eq!(repo_status.staged_files.len(), 0);
@@ -125,6 +126,7 @@ mod tests {
 
             Ok(())
         })
+        .await
     }
 
     #[tokio::test]
@@ -132,7 +134,7 @@ mod tests {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             repositories::add(&repo, repo.path.join(Path::new("labels.txt"))).await?;
 
-            let repo_status = repositories::status(&repo)?;
+            let repo_status = repositories::status(&repo).await?;
             repo_status.print();
 
             // TODO: v0_10_0 logic should have no dirs staged
@@ -168,7 +170,7 @@ mod tests {
             .await?;
 
             // Make sure that we now see the full annotations/train/ directory
-            let repo_status = repositories::status(&repo)?;
+            let repo_status = repositories::status(&repo).await?;
             repo_status.print();
 
             // annotations/
@@ -211,7 +213,7 @@ mod tests {
             let opts =
                 StagedDataOpts::from_paths(&[repo.path.join(Path::new("annotations/train"))]);
 
-            let repo_status = repositories::status::status_from_opts(&repo, &opts)?;
+            let repo_status = repositories::status::status_from_opts(&repo, &opts).await?;
             repo_status.print();
 
             // Make sure that we only see the modified files
@@ -249,7 +251,7 @@ mod tests {
                 .path
                 .join(Path::new("annotations/train/one_shot.csv"))]);
 
-            let repo_status = repositories::status::status_from_opts(&repo, &opts)?;
+            let repo_status = repositories::status::status_from_opts(&repo, &opts).await?;
             repo_status.print();
 
             // Make sure that we only see the modified files
@@ -289,7 +291,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let repo_status = repositories::status::status_from_opts(&repo, &opts)?;
+            let repo_status = repositories::status::status_from_opts(&repo, &opts).await?;
             repo_status.print();
 
             // Make sure that we only see the modified files
@@ -334,7 +336,7 @@ mod tests {
             let opts =
                 StagedDataOpts::from_paths(&[repo.path.join(Path::new("annotations/train"))]);
 
-            let repo_status = repositories::status::status_from_opts(&repo, &opts)?;
+            let repo_status = repositories::status::status_from_opts(&repo, &opts).await?;
             repo_status.print();
 
             // Make sure that we only see the modified files
@@ -399,13 +401,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_command_status_has_txt_file() -> Result<(), OxenError> {
-        test::run_empty_local_repo_test(|repo| {
+        test::run_empty_local_repo_test_async(|repo| async move {
             // Write to file
             let hello_file = repo.path.join("hello.txt");
             util::fs::write_to_path(hello_file, "Hello World")?;
 
             // Get status
-            let repo_status = repositories::status(&repo)?;
+            let repo_status = repositories::status(&repo).await?;
             assert_eq!(repo_status.staged_dirs.len(), 0);
             assert_eq!(repo_status.staged_files.len(), 0);
             assert_eq!(repo_status.untracked_files.len(), 1);
@@ -413,6 +415,7 @@ mod tests {
 
             Ok(())
         })
+        .await
     }
 
     #[tokio::test]
@@ -446,7 +449,7 @@ mod tests {
             assert!(commit.is_none());
 
             // Make sure we can access the conflicts in the status command
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.merge_conflicts.len(), 1);
 
             Ok(())
@@ -462,14 +465,14 @@ mod tests {
             let og_file = repo.path.join(&og_basename);
             util::fs::remove_file(og_file)?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             assert_eq!(status.removed_files.len(), 1);
 
             let opts = RmOpts::from_path(&og_basename);
-            repositories::rm(&repo, &opts)?;
-            let status = repositories::status(&repo)?;
+            repositories::rm(&repo, &opts).await?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             assert_eq!(status.staged_files.len(), 1);
@@ -491,14 +494,14 @@ mod tests {
             let og_file = repo.path.join(&og_basename);
             util::fs::remove_file(og_file)?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             assert_eq!(status.removed_files.len(), 1);
 
             let opts = RmOpts::from_path(&og_basename);
-            repositories::rm(&repo, &opts)?;
-            let status = repositories::status(&repo)?;
+            repositories::rm(&repo, &opts).await?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             assert_eq!(status.staged_files.len(), 1);
@@ -524,7 +527,7 @@ mod tests {
             util::fs::rename(&og_file, &new_file)?;
 
             // Status before
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
 
             assert_eq!(status.moved_files.len(), 0);
             assert_eq!(status.removed_files.len(), 1);
@@ -532,14 +535,14 @@ mod tests {
 
             // Add one file...
             repositories::add(&repo, &og_file).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             // No notion of movement until the pair are added
             assert_eq!(status.moved_files.len(), 0);
             assert_eq!(status.staged_files.len(), 1);
 
             // Complete the pair
             repositories::add(&repo, &new_file).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.moved_files.len(), 1);
             assert_eq!(status.staged_files.len(), 2); // Staged files still operates on the addition + removal
 
@@ -547,7 +550,7 @@ mod tests {
             repositories::restore(&repo, RestoreOpts::from_staged_path(og_basename)).await?;
 
             // Pair is broken; no more "moved"
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.moved_files.len(), 0);
             assert_eq!(status.staged_files.len(), 1);
 
@@ -569,7 +572,7 @@ mod tests {
             util::fs::create_dir_all(&new_dir)?;
             util::fs::rename(&og_dir, &new_dir)?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             assert_eq!(status.moved_files.len(), 0);
             // TODO: v0_10_0 logic should have root and new_train/train2
@@ -582,7 +585,7 @@ mod tests {
             repositories::add(&repo, &og_dir).await?;
             // repositories::add(&repo, &new_dir)?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             // No moved files, 7 staged (the removals)
             assert_eq!(status.moved_files.len(), 0);
             assert_eq!(status.staged_files.len(), 7);
@@ -590,7 +593,7 @@ mod tests {
 
             // Complete the pairs
             repositories::add(&repo, &new_dir).await?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             assert_eq!(status.moved_files.len(), 7);
             assert_eq!(status.staged_files.len(), 14);
             assert_eq!(status.staged_dirs.len(), 2);
@@ -614,7 +617,7 @@ mod tests {
             repositories::add(&repo, &sub_dir).await?;
 
             // List files
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             println!("status: {status:?}");
             status.print();
             let dirs = status.staged_dirs;
@@ -638,14 +641,14 @@ mod tests {
             let repo_path = &repo.path;
             let file_to_rm = repo_path.join("labels.txt");
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
 
             // Remove a committed file
             util::fs::remove_file(&file_to_rm)?;
 
             // List removed
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             let files = status.removed_files;
 
@@ -679,7 +682,7 @@ mod tests {
             util::fs::remove_file(&one_shot_file)?;
 
             // List removed
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             let files = status.removed_files;
 
@@ -711,7 +714,7 @@ mod tests {
             util::fs::remove_file(&target_file)?;
 
             let opts = StagedDataOpts::from_paths(std::slice::from_ref(&target_file));
-            let status = repositories::status::status_from_opts(&repo, &opts)?;
+            let status = repositories::status::status_from_opts(&repo, &opts).await?;
             status.print();
 
             let relative_path = util::fs::path_relative_to_dir(&target_file, repo_path)?;
@@ -736,7 +739,7 @@ mod tests {
             let one_shot_file = test::modify_txt_file(one_shot_file, "new content coming in hot")?;
 
             // List modified
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             let files = status.modified_files;
 
@@ -799,7 +802,7 @@ mod tests {
             let _base_file_3 = test::add_txt_file_to_dir(repo_path, "Hello 3")?;
 
             // At first there should be 3 untracked
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             let untracked_dirs = status.untracked_dirs;
             assert_eq!(untracked_dirs.len(), 3);
@@ -810,7 +813,7 @@ mod tests {
             repositories::add(&repo, &base_file_1).await?;
 
             // List the files
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             println!("status: {status:?}");
             status.print();
             let staged_files = status.staged_files;
@@ -845,7 +848,7 @@ mod tests {
             // commit the file
             repositories::commit(&repo, "added hello 1")?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             let mod_files = status.modified_files;
             assert_eq!(mod_files.len(), 0);
 
@@ -853,7 +856,7 @@ mod tests {
             let hello_file = test::modify_txt_file(hello_file, "Hello 2")?;
 
             // List files
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             let mod_files = status.modified_files;
             assert_eq!(mod_files.len(), 1);
@@ -878,7 +881,7 @@ mod tests {
 
             let file_contents = "file,label\ntrain/cat_1.jpg,0\n";
             test::modify_txt_file(one_shot_path, file_contents)?;
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             status.print();
             assert_eq!(status.modified_files.len(), 1);
             assert!(

--- a/crates/lib/src/repositories/tree.rs
+++ b/crates/lib/src/repositories/tree.rs
@@ -1472,7 +1472,7 @@ mod tests {
                 recursive: true,
             };
 
-            repositories::rm(&repo, &opts)?;
+            repositories::rm(&repo, &opts).await?;
             let commit = repositories::commit(&repo, "Removing dir")?;
 
             let files = repositories::tree::list_tabular_files_in_repo(&repo, &commit)?;
@@ -1499,7 +1499,7 @@ mod tests {
             repositories::add(&local_repo, &path_1).await?;
             repositories::add(&local_repo, &path_2).await?;
 
-            let status = repositories::status(&local_repo)?;
+            let status = repositories::status(&local_repo).await?;
 
             log::debug!("staged files here are {:?}", status.staged_files);
 

--- a/crates/lib/src/repositories/workspaces/data_frames.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames.rs
@@ -836,7 +836,7 @@ mod tests {
                 _ => panic!("Expected tabular diff result"),
             }
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             log::debug!("got this status {status:?}");
 
             // Commit the new file

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -572,7 +572,7 @@ pub async fn make_many_commits(local_repo: &LocalRepository) -> Result<(), OxenE
         ..Default::default()
     };
 
-    repositories::rm(local_repo, &rm_opts)?;
+    repositories::rm(local_repo, &rm_opts).await?;
     repositories::commit(local_repo, "Removing test/")?;
 
     // Add all the files
@@ -1613,7 +1613,7 @@ where
     repositories::add(&repo, &repo.path).await?;
 
     // Get the status and print it
-    let status = repositories::status(&repo)?;
+    let status = repositories::status(&repo).await?;
     println!("setup status: {status:?}");
     status.print();
 
@@ -2321,7 +2321,7 @@ mod tests {
             let oxenignore_file = repo.path.join(".oxenignore");
             write_txt_file_to_path(oxenignore_file, ignore_filename)?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             // Only untracked file should be .oxenignore
             assert_eq!(status.untracked_files.len(), 1);
             assert_eq!(
@@ -2347,7 +2347,7 @@ mod tests {
             let oxenignore_file = repo.path.join(".oxenignore");
             write_txt_file_to_path(oxenignore_file, "ignoreme/")?;
 
-            let status = repositories::status(&repo)?;
+            let status = repositories::status(&repo).await?;
             // Only untracked file should be .oxenignore
             assert_eq!(status.untracked_files.len(), 1);
             assert_eq!(

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -1575,43 +1575,9 @@ pub fn remove_paths(src: &Path) -> Result<(), OxenError> {
     }
 }
 
-/// Strict-mtime variant. Treats `disk_mtime != node_mtime` (to the nanosecond) as "different
-/// enough to fall through to the hash check," which on coarse-mtime mounts (FAT/exFAT, HFS+,
-/// some NFS) misclassifies files inside `restore_file`'s tolerance window as modified.
-///
-/// Use [`crate::model::LocalRepository::is_modified_from_node`] /
-/// [`crate::model::LocalRepository::is_modified_from_node_with_metadata`] from any caller
-/// that has access to a `&LocalRepository` and is already in an async context — those use
-/// `repo.mtime_matches`. The sync version remains for `oxen status`, whose walker is
-/// sync-everywhere by design.
-pub fn is_modified_from_node_with_metadata(
-    path: &Path,
-    node: &FileNode,
-    metadata: Result<std::fs::Metadata, OxenError>,
-) -> Result<bool, OxenError> {
-    if !path.exists() {
-        log::debug!("is_modified_from_node found non-existent path {path:?}. Returning false");
-        return Ok(false);
-    }
-
-    let metadata = metadata?;
-    let file_last_modified = FileTime::from_last_modification_time(&metadata);
-    let node_last_modified = util::fs::last_modified_time(
-        node.last_modified_seconds(),
-        node.last_modified_nanoseconds(),
-    );
-    let mtime_matched = file_last_modified == node_last_modified;
-    classify_modified_from_node_with_metadata(path, node, &metadata, mtime_matched)
-}
-
-pub fn is_modified_from_node(path: &Path, node: &FileNode) -> Result<bool, OxenError> {
-    is_modified_from_node_with_metadata(path, node, util::fs::metadata(path))
-}
-
-/// Shared between [`is_modified_from_node_with_metadata`] and
-/// [`crate::model::LocalRepository::is_modified_from_node_with_metadata`]. Given the
-/// already-decided mtime equality verdict, applies the size / metadata-hash / content-hash
-/// checks. `path` is assumed to exist and `metadata` to be valid.
+/// Backing helper for [`crate::model::LocalRepository::is_modified_from_node_with_metadata`].
+/// Given the already-decided mtime equality verdict, applies the size / metadata-hash /
+/// content-hash checks. `path` is assumed to exist and `metadata` to be valid.
 pub(crate) fn classify_modified_from_node_with_metadata(
     path: &Path,
     node: &FileNode,

--- a/crates/lib/src/util/glob.rs
+++ b/crates/lib/src/util/glob.rs
@@ -17,7 +17,7 @@ use walkdir::WalkDir;
 // TODO: Should 'oxenignore' filter out non-glob paths too, or only dictate which paths glob patterns can expand into?
 
 // Top level module for parsing glob paths
-pub fn parse_glob_paths(
+pub async fn parse_glob_paths(
     opts: &GlobOpts,
     repo: Option<&LocalRepository>,
 ) -> Result<HashSet<PathBuf>, OxenError> {
@@ -73,7 +73,7 @@ pub fn parse_glob_paths(
                     ));
                 };
 
-                let staged_paths = search_staged_db(&glob_path, repo)?;
+                let staged_paths = search_staged_db(&glob_path, repo).await?;
 
                 expanded_paths.extend(staged_paths);
                 // If the merkle_tree flag is set, match against the merkle tree
@@ -128,13 +128,16 @@ pub fn parse_glob_paths(
     Ok(expanded_paths)
 }
 
-fn search_staged_db(path: &Path, repo: &LocalRepository) -> Result<HashSet<PathBuf>, OxenError> {
+async fn search_staged_db(
+    path: &Path,
+    repo: &LocalRepository,
+) -> Result<HashSet<PathBuf>, OxenError> {
     let mut paths = HashSet::new();
     let path_str = path
         .to_str()
         .ok_or_else(|| OxenError::basic_str("Invalid UTF-8 in search path"))?;
     let glob_pattern = Pattern::new(path_str)?;
-    let staged_data = repositories::status::status(repo)?;
+    let staged_data = repositories::status::status(repo).await?;
 
     for entry in staged_data.staged_files {
         let entry_path_str = entry
@@ -461,7 +464,7 @@ mod tests {
                 walk_dirs: false,
             };
 
-            let paths = parse_glob_paths(&opts, Some(&repo))?;
+            let paths = parse_glob_paths(&opts, Some(&repo)).await?;
 
             let expected: HashSet<PathBuf> = vec![
                 PathBuf::from("README.md"),
@@ -489,7 +492,7 @@ mod tests {
                 walk_dirs: false,
             };
 
-            let paths = parse_glob_paths(&opts, Some(&repo))?;
+            let paths = parse_glob_paths(&opts, Some(&repo)).await?;
             let expected: HashSet<PathBuf> = vec![
                 PathBuf::from("annotations/README.md"),
                 PathBuf::from("annotations/train"),
@@ -520,7 +523,7 @@ mod tests {
                 walk_dirs: true,
             };
 
-            let paths = parse_glob_paths(&opts, Some(&repo))?;
+            let paths = parse_glob_paths(&opts, Some(&repo)).await?;
 
             let expected: HashSet<PathBuf> = vec![
                 PathBuf::from("nlp/classification/annotations/test.tsv"),
@@ -541,7 +544,7 @@ mod tests {
                 walk_dirs: true,
             };
 
-            let paths = parse_glob_paths(&opts, Some(&repo))?;
+            let paths = parse_glob_paths(&opts, Some(&repo)).await?;
 
             let expected: HashSet<PathBuf> = vec![
                 PathBuf::from("annotations/README.md"),
@@ -579,7 +582,7 @@ mod tests {
                 walk_dirs: false,
             };
 
-            let paths = parse_glob_paths(&opts, Some(&repo))?;
+            let paths = parse_glob_paths(&opts, Some(&repo)).await?;
 
             let expected: HashSet<PathBuf> = vec![
                 PathBuf::from("annotations/train/annotations.txt"),
@@ -601,7 +604,7 @@ mod tests {
                 walk_dirs: false,
             };
 
-            let paths_root = parse_glob_paths(&opts_root, Some(&repo))?;
+            let paths_root = parse_glob_paths(&opts_root, Some(&repo)).await?;
 
             let expected_root: HashSet<PathBuf> = vec![
                 PathBuf::from("annotations/train/annotations.txt"),
@@ -633,7 +636,7 @@ mod tests {
                 walk_dirs: false,
             };
 
-            let paths = parse_glob_paths(&opts, Some(&repo))?;
+            let paths = parse_glob_paths(&opts, Some(&repo)).await?;
 
             let expected: HashSet<PathBuf> = vec![
                 PathBuf::from("nlp/classification/annotations/test.tsv"),
@@ -653,7 +656,7 @@ mod tests {
                 walk_dirs: false,
             };
 
-            let paths_root = parse_glob_paths(&opts_root, Some(&repo))?;
+            let paths_root = parse_glob_paths(&opts_root, Some(&repo)).await?;
 
             // Merkle tree search should return both files and directories at this level
             let expected_root: HashSet<PathBuf> = vec![

--- a/crates/oxen-py/src/py_repo.rs
+++ b/crates/oxen-py/src/py_repo.rs
@@ -121,7 +121,8 @@ impl PyRepo {
             recursive,
         };
 
-        repositories::rm(&repo, &rm_opts)?;
+        pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(async { repositories::rm(&repo, &rm_opts).await })?;
 
         Ok(())
     }
@@ -149,7 +150,8 @@ impl PyRepo {
 
     pub fn status(&self) -> Result<PyStagedData, PyOxenError> {
         let repo = LocalRepository::from_dir(&self.path)?;
-        let status = repositories::status(&repo)?;
+        let status = pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(async { repositories::status(&repo).await })?;
         Ok(PyStagedData { data: status })
     }
 

--- a/crates/server/src/controllers/diff.rs
+++ b/crates/server/src/controllers/diff.rs
@@ -1012,7 +1012,7 @@ mod tests {
 
         repositories::add(&repo, &repo.path).await?;
 
-        repositories::status(&repo)?;
+        repositories::status(&repo).await?;
 
         repositories::commit(&repo, "commit 1")?;
 


### PR DESCRIPTION
`oxen status` is the final operation that needs to gain mtime tolerance to deal with filesystems with coarse-grained timestamps. Both #507 and #508 were to prepare the ground for this change so it would be easier to understand and review.

As part of making the switch, the call-stack of the function needed to be converted to async. The mechanical `async/await` updates are most of this repository. The `status` command is apparently extensively used internally by other calls, so there were lots of places updated. The only actual logic changes are:

- Call the async, `LocalRepository::is_modified_from_node_with_metadata` which is mtime tolerant, and removing the now-unused sync freestanding `is_modified_from_node_with_metadata` function. ([here](https://github.com/Oxen-AI/Oxen/pull/509/changes#diff-318243296f1b413c9b6b5993da892dff1a48bbcdaada0b52022e6a50974e7fbaR695) and [here](https://github.com/Oxen-AI/Oxen/pull/509/changes#diff-318243296f1b413c9b6b5993da892dff1a48bbcdaada0b52022e6a50974e7fbaR711))
- (bugfix) Use `metadata.is_dir()` instead of `path.is_dir()` to ignore symlinks ([link](https://github.com/Oxen-AI/Oxen/pull/509/changes#diff-318243296f1b413c9b6b5993da892dff1a48bbcdaada0b52022e6a50974e7fbaR623))
- Add claude instructions about how we ignore symlinks ([link](https://github.com/Oxen-AI/Oxen/pull/509/changes#diff-317ae893ef4add3af4928b72cae8408ac42a97cd487729dcf157d6ed0dbe44d2))

Closes ENG-979.