### PR TITLE
Have `oxen restore` surface per-file restoration errors

### DIFF
--- a/crates/lib/src/core/v_latest/index/restore.rs
+++ b/crates/lib/src/core/v_latest/index/restore.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, SystemTime};
 
 use crate::constants::STAGED_DIR;
 use crate::core::db::{self};
-use crate::error::OxenError;
+use crate::error::{OxenError, PathBufError};
 use crate::model::merkle_tree::node::{EMerkleTreeNode, FileNode, MerkleTreeNode};
 use crate::model::{Commit, LocalRepository, MerkleHash, PartialNode};
 use crate::opts::RestoreOpts;
@@ -36,6 +36,10 @@ pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), Ox
 
     let repo_path = repo.path.clone();
 
+    // Accumulate per-file failures so the caller can recover everything that did succeed
+    // and we can still surface a single aggregated error at the end.
+    let mut failures: Vec<(PathBufError, Box<OxenError>)> = Vec::new();
+
     for path in paths {
         let path = util::fs::path_relative_to_dir(&path, &repo_path)?;
         let Some(node) = repositories::tree::get_node_by_path_with_children(repo, &commit, &path)?
@@ -51,23 +55,13 @@ pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), Ox
         match &node.node {
             EMerkleTreeNode::Directory(_dir_node) => {
                 log::debug!("restore::restore: restoring directory");
-                match restore_dir(repo, node, &path, &version_store).await {
-                    Ok(_) => {}
-                    Err(e) => {
-                        log::error!(
-                            "restore::restore_dir failed for dir {path:?} with error {e:?}"
-                        );
-                    }
-                }
+                let dir_failures = restore_dir(repo, node, &path, &version_store).await?;
+                failures.extend(dir_failures);
             }
             EMerkleTreeNode::File(file_node) => {
-                match restore_file(repo, file_node, &path, &version_store).await {
-                    Ok(_) => {}
-                    Err(e) => {
-                        log::error!(
-                            "restore::restore_file failed for file {path:?} with error {e:?}"
-                        );
-                    }
+                if let Err(e) = restore_file(repo, file_node, &path, &version_store).await {
+                    log::error!("restore::restore_file failed for file {path:?} with error {e:?}");
+                    failures.push((path.clone().into(), Box::new(e)));
                 }
             }
             _ => {
@@ -76,7 +70,11 @@ pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), Ox
         }
     }
 
-    Ok(())
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(OxenError::RestoreFailed { failures })
+    }
 }
 
 fn restore_staged(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), OxenError> {
@@ -167,14 +165,17 @@ fn open_staged_db(db_path: &Path) -> Result<Option<DBWithThreadMode<SingleThread
     }
 }
 
+/// Restore every file in `dir` (recursive). Returns the list of files that failed to
+/// restore — empty when every entry succeeded. Restoration of one file failing does not
+/// stop the loop; the caller wraps any non-empty result in [`OxenError::RestoreFailed`].
+/// An outer error means some other error occurred other than a failed file restore.
 async fn restore_dir(
     repo: &LocalRepository,
     dir: MerkleTreeNode,
     path: &PathBuf,
     version_store: &Arc<dyn VersionStore>,
-) -> Result<(), OxenError> {
+) -> Result<Vec<(PathBufError, Box<OxenError>)>, OxenError> {
     log::debug!("restore::restore_dir: start");
-    // Change the return type to include both FileNode and PathBuf
     let file_nodes_with_paths = repositories::tree::dir_entries_with_paths(&dir, path)?;
     log::debug!(
         "restore::restore_dir: got {} entries",
@@ -185,20 +186,22 @@ async fn restore_dir(
     let bar =
         util::progress_bar::oxen_progress_bar_with_msg(file_nodes_with_paths.len() as u64, &msg);
 
+    let mut failures: Vec<(PathBufError, Box<OxenError>)> = Vec::new();
     for (file_node, file_path) in file_nodes_with_paths.iter() {
         match restore_file(repo, file_node, file_path, version_store).await {
             Ok(_) => log::debug!("restore::restore_dir: entry restored successfully"),
             Err(e) => {
                 log::error!("restore::restore_dir: error restoring file {file_path:?}: {e:?}");
+                failures.push((file_path.clone().into(), Box::new(e)));
             }
         }
         bar.inc(1);
     }
 
     bar.finish_and_clear();
-    log::debug!("restore::restore_dir: end");
+    log::debug!("restore::restore_dir: end ({} failures)", failures.len());
 
-    Ok(())
+    Ok(failures)
 }
 
 pub async fn should_restore_partial_node(

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -7,6 +7,7 @@ use aws_sdk_s3::error::BuildError;
 use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use aws_smithy_runtime_api::client::result::SdkError;
 use duckdb::arrow::error::ArrowError;
+use std::fmt::Write;
 use std::io;
 use std::num::ParseIntError;
 use std::path::Path;
@@ -181,6 +182,21 @@ pub enum OxenError {
     /// An error deleting keys
     #[error("delete_objects: some keys failed to delete: {0:?}")]
     DeleteFailure(Vec<(String, String)>),
+
+    /// The version store does not have the data file for the given hash that `oxen restore` is
+    /// attempting to copy from.
+    #[error("Cannot restore {target_path}: version-store data missing for hash {hash}")]
+    VersionStoreDataMissing {
+        hash: String,
+        target_path: PathBufError,
+    },
+
+    /// `oxen restore` finished with one or more file-restore failures. Aggregated rather than
+    /// fail-fast so the rest of the files can still be restored. The vector should be non-empty.
+    #[error("{}", format_restore_failures(failures))]
+    RestoreFailed {
+        failures: Vec<(PathBufError, Box<OxenError>)>,
+    },
 
     // Entry
     /// A commit entry is not present in the repository.
@@ -402,6 +418,27 @@ pub enum OxenError {
     InternalError(StringError),
 }
 
+/// Multi-line render for [`OxenError::RestoreFailed`]. Each failed file is listed with its
+/// underlying error so users debugging a stuck restore see every problem at once.
+fn format_restore_failures(failures: &[(PathBufError, Box<OxenError>)]) -> String {
+    let mut out = format!("Failed to restore {} file(s):", failures.len());
+    for (path, err) in failures {
+        // Indent each entry
+        let rendered = err.to_string();
+        let mut lines = rendered.lines();
+        if let Some(first) = lines.next() {
+            let _ = write!(out, "\n  {path}: {first}");
+        } else {
+            let _ = write!(out, "\n  {path}:");
+        }
+        // Indent each subsequent line of the error message even further
+        for line in lines {
+            let _ = write!(out, "\n    {line}");
+        }
+    }
+    out
+}
+
 impl OxenError {
     //
     //
@@ -435,6 +472,19 @@ impl OxenError {
             | CommitEntryNotFound(_) => "Check the path and current branch with `oxen status`.",
             MergeInProgressMismatch { .. } => {
                 "Run `oxen merge --abort` to abandon the in-progress merge, or retry the original target."
+            }
+            VersionStoreDataMissing { .. } => {
+                "Run `oxen fetch --missing-files` to re-fetch missing version-store data, then retry `oxen restore`."
+            }
+            RestoreFailed { failures } => {
+                if failures
+                    .iter()
+                    .any(|(_, err)| matches!(err.as_ref(), VersionStoreDataMissing { .. }))
+                {
+                    "Some files could not be restored because their version-store data is missing. Run `oxen fetch --missing-files` to re-fetch, then retry `oxen restore`."
+                } else {
+                    "Run with RUST_LOG=debug for per-file details, or check `oxen status`."
+                }
             }
             HTTP(req_err) => {
                 if req_err.is_connect() || req_err.is_timeout() {

--- a/crates/lib/src/repositories/restore.rs
+++ b/crates/lib/src/repositories/restore.rs
@@ -173,6 +173,148 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_restore_aggregates_per_file_failures() -> Result<(), OxenError> {
+        // `oxen restore .` was silently swallowing per-file failures, so when a previous
+        // interrupted pull left the working tree in a state where the version store no longer had
+        // the data needed to restore HEAD's expected content, the user got a misleading successful
+        // return code with nothing changed on disk. Restore must now surface an
+        // `OxenError::RestoreFailed` whose Display lists every failed file with its underlying
+        // error, so the user can see all the broken paths at once and the CLI hint can point them
+        // at `oxen fetch --missing-files`.
+        //
+        // Three branches of behavior in one restore call:
+        //   succeeds.txt    — blob present, working file removed       → restore writes it back
+        //   missing_blob    — blob removed, working file removed       → VersionStoreDataMissing
+        //   other_error     — blob present, dir replaces working file  → non-missing-data error
+        // This covers (1) the mixed-success case (RestoreFailed must not be raised when zero
+        // files failed, and a successful restore in the same call must still happen) and
+        // (2) the path where a RestoreFailed wraps a non-missing-data error — important
+        // because the CLI hint logic must not assume every failure is a missing blob.
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let succeeds = repo.path.join("succeeds.txt");
+            let missing_blob = repo.path.join("missing_blob.txt");
+            let other_error = repo.path.join("other_error.txt");
+            let succeeds_content = "alpha alpha alpha";
+            util::fs::write_to_path(&succeeds, succeeds_content)?;
+            util::fs::write_to_path(&missing_blob, "beta beta beta")?;
+            util::fs::write_to_path(&other_error, "gamma gamma gamma")?;
+            repositories::add(&repo, &succeeds).await?;
+            repositories::add(&repo, &missing_blob).await?;
+            repositories::add(&repo, &other_error).await?;
+            repositories::commit(&repo, "Add three files")?;
+
+            // Locate and delete the blob backing missing_blob.txt only — leave the other
+            // two blobs alone so succeeds.txt can be restored and other_error.txt's failure
+            // is forced by the destination state, not the source.
+            let head = repositories::commits::head_commit(&repo)?;
+            let node = repositories::tree::get_node_by_path(&repo, &head, "missing_blob.txt")?
+                .expect("missing_blob.txt must be in HEAD's tree");
+            let missing_hash = node.hash.to_string();
+            let missing_blob_data = repo
+                .path
+                .join(crate::constants::OXEN_HIDDEN_DIR)
+                .join("versions")
+                .join("files")
+                .join(&missing_hash[..2])
+                .join(&missing_hash[2..])
+                .join("data");
+            assert!(
+                missing_blob_data.exists(),
+                "test setup expected blob to exist: {missing_blob_data:?}"
+            );
+            util::fs::remove_file(&missing_blob_data)?;
+
+            // Working-tree mutations:
+            //   succeeds and missing_blob: removed so restore takes the copy path
+            //     (succeeds restores cleanly, missing_blob hits VersionStoreDataMissing).
+            //   other_error: replaced by a directory of the same name. The blob is intact,
+            //     but tokio::fs::copy will fail with EISDIR when restore_file tries to
+            //     write the file content to a path that's now a directory — surfacing a
+            //     non-VersionStoreDataMissing error inside the same RestoreFailed.
+            util::fs::remove_file(&succeeds)?;
+            util::fs::remove_file(&missing_blob)?;
+            util::fs::remove_file(&other_error)?;
+            std::fs::create_dir(&other_error)?;
+
+            let mut paths = HashSet::new();
+            paths.insert(PathBuf::from("succeeds.txt"));
+            paths.insert(PathBuf::from("missing_blob.txt"));
+            paths.insert(PathBuf::from("other_error.txt"));
+            let result = repositories::restore::restore(
+                &repo,
+                RestoreOpts {
+                    paths,
+                    staged: false,
+                    is_remote: false,
+                    source_ref: None,
+                },
+            )
+            .await;
+
+            let Err(OxenError::RestoreFailed { failures }) = result else {
+                panic!("expected RestoreFailed, got: {result:?}");
+            };
+
+            // succeeds.txt is not in the failure list — it was actually restored.
+            assert_eq!(failures.len(), 2, "failures: {failures:#?}");
+            let by_path = |name: &str| -> &OxenError {
+                failures
+                    .iter()
+                    .find(|(p, _)| p.to_string() == name)
+                    .map(|(_, e)| e.as_ref())
+                    .unwrap_or_else(|| panic!("{name} should be in failures: {failures:#?}"))
+            };
+
+            assert!(
+                matches!(
+                    by_path("missing_blob.txt"),
+                    OxenError::VersionStoreDataMissing { .. }
+                ),
+                "missing_blob.txt: expected VersionStoreDataMissing, got: {:?}",
+                by_path("missing_blob.txt")
+            );
+            assert!(
+                !matches!(
+                    by_path("other_error.txt"),
+                    OxenError::VersionStoreDataMissing { .. }
+                ),
+                "other_error.txt: expected a non-missing-data error, got: {:?}",
+                by_path("other_error.txt")
+            );
+
+            // Display lists both failed files, exactly one of them as missing-data.
+            let rendered = OxenError::RestoreFailed { failures }.to_string();
+            assert!(
+                rendered.starts_with("Failed to restore 2 file(s):"),
+                "rendered did not lead with the count summary: {rendered}"
+            );
+            assert!(
+                rendered.contains("missing_blob.txt"),
+                "missing_blob.txt missing in:\n{rendered}"
+            );
+            assert!(
+                rendered.contains("other_error.txt"),
+                "other_error.txt missing in:\n{rendered}"
+            );
+            assert_eq!(
+                rendered.matches("version-store data missing").count(),
+                1,
+                "expected exactly one missing-data line in:\n{rendered}"
+            );
+
+            // succeeds.txt was restored from its still-present blob.
+            assert!(succeeds.exists(), "succeeds.txt should have been restored");
+            assert_eq!(util::fs::read_from_path(&succeeds)?, succeeds_content);
+            // The other two files remain in their pre-restore state.
+            assert!(!missing_blob.exists());
+            assert!(other_error.is_dir());
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
     async fn test_restore_directory() -> Result<(), OxenError> {
         test::run_training_data_repo_test_fully_committed_async(|repo| async move {
             let history = repositories::commits::list(&repo)?;

--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -198,6 +198,20 @@ impl VersionStore for LocalVersionStore {
     async fn copy_version_to_path(&self, hash: &str, dest_path: &Path) -> Result<(), OxenError> {
         let version_path = self.version_path(hash);
         log::debug!("copying version path: {version_path:?} to {dest_path:?}");
+        // Distinguish "the version-store blob is missing" from generic copy errors so the
+        // caller (oxen restore / merge / etc.) can surface a useful hint pointing the user
+        // at `oxen fetch --missing-files`. Real IO errors from the existence check (e.g.
+        // permission denied on `.oxen/versions/`) propagate as-is.
+        match fs::try_exists(&version_path).await {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(OxenError::VersionStoreDataMissing {
+                    hash: hash.to_string(),
+                    target_path: dest_path.to_path_buf().into(),
+                });
+            }
+            Err(err) => return Err(OxenError::file_error(&version_path, err)),
+        }
         util::fs::copy_mkdir(&version_path, dest_path).await?;
         Ok(())
     }

--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -202,15 +202,14 @@ impl VersionStore for LocalVersionStore {
         // caller (oxen restore / merge / etc.) can surface a useful hint pointing the user
         // at `oxen fetch --missing-files`. Real IO errors from the existence check (e.g.
         // permission denied on `.oxen/versions/`) propagate as-is.
-        match fs::try_exists(&version_path).await {
-            Ok(true) => {}
-            Ok(false) => {
+        match fs::try_exists(&version_path).await? {
+            true => {}
+            false => {
                 return Err(OxenError::VersionStoreDataMissing {
                     hash: hash.to_string(),
                     target_path: dest_path.to_path_buf().into(),
                 });
             }
-            Err(err) => return Err(OxenError::file_error(&version_path, err)),
         }
         util::fs::copy_mkdir(&version_path, dest_path).await?;
         Ok(())


### PR DESCRIPTION
`oxen restore` was silently ignoring errors when it couldn't find the file content in the version file storage in order to restore it. This PR surfaces those errors as a list of files that are missing from storage, and recommends an `oxen fetch --missing-files` to resolve the issue.

Refs ENG-990.