### PR TITLE
Add Merkle storage enum to RepositoryConfig + merkle_store field

### DIFF
--- a/crates/lib/benches/download.rs
+++ b/crates/lib/benches/download.rs
@@ -171,7 +171,8 @@ pub fn download_benchmark(c: &mut Criterion) {
 
                         // create a clean local repo ready for the fetch
                         let mut local_repo =
-                            LocalRepository::from_remote(remote_repo.clone(), &iter_dir).unwrap();
+                            LocalRepository::from_remote(remote_repo.clone(), &iter_dir, false)
+                                .unwrap();
                         iter_dir.clone_into(&mut local_repo.path);
                         local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
                         local_repo.set_min_version(repo.min_version());

--- a/crates/lib/benches/fetch.rs
+++ b/crates/lib/benches/fetch.rs
@@ -170,7 +170,8 @@ pub fn fetch_benchmark(c: &mut Criterion) {
 
                         // create a clean local repo ready for the fetch
                         let mut local_repo =
-                            LocalRepository::from_remote(remote_repo.clone(), &iter_dir).unwrap();
+                            LocalRepository::from_remote(remote_repo.clone(), &iter_dir, false)
+                                .unwrap();
                         iter_dir.clone_into(&mut local_repo.path);
                         local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
                         local_repo.set_min_version(repo.min_version());

--- a/crates/lib/src/api/client/tree.rs
+++ b/crates/lib/src/api/client/tree.rs
@@ -85,7 +85,7 @@ pub async fn create_nodes(
     // Extend the progress bar's total length by the uncompressed bytes on disk for
     // these Merkle tree nodes. The [`CountingWriter`] will update the progress bar
     // each time we write the uncompressed bytes of a Merkle tree node.
-    let estimated_upload_bytes = local_repo.merkle_store().raw_byte_count(&nodes);
+    let estimated_upload_bytes = local_repo.merkle_transport()?.raw_byte_count(&nodes);
     progress.inc_total_bytes(estimated_upload_bytes);
 
     // Pack -> duplex writer (sync) -> duplex reader (async) -> HTTP body stream.
@@ -99,7 +99,7 @@ pub async fn create_nodes(
             inner: SyncIoBridge::new(async_writer),
             progress: progress_for_pack,
         };
-        repo.merkle_store().pack_nodes(
+        repo.merkle_transport()?.pack_nodes(
             &nodes,
             // Legacy client-push wire format: required so older `oxen-server` deployments
             // (which pre-pend `tree/nodes/` server-side at install time) install entries
@@ -387,7 +387,7 @@ async fn node_download_request(
 
     let repo = local_repo.clone();
     tokio::task::spawn_blocking(move || -> Result<(), OxenError> {
-        repo.merkle_store()
+        repo.merkle_transport()?
             // Download path: overwrite existing files on disk
             .unpack(&mut sync_reader, UnpackOptions::Overwrite)?;
         Ok(())

--- a/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
+++ b/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
@@ -137,8 +137,8 @@ fn run_on_commit(repository: &LocalRepository, commit: &Commit) -> Result<(), Ox
 
     // Write a new commit node via a session on the old repo.
     let commit_node = CommitNode::from_commit(commit.clone());
-    let old_store = old_repo.merkle_store();
-    let new_store = new_repo.merkle_store();
+    let old_store = old_repo.merkle_store()?;
+    let new_store = new_repo.merkle_store()?;
     let old_session = old_store.begin()?;
     let new_session = new_store.begin()?;
     let mut root_commit_ns = old_session.create_node(&commit_node, root_node.parent_id)?;

--- a/crates/lib/src/config/repository_config.rs
+++ b/crates/lib/src/config/repository_config.rs
@@ -1,11 +1,30 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use utoipa::ToSchema;
 
 use crate::constants::DEFAULT_VNODE_SIZE;
 use crate::error::OxenError;
 use crate::model::{LocalRepository, Remote};
 use crate::storage::StorageConfig;
 use crate::util;
+
+/// A sort of registry for known [`MerkleStore`] implementations that can be used by [`LocalRepository`].
+/// This enum serves as a configuration option in a repository's `config.toml`
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, ToSchema)]
+// TODO: remove Serialize + Deserialize derives. These are only necessary because `LocalRepository`
+//       requires them. Those bounds will eventually be dropped.
+#[serde(rename_all = "lowercase")]
+pub enum MerkleStoreKind {
+    /// The [`FileBackend`] store.
+    File,
+}
+
+/// The default is the original custom file format based Merkle tree node storage.
+impl Default for MerkleStoreKind {
+    fn default() -> Self {
+        Self::File
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RepositoryConfig {
@@ -28,6 +47,9 @@ pub struct RepositoryConfig {
     /// Currently used only for remote mode
     pub workspace_name: Option<String>,
     pub workspaces: Option<Vec<String>>,
+    /// The type of Merkle tree node storage that the repository uses.
+    #[serde(default)]
+    pub merkle_store_kind: MerkleStoreKind,
 }
 
 impl Default for RepositoryConfig {
@@ -44,6 +66,7 @@ impl Default for RepositoryConfig {
             remote_mode: None,
             workspace_name: None,
             workspaces: None,
+            merkle_store_kind: MerkleStoreKind::default(),
         }
     }
 }

--- a/crates/lib/src/core/db/merkle_node/file_backend.rs
+++ b/crates/lib/src/core/db/merkle_node/file_backend.rs
@@ -559,7 +559,7 @@ mod tests {
             session.finish()?;
             drop(store);
 
-            let store = repo.merkle_store();
+            let store = repo.merkle_store()?;
             assert!(
                 store
                     .exists(commit_hash)
@@ -845,7 +845,7 @@ mod tests {
     async fn test_transport_round_trip() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test(|repo| {
             let mut packed = Vec::new();
-            repo.merkle_store()
+            repo.merkle_transport()?
                 .pack_all(&mut packed)
                 .expect("pack_all failed");
             assert!(!packed.is_empty(), "pack_all produced empty buffer");
@@ -853,14 +853,14 @@ mod tests {
             let tmp = tempfile::TempDir::new()?;
             let clone = repositories::init(tmp.path())?;
             let installed = clone
-                .merkle_store()
+                .merkle_transport()?
                 .unpack(&mut &packed[..], UnpackOptions::Overwrite)
                 .expect("unpack failed");
             assert!(!installed.is_empty(), "unpack installed no nodes");
 
             for hash in &installed {
                 assert!(
-                    clone.merkle_store().exists(hash).expect("exists failed"),
+                    clone.merkle_store()?.exists(hash).expect("exists failed"),
                     "expected installed hash {hash} to be readable"
                 );
             }
@@ -884,7 +884,7 @@ mod tests {
 
             let new_pack_method = {
                 let mut via_trait = Vec::new();
-                repo.merkle_store()
+                repo.merkle_transport()?
                     .pack_nodes(&hashes, PackOptions::ServerCanonical, &mut via_trait)
                     .expect("pack_nodes failed");
                 via_trait
@@ -909,7 +909,7 @@ mod tests {
 
             let new_pack_method = {
                 let mut via_trait = Vec::new();
-                repo.merkle_store()
+                repo.merkle_transport()?
                     .pack_all(&mut via_trait)
                     .expect("pack_all failed");
                 via_trait
@@ -940,7 +940,7 @@ mod tests {
             let new_pack_method = {
                 let hashes = HashSet::from_iter([hash]);
                 let mut via_trait = Vec::new();
-                repo.merkle_store()
+                repo.merkle_transport()?
                     .pack_nodes(&hashes, PackOptions::ServerCanonical, &mut via_trait)
                     .expect("pack_nodes failed");
                 via_trait
@@ -974,7 +974,7 @@ mod tests {
                     hashes.insert(c.hash().expect("no hash for commit"));
                 }
                 let mut via_trait = Vec::new();
-                repo.merkle_store()
+                repo.merkle_transport()?
                     .pack_nodes(&hashes, PackOptions::ServerCanonical, &mut via_trait)
                     .expect("pack_nodes failed");
                 via_trait
@@ -1040,7 +1040,7 @@ mod tests {
             // Old `unpack_nodes` skipped existing files; mirror that with
             // `UnpackOptions::SkipExisting` so the parity check is semantically faithful.
             let new_hashes = repo_new
-                .merkle_store()
+                .merkle_transport()?
                 .unpack(&mut &bytes[..], UnpackOptions::SkipExisting)
                 .expect("new unpack failed");
 
@@ -1057,14 +1057,14 @@ mod tests {
             for h in &new_hashes {
                 assert!(
                     repo_old
-                        .merkle_store()
+                        .merkle_store()?
                         .exists(h)
                         .expect("old repo exists check failed"),
                     "hash {h} not readable in repo unpacked via legacy unpack_nodes"
                 );
                 assert!(
                     repo_new
-                        .merkle_store()
+                        .merkle_store()?
                         .exists(h)
                         .expect("new repo exists check failed"),
                     "hash {h} not readable in repo unpacked via trait unpack"
@@ -1112,7 +1112,7 @@ mod tests {
     async fn test_node_download_request_unpack_unchanged() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|repo| async move {
             let mut packed = Vec::new();
-            repo.merkle_store()
+            repo.merkle_transport()?
                 .pack_all(&mut packed)
                 .expect("pack_all failed");
             assert!(!packed.is_empty(), "pack_all produced empty buffer");
@@ -1128,7 +1128,7 @@ mod tests {
             let tmp_new = tempfile::TempDir::new()?;
             let repo_new = repositories::init(tmp_new.path())?;
             let installed = repo_new
-                .merkle_store()
+                .merkle_transport()?
                 .unpack(&mut &packed[..], UnpackOptions::Overwrite)
                 .expect("new unpack failed");
 
@@ -1161,7 +1161,7 @@ mod tests {
             assert!(!installed.is_empty(), "trait unpack reported no hashes");
             for h in &installed {
                 assert!(
-                    repo_new.merkle_store().exists(h).expect("exists failed"),
+                    repo_new.merkle_store()?.exists(h).expect("exists failed"),
                     "hash {h} not readable in repo unpacked via trait unpack"
                 );
             }
@@ -1199,7 +1199,7 @@ mod tests {
         let tmp = tempfile::TempDir::new()?;
         let repo = repositories::init(tmp.path())?;
         let err = repo
-            .merkle_store()
+            .merkle_transport()?
             .unpack(&mut &buf[..], UnpackOptions::Overwrite)
             .expect_err("path traversal must be rejected");
         let msg = format!("{err}");
@@ -1238,7 +1238,7 @@ mod tests {
         let tmp = tempfile::TempDir::new()?;
         let repo = repositories::init(tmp.path())?;
         let err = repo
-            .merkle_store()
+            .merkle_transport()?
             .unpack(&mut &buf[..], UnpackOptions::Overwrite)
             .expect_err("unsupported entry type must be rejected");
         let msg = format!("{err}");
@@ -1285,7 +1285,7 @@ mod tests {
             // Pack just this hash.
             let hashes = HashSet::from_iter([stripped_hash]);
             let mut buf = Vec::new();
-            repo.merkle_store()
+            repo.merkle_transport()?
                 .pack_nodes(&hashes, PackOptions::ServerCanonical, &mut buf)
                 .expect("pack_nodes failed");
 
@@ -1293,7 +1293,7 @@ mod tests {
             let tmp = tempfile::TempDir::new()?;
             let target = repositories::init(tmp.path())?;
             let installed = target
-                .merkle_store()
+                .merkle_transport()?
                 .unpack(&mut &buf[..], UnpackOptions::Overwrite)
                 .expect("unpack failed");
 
@@ -1332,7 +1332,7 @@ mod tests {
         let tmp = tempfile::TempDir::new()?;
         let repo = repositories::init(tmp.path())?;
         let err = repo
-            .merkle_store()
+            .merkle_transport()?
             .unpack(&mut &buf[..], UnpackOptions::Overwrite)
             .expect_err("non-hex node id must be rejected");
         let msg = format!("{err}");
@@ -1383,7 +1383,7 @@ mod tests {
         let tmp = tempfile::TempDir::new()?;
         let repo = repositories::init(tmp.path())?;
         let err = repo
-            .merkle_store()
+            .merkle_transport()?
             .unpack(&mut &buf[..], UnpackOptions::Overwrite)
             .expect_err("over-deep entry must be rejected");
         let msg = format!("{err}");
@@ -1428,7 +1428,7 @@ mod tests {
         let tmp = tempfile::TempDir::new()?;
         let repo = repositories::init(tmp.path())?;
         let err = repo
-            .merkle_store()
+            .merkle_transport()?
             .unpack(&mut &buf[..], UnpackOptions::Overwrite)
             .expect_err("unknown leaf filename must be rejected");
         let msg = format!("{err}");
@@ -1548,7 +1548,7 @@ mod tests {
 
             let new_pack = {
                 let mut buf = Vec::new();
-                repo.merkle_store()
+                repo.merkle_transport()?
                     .pack_nodes(&hashes, PackOptions::LegacyClientPush, &mut buf)
                     .expect("new pack failed");
                 buf
@@ -1570,7 +1570,7 @@ mod tests {
     #[test]
     fn test_exists_returns_false_for_missing_hash() -> Result<(), OxenError> {
         test::run_empty_local_repo_test(|repo| {
-            let store = repo.merkle_store();
+            let store = repo.merkle_store()?;
             let missing = MerkleHash::new(0xDEAD_BEEF_DEAD_BEEF_DEAD_BEEF_DEAD_BEEF_u128);
             assert!(
                 !store.exists(&missing).expect("exists must not error"),
@@ -1584,7 +1584,7 @@ mod tests {
     #[test]
     fn test_get_node_returns_none_for_missing_hash() -> Result<(), OxenError> {
         test::run_empty_local_repo_test(|repo| {
-            let store = repo.merkle_store();
+            let store = repo.merkle_store()?;
             let missing = MerkleHash::new(0xDEAD_BEEF_DEAD_BEEF_DEAD_BEEF_DEAD_BEEF_u128);
             assert!(
                 store
@@ -1606,7 +1606,7 @@ mod tests {
             let commit = CommitNode::default();
             let commit_hash = *commit.hash();
             {
-                let store = repo.merkle_store();
+                let store = repo.merkle_store()?;
                 let session = store.begin().expect("begin failed");
                 let ns = session
                     .create_node(&commit, None)
@@ -1614,7 +1614,7 @@ mod tests {
                 ns.finish().expect("finish node session failed");
                 session.finish().expect("finish session failed");
             }
-            let store = repo.merkle_store();
+            let store = repo.merkle_store()?;
             let children = store
                 .get_children(&commit_hash)
                 .expect("get_children must not error");
@@ -1632,7 +1632,7 @@ mod tests {
     #[test]
     fn test_writer_session_with_no_nodes() -> Result<(), OxenError> {
         test::run_empty_local_repo_test(|repo| {
-            let store = repo.merkle_store();
+            let store = repo.merkle_store()?;
             let session = store.begin().expect("begin failed");
             session
                 .finish()
@@ -1647,14 +1647,14 @@ mod tests {
     async fn test_unpack_empty_tarball() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test(|repo| {
             let mut buf = Vec::new();
-            repo.merkle_store()
+            repo.merkle_transport()?
                 .pack_nodes(&HashSet::new(), PackOptions::ServerCanonical, &mut buf)
                 .expect("pack_nodes(empty) must not error");
 
             let tmp = tempfile::TempDir::new()?;
             let target = repositories::init(tmp.path())?;
             let installed = target
-                .merkle_store()
+                .merkle_transport()?
                 .unpack(&mut &buf[..], UnpackOptions::Overwrite)
                 .expect("unpack of empty tarball must not error");
             assert!(
@@ -1682,7 +1682,7 @@ mod tests {
             hashes.insert(absent);
 
             let mut buf = Vec::new();
-            repo.merkle_store()
+            repo.merkle_transport()?
                 .pack_nodes(&hashes, PackOptions::ServerCanonical, &mut buf)
                 .expect("pack_nodes failed");
 
@@ -1719,11 +1719,11 @@ mod tests {
             let mut hashes = HashSet::new();
             hashes.insert(head_hash);
 
-            let estimate = repo.merkle_store().raw_byte_count(&hashes);
+            let estimate = repo.merkle_transport()?.raw_byte_count(&hashes);
             assert!(estimate > 0, "estimate must be non-zero for a present hash");
 
             let mut buf = Vec::new();
-            repo.merkle_store()
+            repo.merkle_transport()?
                 .pack_nodes(&hashes, PackOptions::ServerCanonical, &mut buf)
                 .expect("pack_nodes failed");
             assert!(
@@ -1737,7 +1737,7 @@ mod tests {
             let absent = MerkleHash::new(0xDEAD_BEEF_DEAD_BEEF_DEAD_BEEF_DEAD_BEEF_u128);
             let absent_only: HashSet<_> = HashSet::from_iter([absent]);
             assert_eq!(
-                repo.merkle_store().raw_byte_count(&absent_only),
+                repo.merkle_transport()?.raw_byte_count(&absent_only),
                 0,
                 "absent hash should contribute 0 to the estimate"
             );
@@ -1747,8 +1747,8 @@ mod tests {
             mixed.insert(head_hash);
             mixed.insert(absent);
             assert_eq!(
-                repo.merkle_store().raw_byte_count(&mixed),
-                repo.merkle_store().raw_byte_count(&hashes),
+                repo.merkle_transport()?.raw_byte_count(&mixed),
+                repo.merkle_transport()?.raw_byte_count(&hashes),
                 "absent hash must not change the estimate when added to a present hash"
             );
             Ok(())
@@ -1763,18 +1763,21 @@ mod tests {
     async fn test_unpack_via_vfs_branch() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test(|repo| {
             let mut packed = Vec::new();
-            repo.merkle_store()
+            repo.merkle_transport()?
                 .pack_all(&mut packed)
                 .expect("pack_all failed");
             assert!(!packed.is_empty(), "pack_all produced empty buffer");
 
             let tmp = tempfile::TempDir::new()?;
-            let mut clone = repositories::init(tmp.path())?;
-            clone.set_vfs(Some(true));
+            let clone = crate::core::v_latest::init_with_version_default(
+                tmp.path(),
+                crate::constants::MIN_OXEN_VERSION,
+                true,
+            )?;
             assert!(clone.is_vfs(), "vfs flag should be on for this test");
 
             let installed = clone
-                .merkle_store()
+                .merkle_transport()?
                 .unpack(&mut &packed[..], UnpackOptions::Overwrite)
                 .expect("unpack via vfs branch failed");
             assert!(
@@ -1783,7 +1786,7 @@ mod tests {
             );
             for h in &installed {
                 assert!(
-                    clone.merkle_store().exists(h).expect("exists failed"),
+                    clone.merkle_store()?.exists(h).expect("exists failed"),
                     "hash {h} not readable in vfs-cloned repo"
                 );
             }

--- a/crates/lib/src/core/v_latest/clone.rs
+++ b/crates/lib/src/core/v_latest/clone.rs
@@ -29,19 +29,17 @@ pub async fn clone_repo(
     util::fs::create_dir_all(&oxen_hidden_path)?;
 
     // save LocalRepository in .oxen directory
-    let mut local_repo = LocalRepository::from_remote(remote_repo.clone(), repo_path)?;
-    local_repo.version_store().init().await?;
-    repo_path.clone_into(&mut local_repo.path);
-    local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
-    local_repo.set_min_version(remote_repo.min_version());
-    local_repo.set_subtree_paths(opts.fetch_opts.subtree_paths.clone());
-    local_repo.set_depth(opts.fetch_opts.depth);
-
-    if opts.is_vfs {
-        local_repo.set_vfs(Some(true));
-    } else {
-        local_repo.set_vfs(None);
-    }
+    let local_repo = {
+        let mut local_repo =
+            LocalRepository::from_remote(remote_repo.clone(), repo_path, opts.is_vfs)?;
+        local_repo.version_store().init().await?;
+        repo_path.clone_into(&mut local_repo.path);
+        local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
+        local_repo.set_min_version(remote_repo.min_version());
+        local_repo.set_subtree_paths(opts.fetch_opts.subtree_paths.clone());
+        local_repo.set_depth(opts.fetch_opts.depth);
+        local_repo
+    };
 
     local_repo.save()?;
 
@@ -92,18 +90,12 @@ pub async fn clone_repo_remote_mode(
     let name = format!("{}: {workspace_id}", branch_name.clone());
 
     // Save LocalRepository in .oxen directory
-    let mut local_repo = LocalRepository::from_remote(remote_repo.clone(), repo_path)?;
+    let mut local_repo = LocalRepository::from_remote(remote_repo.clone(), repo_path, opts.is_vfs)?;
     local_repo.version_store().init().await?;
     repo_path.clone_into(&mut local_repo.path);
     local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
     local_repo.set_min_version(remote_repo.min_version());
     local_repo.set_remote_mode(Some(true));
-
-    if opts.is_vfs {
-        local_repo.set_vfs(Some(true));
-    } else {
-        local_repo.set_vfs(None);
-    }
 
     let workspace = api::client::workspaces::create_with_path(
         &remote_repo,

--- a/crates/lib/src/core/v_latest/commits.rs
+++ b/crates/lib/src/core/v_latest/commits.rs
@@ -289,7 +289,7 @@ pub fn create_empty_commit(
     )?;
 
     let parent_id = Some(existing_node.hash);
-    let store = repo.merkle_store();
+    let store = repo.merkle_store()?;
     let session = store.begin()?;
     let mut commit_ns = session.create_node(&commit_node, parent_id)?;
     // There should always be one child, the root directory
@@ -373,7 +373,7 @@ pub fn create_initial_commit(
     )?;
 
     // Open the commit write session and add the root directory
-    let store = repo.merkle_store();
+    let store = repo.merkle_store()?;
     let session = store.begin()?;
     let mut commit_ns = session.create_node(&commit_node, None)?;
     commit_ns.add_child(&dir_node)?;

--- a/crates/lib/src/core/v_latest/entries.rs
+++ b/crates/lib/src/core/v_latest/entries.rs
@@ -547,7 +547,7 @@ pub fn update_metadata(repo: &LocalRepository, revision: impl AsRef<str>) -> Res
     let mut num_bytes = 0;
 
     // One merkle write session covers every node written during the traversal.
-    let store = repo.merkle_store();
+    let store = repo.merkle_store()?;
     let session = store.begin()?;
     traverse_and_update_sizes_and_counts(&*session, &mut node, &mut num_bytes)?;
     session.finish()?;

--- a/crates/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/crates/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -204,7 +204,7 @@ impl CommitMerkleTree {
         unique_hashes: Option<&mut HashSet<MerkleHash>>,
         shared_hashes: Option<&mut HashSet<MerkleHash>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        if !repo.merkle_store().exists(hash)? {
+        if !repo.merkle_store()?.exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -229,7 +229,7 @@ impl CommitMerkleTree {
         unique_hashes: Option<&mut HashMap<(MerkleHash, MerkleTreeNodeType), PathBuf>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !repo.merkle_store().exists(hash)? {
+        if !repo.merkle_store()?.exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -255,7 +255,7 @@ impl CommitMerkleTree {
         partial_nodes: &mut HashMap<PathBuf, PartialNode>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !repo.merkle_store().exists(hash)? {
+        if !repo.merkle_store()?.exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -279,7 +279,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read depth {} node hash [{}]", depth, hash);
-        if !repo.merkle_store().exists(hash)? {
+        if !repo.merkle_store()?.exists(hash)? {
             log::debug!("read_depth merkle node db does not exist for hash: {hash}");
             return Ok(None);
         }
@@ -311,7 +311,7 @@ impl CommitMerkleTree {
         shared_hashes: Option<&mut HashSet<MerkleHash>>,
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        if !repo.merkle_store().exists(hash)? {
+        if !repo.merkle_store()?.exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -340,7 +340,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !repo.merkle_store().exists(hash)? {
+        if !repo.merkle_store()?.exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -372,7 +372,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !repo.merkle_store().exists(hash)? {
+        if !repo.merkle_store()?.exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }

--- a/crates/lib/src/core/v_latest/init.rs
+++ b/crates/lib/src/core/v_latest/init.rs
@@ -9,12 +9,11 @@ use crate::util;
 pub fn init(path: &Path) -> Result<LocalRepository, OxenError> {
     let hidden_dir = util::fs::oxen_hidden_dir(path);
     if hidden_dir.exists() {
-        let err = format!("Oxen repository already exists: {path:?}");
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::RepoAlreadyExistsAtPath(path.to_path_buf()));
     }
 
     // Cleanup the .oxen dir if init fails
-    match init_with_version_default(path, MinOxenVersion::LATEST) {
+    match init_with_version_default(path, MinOxenVersion::LATEST, false) {
         Ok(result) => Ok(result),
         Err(error) => {
             util::fs::remove_dir_all(hidden_dir)?;
@@ -27,16 +26,16 @@ pub fn init(path: &Path) -> Result<LocalRepository, OxenError> {
 pub fn init_with_version_default(
     path: &Path,
     version: MinOxenVersion,
+    is_vfs: bool,
 ) -> Result<LocalRepository, OxenError> {
     let hidden_dir = util::fs::oxen_hidden_dir(path);
 
     util::fs::create_dir_all(hidden_dir)?;
     if util::fs::config_filepath(path).try_exists()? {
-        let err = format!("Oxen repository already exists: {path:?}");
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::RepoAlreadyExistsAtPath(path.to_path_buf()));
     }
 
-    let repo = LocalRepository::new_from_version(path, version.to_string(), None)?;
+    let repo = LocalRepository::new_from_version(path, version.to_string(), None, is_vfs)?;
     repo.save()?;
 
     Ok(repo)
@@ -46,16 +45,17 @@ pub async fn init_with_version_and_storage_config(
     path: &Path,
     version: MinOxenVersion,
     storage_config: Option<StorageConfig>,
+    is_vfs: bool,
 ) -> Result<LocalRepository, OxenError> {
     let hidden_dir = util::fs::oxen_hidden_dir(path);
 
     util::fs::create_dir_all(hidden_dir)?;
     if util::fs::config_filepath(path).try_exists()? {
-        let err = format!("Oxen repository already exists: {path:?}");
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::RepoAlreadyExistsAtPath(path.to_path_buf()));
     }
 
-    let repo = LocalRepository::new_from_version(path, version.to_string(), storage_config)?;
+    let repo =
+        LocalRepository::new_from_version(path, version.to_string(), storage_config, is_vfs)?;
     repo.save()?;
 
     let version_store = repo.version_store();

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -1094,7 +1094,7 @@ fn create_empty_merge_commit(
             ))
         })?;
 
-    let merkle_store = repo.merkle_store();
+    let merkle_store = repo.merkle_store()?;
     let session = merkle_store.begin()?;
     let mut ns = session.create_node(&commit_node, Some(base_node.hash))?;
     let root_dir = base_node

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -56,6 +56,9 @@ pub enum OxenError {
     #[error("Repository '{0}' already exists")]
     RepoAlreadyExists(Box<RepoNew>),
 
+    #[error("Oxen repository already exists: {0:?}")]
+    RepoAlreadyExistsAtPath(PathBuf),
+
     /// Error when creating a repository: repo names are restricted.
     #[error("Invalid repository or namespace name '{0}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+")]
     InvalidRepoName(StringError),
@@ -63,6 +66,13 @@ pub enum OxenError {
     /// When `get_fork_status` cannot obtain the fork status for a repository.
     #[error("No fork status found.")]
     ForkStatusNotFound,
+
+    // TODO: Once all serialization paths use `*View` instead of `Workspace`, which requires `LocalRepository`
+    //       to implement `Serializable`, then these *StoreNotInitialized errors can be deleted.,
+    /// The [`MerkleStore`] or [`TransportMerkle`] for a [`LocalRepository`] was not initialized before access.
+    #[error("Merkle store not initialized")]
+    MerkleStoreNotInitialized,
+
     //
     // Remotes
     //
@@ -178,9 +188,6 @@ pub enum OxenError {
     //
     // Version Store
     //
-    #[error("Version store not initialized")]
-    VersionStoreNotInitialized,
-
     /// An error uploading a file to the version store
     #[error("{0}")]
     Upload(StringError),

--- a/crates/lib/src/model/merkle_tree.rs
+++ b/crates/lib/src/model/merkle_tree.rs
@@ -5,6 +5,8 @@ pub mod merkle_writer;
 pub mod node;
 pub mod node_type;
 
+use std::fmt::Debug;
+
 pub use crate::model::merkle_tree::merkle_hash::MerkleHash;
 pub use crate::model::merkle_tree::merkle_reader::MerkleReader;
 pub use crate::model::merkle_tree::merkle_transport::{
@@ -31,9 +33,10 @@ pub trait MerkleStore: MerkleReader + MerkleWriter {}
 impl<T: MerkleReader + MerkleWriter + ?Sized> MerkleStore for T {}
 
 /// A [`MerkleStore`] that can also pack and unpack Merkle tree nodes for transport.
-pub trait TransportableMerkleStore: MerkleStore + MerkleTransport {}
+pub trait TransportableMerkleStore: MerkleStore + MerkleTransport + Debug {}
 
 /// Any type that is a [`MerkleStore`] and a [`MerkleTransport`] is automatically a
 /// [`TransportableMerkleStore`]. The `?Sized` bound lets the marker apply to
-/// `dyn TransportableMerkleStore` itself.
-impl<T: MerkleStore + MerkleTransport + ?Sized> TransportableMerkleStore for T {}
+/// `dyn TransportableMerkleStore` itself. [`Debug`] is required since this is
+/// used in [`LocalRepository`] and that struct has a [`Debug`] derive.
+impl<T: MerkleStore + MerkleTransport + ?Sized + Debug> TransportableMerkleStore for T {}

--- a/crates/lib/src/model/merkle_tree/node/merkle_tree_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/merkle_tree_node.rs
@@ -42,7 +42,7 @@ impl MerkleTreeNode {
     /// Private implementation that loads from disk without caching
     fn from_hash_uncached(repo: &LocalRepository, hash: &MerkleHash) -> Result<Self, OxenError> {
         let MerkleEntry { node, parent_id } = repo
-            .merkle_store()
+            .merkle_store()?
             .get_node(hash)?
             .ok_or_else(|| OxenError::MerkleNodeNotFound(hash.to_hex_hash()))?;
         Ok(MerkleTreeNode {
@@ -76,7 +76,7 @@ impl MerkleTreeNode {
         repo: &LocalRepository,
         hash: &MerkleHash,
     ) -> Result<Vec<(MerkleHash, MerkleTreeNode)>, OxenError> {
-        let store = repo.merkle_store();
+        let store = repo.merkle_store()?;
         // We don't return an error here because there are some situations where we won't have
         // all of the node files. For example, when working in a subtree clone.
         // However, parse/IO errors from an existing node DO still propagate.
@@ -84,7 +84,7 @@ impl MerkleTreeNode {
             log::error!("[assuming no children] no child node db for {hash}");
             return Ok(Vec::new());
         }
-        repo.merkle_store().get_children(hash)
+        repo.merkle_store()?.get_children(hash)
     }
 
     /// Check if the node is a leaf node (i.e. it has no children)

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -1,11 +1,12 @@
 use crate::config::RepositoryConfig;
+use crate::config::repository_config::MerkleStoreKind;
 use crate::constants::SHALLOW_FLAG;
 use crate::constants::{self, DEFAULT_VNODE_SIZE, MIN_OXEN_VERSION};
 use crate::core::db::merkle_node::file_backend::FileBackend;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::merkle_tree::TransportableMerkleStore;
 use crate::model::merkle_tree::node::FileNode;
+use crate::model::merkle_tree::{MerkleStore, MerkleTransport, TransportableMerkleStore};
 use crate::model::{MetadataEntry, Remote, RemoteRepository};
 use crate::storage::{NoopVersionStore, StorageConfig, VersionStore, create_version_store};
 use crate::util;
@@ -50,7 +51,7 @@ pub struct LocalRepository {
     #[schema(value_type = Option<Vec<String>>)]
     subtree_paths: Option<Vec<PathBuf>>, // If the user clones a subtree, we store the paths here so that we know we don't have the full tree
     pub depth: Option<i32>, // If the user clones with a depth, we store the depth here so that we know we don't have the full tree
-    pub vfs: Option<bool>,  // Flag for repositories stored on virtual file systems
+    vfs: Option<bool>,      // Flag for repositories stored on virtual file systems
     pub remote_mode: Option<bool>, // Flag for remote repositories
     pub workspace_name: Option<String>, // ID of the associated workspace for remote mode
     workspaces: Option<Vec<String>>, // List of workspaces for remote mode
@@ -68,6 +69,15 @@ pub struct LocalRepository {
     #[serde(skip, default = "placeholder_version_store")]
     #[schema(ignore)]
     version_store: Arc<dyn VersionStore>,
+
+    // Skip this field during serialization/deserialization as it relates to on-disk repo state.
+    #[serde(skip)]
+    #[schema(ignore)]
+    merkle_store: Option<Arc<dyn TransportableMerkleStore>>,
+    #[serde(default)]
+    merkle_store_kind: MerkleStoreKind, // it's a little awkward to have both, but the `Serialize` trait
+                                        // means we can't always have the `merkle_store`, so we can't
+                                        // rely on it to always provide the MerkleStoreKind
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -83,8 +93,16 @@ impl LocalRepository {
         let config_path = util::fs::config_filepath(path);
         let config = RepositoryConfig::from_file(&config_path)?;
 
+        let merkle_store_kind = config.merkle_store_kind;
+        let m_store = Self::load_merkle_store(
+            path.to_path_buf(),
+            merkle_store_kind,
+            config.vfs.unwrap_or(false),
+        )?;
+
         let storage_config = config.storage.unwrap_or_default();
         let version_store = create_version_store(path, &storage_config)?;
+
         Ok(LocalRepository {
             path: path.to_path_buf(),
             remote_name: config.remote_name,
@@ -99,36 +117,49 @@ impl LocalRepository {
             workspaces: config.workspaces,
             storage_config,
             version_store,
+            merkle_store: Some(m_store),
+            merkle_store_kind,
         })
     }
 
-    /// Get a reference to the storage configuration this repository was constructed with.
-    pub fn storage_config(&self) -> &StorageConfig {
-        &self.storage_config
-    }
-
     /// Loads the Merkle store for the repository at the specified root path.
-    // NOTE: When new backends (e.g. LMDB) are added, branch on the appropriate config
-    // here and return a `Box::new(<that new backend>)`.
-    #[inline]
-    fn load_merkle_store(repo_path: PathBuf, _is_vfs: bool) -> Box<dyn TransportableMerkleStore> {
-        // TODO: Add reading config to select Merkle store implementation that
-        //       the repository uses.
-        //       => Right now, the only option is the FileBackend.
-        Box::new(FileBackend { repo_path })
+    fn load_merkle_store(
+        repo_path: PathBuf,
+        merkle_store_kind: MerkleStoreKind,
+        _is_vfs: bool,
+    ) -> Result<Arc<dyn TransportableMerkleStore>, OxenError> {
+        match merkle_store_kind {
+            MerkleStoreKind::File => Ok(Arc::new(FileBackend { repo_path })),
+        }
     }
 
     /// Obtain the Merkle tree store for this repository.
     ///
     /// All operations with the repository's Merkle tree store **MUST** go through its
-    /// `MerkleStore` implementation.
+    /// [`MerkleStore`] implementation.
+    pub fn merkle_store(&self) -> Result<&dyn MerkleStore, OxenError> {
+        let store = self
+            .merkle_store
+            .as_ref()
+            .ok_or(OxenError::MerkleStoreNotInitialized)?;
+        Ok(&**store)
+    }
+
+    /// Obtain the Merkle tree node packer & unpacker for this repository's merkle store.
     ///
-    /// Returns a boxed trait object so the trait surface stays simple and dyn-dispatch
-    /// handles backend selection. Callers use it purely through the trait surface
-    /// (read, write); backend selection is an implementation detail of this method.
-    pub fn merkle_store(&self) -> Box<dyn TransportableMerkleStore> {
-        // **self.merkle_store
-        Self::load_merkle_store(self.path.clone(), self.is_vfs())
+    /// All operations that transmit Merkle tree nodes between a client and a server **MUST**
+    /// go through its [`MerkleTransport`] implementation.
+    pub fn merkle_transport(&self) -> Result<&dyn MerkleTransport, OxenError> {
+        let store = self
+            .merkle_store
+            .as_ref()
+            .ok_or(OxenError::MerkleStoreNotInitialized)?;
+        Ok(&**store)
+    }
+
+    /// Get a reference to the storage configuration this repository was constructed with.
+    pub fn storage_config(&self) -> &StorageConfig {
+        &self.storage_config
     }
 
     /// Get a reference to the version store.
@@ -156,6 +187,8 @@ impl LocalRepository {
         let path = path.as_ref().to_path_buf();
         let storage_config = storage_config.unwrap_or_default();
         let version_store = create_version_store(&path, &storage_config)?;
+        let merkle_store_kind = MerkleStoreKind::default();
+        let m_store = Self::load_merkle_store(path.clone(), merkle_store_kind, false)?;
         Ok(LocalRepository {
             path,
             remotes: vec![],
@@ -171,6 +204,8 @@ impl LocalRepository {
             workspaces: None,
             storage_config,
             version_store,
+            merkle_store: Some(m_store),
+            merkle_store_kind,
         })
     }
 
@@ -179,10 +214,13 @@ impl LocalRepository {
         path: impl AsRef<Path>,
         min_version: impl AsRef<str>,
         storage_config: Option<StorageConfig>,
+        is_vfs: bool,
     ) -> Result<LocalRepository, OxenError> {
         let path = path.as_ref().to_path_buf();
         let storage_config = storage_config.unwrap_or_default();
         let version_store = create_version_store(&path, &storage_config)?;
+        let merkle_store_kind = MerkleStoreKind::default();
+        let m_store = Self::load_merkle_store(path.clone(), merkle_store_kind, is_vfs)?;
         Ok(LocalRepository {
             path,
             remotes: vec![],
@@ -191,12 +229,14 @@ impl LocalRepository {
             vnode_size: None,
             subtree_paths: None,
             depth: None,
-            vfs: None,
+            vfs: if is_vfs { Some(true) } else { None },
             remote_mode: None,
             workspace_name: None,
             workspaces: None,
             storage_config,
             version_store,
+            merkle_store: Some(m_store),
+            merkle_store_kind,
         })
     }
 
@@ -204,6 +244,8 @@ impl LocalRepository {
         let path = std::env::current_dir()?.join(view.name);
         let storage_config = StorageConfig::default();
         let version_store = create_version_store(&path, &storage_config)?;
+        let merkle_store_kind = MerkleStoreKind::default();
+        let m_store = Self::load_merkle_store(path.clone(), merkle_store_kind, false)?;
         Ok(LocalRepository {
             path,
             remotes: vec![],
@@ -218,13 +260,21 @@ impl LocalRepository {
             workspaces: None,
             storage_config,
             version_store,
+            merkle_store: Some(m_store),
+            merkle_store_kind,
         })
     }
 
-    pub fn from_remote(repo: RemoteRepository, path: &Path) -> Result<LocalRepository, OxenError> {
+    pub fn from_remote(
+        repo: RemoteRepository,
+        path: &Path,
+        is_vfs: bool,
+    ) -> Result<LocalRepository, OxenError> {
         let path = path.to_owned();
         let storage_config = StorageConfig::default();
         let version_store = create_version_store(&path, &storage_config)?;
+        let merkle_store_kind = MerkleStoreKind::default();
+        let m_store = Self::load_merkle_store(path.clone(), merkle_store_kind, is_vfs)?;
         Ok(LocalRepository {
             path,
             remotes: vec![repo.remote],
@@ -233,12 +283,14 @@ impl LocalRepository {
             vnode_size: None,
             subtree_paths: None,
             depth: None,
-            vfs: None,
+            vfs: if is_vfs { Some(true) } else { None },
             remote_mode: None,
             workspace_name: None,
             workspaces: None,
             storage_config,
             version_store,
+            merkle_store: Some(m_store),
+            merkle_store_kind,
         })
     }
 
@@ -314,15 +366,16 @@ impl LocalRepository {
         self.vfs.unwrap_or(false)
     }
 
-    pub fn set_vfs(&mut self, is_vfs: Option<bool>) {
-        self.vfs = is_vfs;
-    }
-
     /// Save the repository configuration to disk
     pub fn save(&self) -> Result<(), OxenError> {
+        let config = self.as_config();
         let config_path = util::fs::config_filepath(&self.path);
+        config.save(&config_path)
+    }
 
-        let config = RepositoryConfig {
+    /// Re-create the repository's configuration.
+    pub fn as_config(&self) -> RepositoryConfig {
+        RepositoryConfig {
             remote_name: self.remote_name.clone(),
             remotes: self.remotes.clone(),
             subtree_paths: self.subtree_paths.clone(),
@@ -334,9 +387,8 @@ impl LocalRepository {
             remote_mode: self.remote_mode,
             workspace_name: self.workspace_name.clone(),
             workspaces: self.workspaces.clone(),
-        };
-
-        config.save(&config_path)
+            merkle_store_kind: self.merkle_store_kind,
+        }
     }
 
     pub fn set_remote(&mut self, name: impl AsRef<str>, url: impl AsRef<str>) -> Remote {

--- a/crates/lib/src/repositories/commits/commit_writer.rs
+++ b/crates/lib/src/repositories/commits/commit_writer.rs
@@ -269,7 +269,7 @@ pub(crate) fn commit_dir_entries_with_parents(
         }
     }
 
-    let store = repo.merkle_store();
+    let store = repo.merkle_store()?;
     let session = store.begin()?;
     let mut commit_ns = session.create_node(&node, parent_id)?;
     write_commit_entries(
@@ -367,7 +367,7 @@ pub fn commit_dir_entries_new(
         }
     }
 
-    let store = repo.merkle_store();
+    let store = repo.merkle_store()?;
     let session = store.begin()?;
     let mut commit_ns = session.create_node(&node, parent_id)?;
 
@@ -483,7 +483,7 @@ pub fn commit_dir_entries(
         }
     }
 
-    let store = repo.merkle_store();
+    let store = repo.merkle_store()?;
     let session = store.begin()?;
     let mut commit_ns = session.create_node(&node, None)?;
     write_commit_entries(

--- a/crates/lib/src/repositories/init.rs
+++ b/crates/lib/src/repositories/init.rs
@@ -32,7 +32,7 @@ pub fn init_with_version(
     let path = path.as_ref();
     match version {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::init_with_version_default(path, version),
+        _ => core::v_latest::init_with_version_default(path, version, false),
     }
 }
 
@@ -52,8 +52,13 @@ pub async fn init_with_version_and_storage_config(
     match version {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => {
-            core::v_latest::init_with_version_and_storage_config(path, version, storage_config)
-                .await
+            core::v_latest::init_with_version_and_storage_config(
+                path,
+                version,
+                storage_config,
+                false,
+            )
+            .await
         }
     }
 }

--- a/crates/lib/src/repositories/tree.rs
+++ b/crates/lib/src/repositories/tree.rs
@@ -836,7 +836,7 @@ pub fn cp_dir_hashes_to(
 
 pub fn compress_tree(repository: &LocalRepository) -> Result<Vec<u8>, OxenError> {
     let mut buf = Vec::new();
-    repository.merkle_store().pack_all(&mut buf)?;
+    repository.merkle_transport()?.pack_all(&mut buf)?;
     let total_size: u64 = u64::try_from(buf.len()).unwrap_or(u64::MAX);
     log::debug!("Compressed entire tree size is {}", ByteSize::b(total_size));
     Ok(buf)
@@ -851,7 +851,7 @@ pub fn unpack_nodes(
     // a `&mut` over a fresh slice cursor that advances as bytes are consumed.
     let mut reader: &[u8] = buffer;
     repository
-        .merkle_store()
+        .merkle_transport()?
         .unpack(&mut reader, UnpackOptions::SkipExisting)
 }
 
@@ -862,7 +862,7 @@ pub fn write_tree(repo: &LocalRepository, node: &MerkleTreeNode) -> Result<(), O
         return Err(OxenError::basic_str("Expected commit node"));
     };
     let commit_node = CommitNode::new(repo, commit_node.get_opts())?;
-    let store = repo.merkle_store();
+    let store = repo.merkle_store()?;
     let session = store.begin()?;
     p_write_tree(&*session, node, &commit_node)?;
     session.finish()?;

--- a/crates/server/src/controllers/tree.rs
+++ b/crates/server/src/controllers/tree.rs
@@ -273,7 +273,7 @@ pub async fn download_tree_nodes(
 
     let buffer = {
         let mut buffer = Vec::new();
-        repository.merkle_store().pack_nodes(
+        repository.merkle_transport()?.pack_nodes(
             &node_hashes,
             PackOptions::ServerCanonical,
             &mut buffer,
@@ -330,7 +330,7 @@ pub async fn download_node(req: HttpRequest) -> actix_web::Result<HttpResponse, 
 
     let buffer = {
         let mut buffer = Vec::new();
-        repository.merkle_store().pack_nodes(
+        repository.merkle_transport()?.pack_nodes(
             &HashSet::from_iter([hash]),
             PackOptions::ServerCanonical,
             &mut buffer,


### PR DESCRIPTION
Adds a new `MerkleStoreKind` enum to the `RepositoryConfig`, which dictates
the type of physical storage that the `LocalRepository` uses for storing
and retrieving Merkle tree nodes. Defaults to the existing custom file format
(aka `FileBackend`) so it is backwards compatible with all existing repositories.

Makes the `TransportableMerkleStore` a field of the `LocalRepository` so that
this is only loaded once at construction time and reused. Also added the
`MerkleStoreKind` uses at load time as another field. Since there's
`Serialization` & `Deserialization` derives for `LocalRepository`, the field
has to be `Option` to provide a default value since it cannot be serialized.
This leads to a brittle design where a `LocalRepository` can be made without
being correctly initialized, hence the new `MerkleStoreNotInitialized` error
variant for `OxenError`. A follow up refactor is necessary to remove these
unnecessary serializaton derives and migrate the HTTP responses to only use
`*View` structs (i.e. `WorkspaceView`, ParsedResourceView`, etc.)

As a result of this initialization problem, `LocalRepository::merkle_store`
has been changed to return a `Result.` It returns a `&dyn MerkleStore` as
the borrow on the `LocalRepository` means we can return a borrow on the
inner state without needing to increment the refcount.

Additionally, uses of the `MerkleTransport` trait from the `LocalRepository`
now go through a new method: `merkle_transport()`. This borrows the internal
`merkle_store` `Arc` and coerces the fat pointer to a `&dyn MerkleTransport`.
The original `merkle_store()` method has been changed to do the same thing,
returning a `&dyn MerkleStore`.

Finally, removes the `set_vfs` method. Merkle store backends need a consistent
`vfs` value and allowing mutation to make this go out of sync. Any places
that needed to use `set_vfs` have been updated to use a modified constructor
that sets the right `vfs` value.