### PR TITLE
Fix empty 3-way merges

### DIFF
--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -1,5 +1,6 @@
 use crate::constants;
 use crate::core::db;
+use crate::core::db::merkle_node::MerkleNodeDB;
 pub use crate::core::merge::entry_merge_conflict_db_reader::EntryMergeConflictDBReader;
 pub use crate::core::merge::node_merge_conflict_db_reader::NodeMergeConflictDBReader;
 use crate::core::merge::node_merge_conflict_reader::NodeMergeConflictReader;
@@ -10,9 +11,12 @@ use crate::core::v_latest::branches::OnConflict;
 use crate::core::v_latest::commits::{get_commit_or_head, list_between};
 use crate::core::v_latest::merge_marker;
 use crate::error::OxenError;
+use crate::model::NewCommit;
 use crate::model::StagedEntryStatus;
 use crate::model::merge_conflict::NodeMergeConflict;
+use crate::model::merkle_tree::node::CommitNode;
 use crate::model::merkle_tree::node::StagedMerkleTreeNode;
+use crate::model::merkle_tree::node::commit_node::CommitNodeOpts;
 use crate::model::merkle_tree::node::file_node::FileNode;
 use crate::model::merkle_tree::node::{EMerkleTreeNode, MerkleTreeNode};
 use crate::model::{Branch, Commit, LocalRepository};
@@ -247,6 +251,10 @@ pub async fn merge_into_base(
 
     let result = if commits.is_fast_forward_merge() {
         Ok(commits.merge)
+    } else if commits.is_already_up_to_date() {
+        // Merge branch is an ancestor of base — base already contains everything from merge.
+        // Mirrors `git merge`'s "Already up to date" outcome: no merge commit, base unchanged.
+        Ok(commits.base.clone())
     } else {
         server_three_way_merge(repo, &commits).await
     };
@@ -293,7 +301,16 @@ async fn server_three_way_merge(
     }
 
     if analysis.entries.is_empty() {
-        return Err(OxenError::basic_str("No changes to commit"));
+        // The merge branch contributes no new content on top of base — its changes are already
+        // present in base via a separate path (e.g. base squash-replayed the merge branch). Build
+        // an empty merge commit (two parents, base's tree) so the merge is preserved in commit
+        // history. Mirrors `git merge`'s behavior on a 3-way merge with no content delta.
+        log::info!(
+            "server_three_way_merge: merge {} contributes no new content to base {}; creating empty merge commit",
+            merge_commits.merge.id,
+            merge_commits.base.id,
+        );
+        return create_empty_merge_commit(repo, merge_commits);
     }
 
     // 2. Build dir_entries HashMap (parent dir -> staged nodes) for the commit writer
@@ -915,6 +932,11 @@ async fn merge_commits(
         let commit =
             fast_forward_merge(repo, &merge_commits.base, &merge_commits.merge, checkout).await?;
         Ok(commit)
+    } else if merge_commits.is_already_up_to_date() {
+        // Merge branch is an ancestor of base — `git merge`'s "Already up to date" outcome.
+        // No merge commit, working tree and HEAD unchanged.
+        println!("Already up to date.");
+        Ok(Some(merge_commits.base.clone()))
     } else {
         log::debug!(
             "Three way merge! {} -> {}",
@@ -950,7 +972,18 @@ Found {} conflicts, please resolve them before merging.
         log::debug!("Got {} conflicts", analysis.conflicts.len());
 
         if analysis.conflicts.is_empty() {
-            let commit = create_merge_commit(repo, merge_commits, shared_hashes).await?;
+            let commit = if analysis.entries.is_empty() {
+                // Same case as server_three_way_merge: merge contributes no new content on top of
+                // base. Build an empty merge commit aliasing base's tree (matches `git merge`'s
+                // 3-way no-delta behavior). Skips the staging path since there's nothing to stage,
+                // and advances HEAD afterward since `commit_dir_entries_with_parents` and the
+                // empty-merge-commit helper don't update HEAD on their own.
+                let commit = create_empty_merge_commit(repo, merge_commits)?;
+                with_ref_manager(repo, |manager| manager.set_head_commit_id(&commit.id))?;
+                commit
+            } else {
+                create_merge_commit(repo, merge_commits, shared_hashes).await?
+            };
             Ok(Some(commit))
         } else {
             let db_path = db_path(repo);
@@ -991,6 +1024,76 @@ async fn create_merge_commit(
     // rm::remove_staged(repo, &HashSet::from([PathBuf::from("/")]))?;
 
     Ok(commit)
+}
+
+/// Create an empty merge commit: a commit with two parents whose tree is identical to base's
+/// tree. Used when a 3-way merge analysis produces no entries (the merge branch contributes no
+/// new content on top of base) but the merge isn't a fast-forward / "already up to date" case
+/// either. Mirrors `git merge`'s empty-merge-commit behavior on a 3-way merge with no content
+/// delta.
+///
+/// This aliases base's existing root DirNode by hash — Merkle storage is content-addressed, so
+/// the new commit and base share the underlying tree storage. Only a new CommitNode and a copy
+/// of base's `dir_hash_db` are written. The caller is responsible for advancing the appropriate
+/// ref (server-side: the base branch ref via `merge_into_base`; client-side: HEAD via the
+/// `with_ref_manager` helper).
+fn create_empty_merge_commit(
+    repo: &LocalRepository,
+    merge_commits: &MergeCommits,
+) -> Result<Commit, OxenError> {
+    let cfg = crate::config::UserConfig::get()?;
+    let timestamp = time::OffsetDateTime::now_utc();
+    let new_commit_data = NewCommit {
+        parent_ids: vec![
+            merge_commits.base.id.clone(),
+            merge_commits.merge.id.clone(),
+        ],
+        message: merge_commits.commit_message(),
+        author: cfg.name.clone(),
+        email: cfg.email.clone(),
+        timestamp,
+    };
+    let commit_id = commit_writer::compute_commit_id(&new_commit_data)?;
+
+    let base_commit_hash: MerkleHash = merge_commits.base.id.parse()?;
+    let merge_commit_hash: MerkleHash = merge_commits.merge.id.parse()?;
+
+    let commit_node = CommitNode::new(
+        repo,
+        CommitNodeOpts {
+            hash: commit_id,
+            // CommitNode.parent_ids holds parent commit hashes (matches `create_empty_commit`
+            // in core/v_latest/commits.rs).
+            parent_ids: vec![base_commit_hash, merge_commit_hash],
+            email: cfg.email.clone(),
+            author: cfg.name.clone(),
+            message: merge_commits.commit_message(),
+            timestamp,
+        },
+    )?;
+
+    // Open the new commit's MerkleNodeDB and add base's existing root DirNode as the only child.
+    // Tree is content-addressed, so the new commit's tree equals base's tree without any tree
+    // rebuild or copy.
+    let base_node = repositories::tree::get_node_by_id_with_children(repo, &base_commit_hash)?
+        .ok_or_else(|| {
+            OxenError::resource_not_found(format!(
+                "Merkle tree node not found for base commit '{}'",
+                merge_commits.base.id
+            ))
+        })?;
+    let mut commit_db = MerkleNodeDB::open_read_write(repo, &commit_node, Some(base_node.hash))?;
+    let root_dir = base_node
+        .children
+        .first()
+        .expect("base commit must have a root dir as its first child")
+        .dir()?;
+    commit_db.add_child(&root_dir)?;
+
+    // Copy base's path -> dir hash mapping so path-based tree lookups work for the new commit.
+    repositories::tree::cp_dir_hashes_to(repo, &base_commit_hash, commit_node.hash())?;
+
+    Ok(commit_node.to_commit())
 }
 
 pub fn lowest_common_ancestor_from_commits(

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -934,6 +934,12 @@ async fn merge_commits(
     // predicates are true, and we want the no-op outcome (return base unchanged) rather than
     // calling `fast_forward_merge`, which would return Ok(None).
     if merge_commits.is_already_up_to_date() {
+        // Clear any stale marker for this target left by a prior interrupted attempt at the same
+        // merge: the mismatch check above already rejected markers naming a different target, so
+        // anything still on disk here is for the very merge we're now declaring done.
+        if checkout.writes_to_disk() {
+            merge_marker::clear(repo).await?;
+        }
         // Merge branch is an ancestor of base (or equal tips) — `git merge`'s "Already up to
         // date" outcome. No merge commit, working tree and HEAD unchanged.
         println!("Already up to date.");

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -232,10 +232,6 @@ pub async fn merge_into_base(
 ) -> Result<Commit, OxenError> {
     log::debug!("merge_into_base merge {merge_branch} into {base_branch}");
 
-    if merge_branch.commit_id == base_branch.commit_id {
-        return Err(OxenError::basic_str("No changes to merge"));
-    }
-
     let base_commit = get_commit_or_head(repo, Some(base_branch.commit_id.clone()))?;
     let merge_commit = get_commit_or_head(repo, Some(merge_branch.commit_id.clone()))?;
 
@@ -249,12 +245,13 @@ pub async fn merge_into_base(
         merge: merge_commit,
     };
 
-    let result = if commits.is_fast_forward_merge() {
-        Ok(commits.merge)
-    } else if commits.is_already_up_to_date() {
-        // Merge branch is an ancestor of base — base already contains everything from merge.
-        // Mirrors `git merge`'s "Already up to date" outcome: no merge commit, base unchanged.
+    let result = if commits.is_already_up_to_date() {
+        // Merge branch is an ancestor of base (or equal tips) — base already contains everything
+        // from merge. Mirrors `git merge`'s "Already up to date" outcome: no merge commit, base
+        // unchanged.
         Ok(commits.base.clone())
+    } else if commits.is_fast_forward_merge() {
+        Ok(commits.merge)
     } else {
         server_three_way_merge(repo, &commits).await
     };
@@ -465,7 +462,12 @@ pub async fn merge_commit_into_base_on_branch(
         merge: merge_commit.to_owned(),
     };
 
-    let result = if merge_commits.is_fast_forward_merge() {
+    let result = if merge_commits.is_already_up_to_date() {
+        // Merge is an ancestor of base (or equal tips) — base already contains everything from
+        // merge. Return base unchanged rather than fabricating an empty merge commit via
+        // `server_three_way_merge`. Mirrors `git merge`'s "Already up to date" outcome.
+        Ok(merge_commits.base.clone())
+    } else if merge_commits.is_fast_forward_merge() {
         Ok(merge_commits.merge)
     } else {
         server_three_way_merge(repo, &merge_commits).await
@@ -927,16 +929,19 @@ async fn merge_commits(
         LocalCheckout::Absent
     };
 
-    // Check which type of merge we need to do
-    if merge_commits.is_fast_forward_merge() {
+    // Check which type of merge we need to do.
+    // "Already up to date" must be checked before the fast-forward case: when base == merge both
+    // predicates are true, and we want the no-op outcome (return base unchanged) rather than
+    // calling `fast_forward_merge`, which would return Ok(None).
+    if merge_commits.is_already_up_to_date() {
+        // Merge branch is an ancestor of base (or equal tips) — `git merge`'s "Already up to
+        // date" outcome. No merge commit, working tree and HEAD unchanged.
+        println!("Already up to date.");
+        Ok(Some(merge_commits.base.clone()))
+    } else if merge_commits.is_fast_forward_merge() {
         let commit =
             fast_forward_merge(repo, &merge_commits.base, &merge_commits.merge, checkout).await?;
         Ok(commit)
-    } else if merge_commits.is_already_up_to_date() {
-        // Merge branch is an ancestor of base — `git merge`'s "Already up to date" outcome.
-        // No merge commit, working tree and HEAD unchanged.
-        println!("Already up to date.");
-        Ok(Some(merge_commits.base.clone()))
     } else {
         log::debug!(
             "Three way merge! {} -> {}",

--- a/crates/lib/src/repositories/checkout.rs
+++ b/crates/lib/src/repositories/checkout.rs
@@ -321,12 +321,16 @@ mod tests {
             // // Checkout the branch
             // repositories::checkout(&repo, second_commit.id).await?;
 
-            let has_merges = repositories::merge::merge(&repo, DEFAULT_BRANCH_NAME)
-                .await
-                .is_ok();
-
-            // We should not have a merge because the current branch has all the old commits
-            assert!(!has_merges);
+            // Merging main into the current branch is a no-op: main is an ancestor of
+            // feature/my-branch (current HEAD), so the merge succeeds as "Already up to date" —
+            // no new merge commit, HEAD unchanged.
+            let head_before_merge = repositories::commits::head_commit(&repo)?;
+            let merge_result = repositories::merge::merge(&repo, DEFAULT_BRANCH_NAME)
+                .await?
+                .expect("merge should succeed (already up to date)");
+            assert_eq!(merge_result.id, head_before_merge.id);
+            let head_after_merge = repositories::commits::head_commit(&repo)?;
+            assert_eq!(head_after_merge.id, head_before_merge.id);
             assert!(world_file.exists());
             assert!(hello_file.exists());
 

--- a/crates/lib/src/repositories/merge.rs
+++ b/crates/lib/src/repositories/merge.rs
@@ -22,6 +22,13 @@ impl MergeCommits {
     pub fn is_fast_forward_merge(&self) -> bool {
         self.lca.as_ref().is_some_and(|lca| lca.id == self.base.id)
     }
+
+    /// True when the merge branch is an ancestor of base (LCA equals merge). Mirrors `git merge`'s
+    /// "Already up to date" condition — no merge work needed because every change reachable from
+    /// the merge branch is already in base.
+    pub fn is_already_up_to_date(&self) -> bool {
+        self.lca.as_ref().is_some_and(|lca| lca.id == self.merge.id)
+    }
 }
 
 pub fn list_conflicts(repo: &LocalRepository) -> Result<Vec<MergeConflict>, OxenError> {
@@ -527,6 +534,146 @@ mod tests {
         .await
     }
 
+    // Regression test for a three-way merge where the merge branch's content is already entirely
+    // present in base via a separate path (e.g. base was squash-merged from the merge branch and
+    // then advanced with an unrelated commit). Pre-fix this errored with "No changes to commit",
+    // which surfaced as a 500 from oxen-server's `/merge/{base..head}` endpoint and broke
+    // OxenHub merge requests in that state.
+    //
+    //   A — B — D    <- main (base): B replays the merge branch's change as its own commit, then
+    //    \     /                     D adds an unrelated file so main has commits not on feature.
+    //     C        <- feature (merge): the change that B already incorporated.
+    async fn populate_already_up_to_date_three_way(
+        repo: &LocalRepository,
+        feature_branch_name: &str,
+    ) -> Result<Commit, OxenError> {
+        let main_branch = repositories::branches::current_branch(repo)?.unwrap();
+
+        // A: shared ancestor — a.txt at v1.
+        let a_path = repo.path.join("a.txt");
+        util::fs::write_to_path(&a_path, "v1")?;
+        repositories::add(repo, &a_path).await?;
+        repositories::commit(repo, "A: add a.txt with v1")?;
+
+        // C: feature branch flips a.txt to v2.
+        repositories::branches::create_checkout(repo, feature_branch_name)?;
+        test::modify_txt_file(&a_path, "v2")?;
+        repositories::add(repo, &a_path).await?;
+        repositories::commit(repo, "C: change a.txt to v2 on feature")?;
+
+        // Back on main, replay the same content change (a.txt -> v2). This makes main's a.txt
+        // identical to feature's, but via a different commit (not a fast-forward).
+        repositories::checkout(repo, &main_branch.name).await?;
+        test::modify_txt_file(&a_path, "v2")?;
+        repositories::add(repo, &a_path).await?;
+        repositories::commit(repo, "B: replay feature's a.txt change on main")?;
+
+        // D: an unrelated commit on main so main is genuinely diverged from feature.
+        let d_path = repo.path.join("d.txt");
+        util::fs::write_to_path(&d_path, "d")?;
+        repositories::add(repo, &d_path).await?;
+        repositories::commit(repo, "D: add d.txt on main")
+    }
+
+    /// Verifies a 3-way merge with no content delta produced an empty merge commit: a NEW commit
+    /// with two parents and a tree that matches base's content (each path maps to the same file
+    /// hash as in base). Mirrors `git merge`'s empty-merge-commit semantics.
+    fn assert_empty_merge_commit(
+        repo: &LocalRepository,
+        merge_commit: &Commit,
+        base: &Commit,
+        merge_branch_tip: &Commit,
+    ) -> Result<(), OxenError> {
+        assert_ne!(
+            merge_commit.id, base.id,
+            "an empty merge commit must be a new commit, not base itself"
+        );
+        assert_eq!(
+            merge_commit.parent_ids.len(),
+            2,
+            "merge commit should have two parents"
+        );
+        assert!(
+            merge_commit.parent_ids.contains(&base.id),
+            "merge commit parents should include base ({}); got {:?}",
+            base.id,
+            merge_commit.parent_ids,
+        );
+        assert!(
+            merge_commit.parent_ids.contains(&merge_branch_tip.id),
+            "merge commit parents should include merge branch tip ({}); got {:?}",
+            merge_branch_tip.id,
+            merge_commit.parent_ids,
+        );
+        // Tree content: every file present in base must be present at the same path in the merge
+        // commit with the same content hash.
+        for path in ["a.txt", "d.txt"] {
+            let base_file = repositories::tree::get_file_by_path(repo, base, path)?
+                .unwrap_or_else(|| panic!("base should contain {path}"));
+            let merge_file = repositories::tree::get_file_by_path(repo, merge_commit, path)?
+                .unwrap_or_else(|| panic!("merge commit should contain {path}"));
+            assert_eq!(
+                base_file.combined_hash(),
+                merge_file.combined_hash(),
+                "{path} should have the same content hash as base"
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_merge_three_way_no_content_delta_client_side() -> Result<(), OxenError> {
+        // Three-way merge where merge isn't an ancestor of base but contributes no new content —
+        // base squash-replayed the merge branch. Pre-fix this 500ed with "No changes to commit".
+        // Post-fix: succeeds and produces an empty merge commit with two parents and base's tree.
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let feature_branch = "feature";
+            let main_head_before_merge =
+                populate_already_up_to_date_three_way(&repo, feature_branch).await?;
+            let feature_tip = repositories::revisions::get(&repo, feature_branch)?
+                .expect("feature branch should resolve");
+
+            let result = repositories::merge::merge(&repo, feature_branch).await?;
+            let merge_commit = result.expect("merge should succeed and produce a commit");
+
+            assert_empty_merge_commit(&repo, &merge_commit, &main_head_before_merge, &feature_tip)?;
+            // Client-side merge advances HEAD to the new merge commit.
+            let current_head = repositories::commits::head_commit(&repo)?;
+            assert_eq!(current_head.id, merge_commit.id);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_three_way_no_content_delta_server_side() -> Result<(), OxenError> {
+        // Server-side equivalent — exercises `merge_into_base`, the path called from the
+        // oxen-server `/api/repos/.../merge/{base..head}` controller.
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let main_branch = repositories::branches::current_branch(&repo)?.unwrap();
+            let feature_branch_name = "feature";
+            let main_head_before_merge =
+                populate_already_up_to_date_three_way(&repo, feature_branch_name).await?;
+
+            let base_branch = repositories::branches::get_by_name(&repo, &main_branch.name)?;
+            let merge_branch = repositories::branches::get_by_name(&repo, feature_branch_name)?;
+            let feature_tip = repositories::revisions::get(&repo, feature_branch_name)?
+                .expect("feature branch should resolve");
+
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+
+            assert_empty_merge_commit(&repo, &merge_commit, &main_head_before_merge, &feature_tip)?;
+            // Server-side: base branch ref is advanced to the new merge commit.
+            let base_after = repositories::branches::get_by_name(&repo, &main_branch.name)?;
+            assert_eq!(base_after.commit_id, merge_commit.id);
+
+            Ok(())
+        })
+        .await
+    }
+
     #[tokio::test]
     async fn test_merge_conflict_three_way_merge() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|repo| async move {
@@ -1022,14 +1169,13 @@ mod tests {
             // 4. merge main onto new branch (re-fetch branches to get current commit IDs)
             let og_branch = repositories::branches::get_by_name(&repo, &og_branch.name)?;
             let new_branch = repositories::branches::get_by_name(&repo, new_branch_name)?;
-            let merge_result =
-                repositories::merge::merge_into_base(&repo, &og_branch, &new_branch).await;
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &og_branch, &new_branch).await?;
 
-            // 5. There should be no commit
-            assert_eq!(
-                merge_result.unwrap_err().to_string(),
-                OxenError::basic_str("No changes to commit").to_string()
-            );
+            // 5. Already up to date: merge_into_base returns base unchanged, no new commit.
+            assert_eq!(merge_commit.id, new_branch.commit_id);
+            let new_branch_after = repositories::branches::get_by_name(&repo, new_branch_name)?;
+            assert_eq!(new_branch_after.commit_id, new_branch.commit_id);
 
             Ok(())
         })
@@ -1088,11 +1234,12 @@ mod tests {
             );
 
             // 7. Merge new branch onto main branch again.
-            // There should be no new merge commit
-            let merge_result2 = repositories::merge::merge(&repo, new_branch_name).await;
+            // Already up to date: no new merge commit, HEAD stays at the first merge commit.
+            let merge_result2 = repositories::merge::merge(&repo, new_branch_name).await?;
+            let merge_commit2 =
+                merge_result2.expect("second merge should succeed (already up to date)");
             assert_eq!(
-                merge_result2.unwrap_err().to_string(),
-                OxenError::basic_str("No changes to commit").to_string(),
+                merge_commit2.id, merge_commit1.id,
                 "Second merge attempt should not create a new commit as it's already merged"
             );
 

--- a/crates/lib/src/repositories/merge.rs
+++ b/crates/lib/src/repositories/merge.rs
@@ -2574,6 +2574,39 @@ mod tests {
         .await
     }
 
+    // A successful no-op (already-up-to-date) merge must also clear any stale marker for the
+    // same target left behind by a prior interrupted attempt — otherwise the next merge of a
+    // different target would error with MergeInProgressMismatch.
+    #[tokio::test]
+    async fn test_merge_clears_marker_on_already_up_to_date() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            // Create commit A on main, then advance main with commit B. Make a sibling branch
+            // "ancestor" pointing at A so merging it into main hits is_already_up_to_date.
+            let f1 = repo.path.join("f1.txt");
+            util::fs::write_to_path(&f1, "one")?;
+            repositories::add(&repo, &f1).await?;
+            let ancestor_commit = repositories::commit(&repo, "Add f1")?;
+            repositories::branches::create(&repo, "ancestor", &ancestor_commit.id)?;
+
+            let f2 = repo.path.join("f2.txt");
+            util::fs::write_to_path(&f2, "two")?;
+            repositories::add(&repo, &f2).await?;
+            repositories::commit(&repo, "Add f2")?;
+
+            // Simulate a prior interrupted merge of "ancestor" by writing a stale marker.
+            merge_marker::write(&repo, &ancestor_commit.id).await?;
+
+            let merged = repositories::merge::merge(&repo, "ancestor").await?;
+            assert!(merged.is_some(), "no-op merge should succeed");
+            assert!(
+                !merge_marker::exists(&repo).await?,
+                "marker must be cleared after an already-up-to-date merge"
+            );
+            Ok(())
+        })
+        .await
+    }
+
     // Abort restores the working tree from a fast-forward-in-progress state and
     // clears every merge marker.
     #[tokio::test]

--- a/crates/lib/src/repositories/merge.rs
+++ b/crates/lib/src/repositories/merge.rs
@@ -23,11 +23,14 @@ impl MergeCommits {
         self.lca.as_ref().is_some_and(|lca| lca.id == self.base.id)
     }
 
-    /// True when the merge branch is an ancestor of base (LCA equals merge). Mirrors `git merge`'s
-    /// "Already up to date" condition — no merge work needed because every change reachable from
-    /// the merge branch is already in base.
+    /// True when the merge branch is an ancestor of base — including the equal-tip case, where
+    /// base and merge are the same commit. Mirrors `git merge`'s "Already up to date" condition:
+    /// no merge work needed because every change reachable from the merge branch is already in
+    /// base. The equal-tip branch is checked explicitly so this still returns true even if a
+    /// caller built `MergeCommits` with `lca: None`.
     pub fn is_already_up_to_date(&self) -> bool {
-        self.lca.as_ref().is_some_and(|lca| lca.id == self.merge.id)
+        self.base.id == self.merge.id
+            || self.lca.as_ref().is_some_and(|lca| lca.id == self.merge.id)
     }
 }
 
@@ -1183,6 +1186,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_merge_client_equal_tips_returns_base() -> Result<(), OxenError> {
+        // Equal-tip merge on the client path: a sibling branch points at the same commit as HEAD.
+        // Must report "Already up to date" — Some(base) — rather than None (which is what
+        // fast_forward_merge used to return for this case before the equal-tip dispatch fix).
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch = repositories::branches::current_branch(&repo)?.unwrap();
+            repositories::branches::create_from_head(&repo, "twin")?;
+
+            let merged = repositories::merge::merge(&repo, "twin").await?;
+            assert_eq!(
+                merged.map(|c| c.id),
+                Some(base_branch.commit_id.clone()),
+                "client merge of equal tips must return the base commit, not None"
+            );
+
+            // HEAD must remain on the same commit.
+            let head_commit = repositories::commits::head_commit(&repo)?;
+            assert_eq!(head_commit.id, base_branch.commit_id);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
     async fn test_merge_diverged_branches_then_merge_again() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|repo| async move {
             // 1. Commit something in main branch
@@ -1258,8 +1286,6 @@ mod tests {
     #[tokio::test]
     async fn test_merge_immediately_after_checkout() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|repo| async move {
-            // Need to have main branch get ahead of branch so that you can traverse to directory to it, but they
-            // have a common ancestor
             // 1. Commit something in main branch
             let og_branch = repositories::branches::current_branch(&repo)?.unwrap();
             let labels_path = repo.path.join("labels.txt");
@@ -1267,15 +1293,17 @@ mod tests {
             repositories::add(&repo, &labels_path).await?;
             repositories::commit(&repo, "Add initial labels.txt file with cat and dog")?;
 
-            // 2. Create a new branch
+            // 2. Create a new branch pointing at HEAD and check it out — equal tips with main.
             let new_branch_name = "new_branch";
-            let _new_branch = repositories::branches::create_checkout(&repo, new_branch_name)?;
+            let new_branch = repositories::branches::create_checkout(&repo, new_branch_name)?;
 
-            // 4. merge main onto new branch
-            let commit = repositories::merge::merge(&repo, og_branch.name).await?;
+            // 3. Merging main into new_branch is a no-op (already up to date): returns the current
+            //    HEAD commit unchanged, with no new merge commit and no movement of HEAD.
+            let merged = repositories::merge::merge(&repo, og_branch.name).await?;
+            assert_eq!(merged.map(|c| c.id), Some(new_branch.commit_id.clone()));
 
-            // 5. There should be no commit
-            assert!(commit.is_none());
+            let head_commit = repositories::commits::head_commit(&repo)?;
+            assert_eq!(head_commit.id, new_branch.commit_id);
 
             Ok(())
         })
@@ -1484,6 +1512,29 @@ mod tests {
             // The base branch ref should now point to the merge commit
             let updated_branch = repositories::branches::get_by_name(&repo, &base_branch.name)?;
             assert_eq!(updated_branch.commit_id, merge_commit.id);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_into_base_equal_tips_returns_base() -> Result<(), OxenError> {
+        // Equal-tip merge on the server path: a sibling branch points at the same commit as the
+        // base branch. Must succeed and return base unchanged — previously this returned
+        // Err("No changes to merge").
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch = repositories::branches::current_branch(&repo)?.unwrap();
+            repositories::branches::create_from_head(&repo, "twin")?;
+            let merge_branch = repositories::branches::get_by_name(&repo, "twin")?;
+
+            let merge_commit =
+                repositories::merge::merge_into_base(&repo, &merge_branch, &base_branch).await?;
+            assert_eq!(merge_commit.id, base_branch.commit_id);
+
+            // The base branch ref must still point at the same commit.
+            let updated_base = repositories::branches::get_by_name(&repo, &base_branch.name)?;
+            assert_eq!(updated_base.commit_id, base_branch.commit_id);
 
             Ok(())
         })
@@ -2196,6 +2247,47 @@ mod tests {
                 repositories::tree::get_file_by_path(&repo, &merge_commit, "data/b.txt")?.is_none(),
                 "data/b.txt should be deleted in merge commit"
             );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_merge_commit_into_base_on_branch_ancestor_is_no_op() -> Result<(), OxenError> {
+        // When the merge commit is an ancestor of the base commit (lca == merge), the merge is a
+        // no-op. The branch ref must NOT advance to a fabricated empty merge commit.
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let base_branch = repositories::branches::current_branch(&repo)?.unwrap();
+
+            // First commit on main becomes the "ancestor" we'll later try to merge into HEAD.
+            let f1 = repo.path.join("f1.txt");
+            util::fs::write_to_path(&f1, "one")?;
+            repositories::add(&repo, &f1).await?;
+            let ancestor_commit = repositories::commit(&repo, "Add f1")?;
+
+            // Advance main with a second commit so base != merge but lca == merge.
+            let f2 = repo.path.join("f2.txt");
+            util::fs::write_to_path(&f2, "two")?;
+            repositories::add(&repo, &f2).await?;
+            let head_commit = repositories::commit(&repo, "Add f2")?;
+
+            let base_branch = repositories::branches::get_by_name(&repo, &base_branch.name)?;
+            let merge_commit_result = repositories::merge::merge_commit_into_base_on_branch(
+                &repo,
+                &ancestor_commit,
+                &head_commit,
+                &base_branch,
+            )
+            .await?;
+
+            // Should return base unchanged, not a new (empty) merge commit.
+            assert_eq!(merge_commit_result.id, head_commit.id);
+            assert_eq!(merge_commit_result.parent_ids, head_commit.parent_ids);
+
+            // Branch ref must still point at the original head commit.
+            let branch_after = repositories::branches::get_by_name(&repo, &base_branch.name)?;
+            assert_eq!(branch_after.commit_id, head_commit.id);
 
             Ok(())
         })

--- a/crates/lib/src/repositories/pull.rs
+++ b/crates/lib/src/repositories/pull.rs
@@ -1958,10 +1958,10 @@ mod tests {
                 )
                 .await;
 
-                assert_eq!(
-                    pull_result.unwrap_err().to_string(),
-                    OxenError::basic_str("No changes to commit").to_string()
-                );
+                // Pulling main into branch1 is a no-op: main is an ancestor of branch1 (branch1
+                // was branched from main and added newfile.txt on top), so the merge step
+                // succeeds as "Already up to date" with no new merge commit.
+                pull_result?;
 
                 // Verify the state after pull
                 assert!(repo.path.join("train").exists());


### PR DESCRIPTION
There were two cases where an "empty" 3-way merge would fail with an error, returning a 500 to the user:

1. **Merge branch is an ancestor of base**. This scenario is when you try to merge something that's already in your branch's history. In other words, your stuff is "Already up to date", so no merge work needed. Now this case succeeds as a no-op.

2. **Merge branch is not an ancestor but contributes no new content.** Sometimes you merge something in that has already been done exactly the same in your branch, so there's no new content to change. Instead of returning an error, we now do exactly what Git does: create an empty merge commit. So there's a new commit that points to both commits you were merging, just like normal, but the file content in your checkout doesn't change, because the same change has already been independently made in the base branch.

Fixes ENG-969