### PR TITLE
Display failing file paths and hashes when bulk version download fails

### DIFF
--- a/crates/lib/src/api/client/entries.rs
+++ b/crates/lib/src/api/client/entries.rs
@@ -798,6 +798,7 @@ pub async fn download_data_from_version_paths(
 ) -> Result<u64, OxenError> {
     let total_retries = constants::NUM_HTTP_RETRIES;
     let mut num_retries = 0;
+    let mut last_err: Option<OxenError> = None;
 
     while num_retries < total_retries {
         match try_download_data_from_version_paths(remote_repo, content_ids, &dst).await {
@@ -808,17 +809,34 @@ pub async fn download_data_from_version_paths(
                 // Exponentially back off
                 let sleep_time = num_retries * num_retries;
                 log::warn!("Could not download content {err:?} sleeping {sleep_time}");
+                last_err = Some(err);
                 tokio::time::sleep(std::time::Duration::from_secs(sleep_time)).await;
             }
         }
     }
 
-    let err = format!(
-        "Err: Failed to download {} files after {} retries",
+    let last_error = last_err
+        .as_ref()
+        .map(|e| format!("{e}"))
+        .unwrap_or_else(|| "(no attempts made)".to_string());
+    let formatted_entries = content_ids
+        .iter()
+        .map(|(h, p)| format!("{} (hash: {h})", p.display()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    log::error!(
+        "Bulk download exhausted {} retries for {} entries: [{}]. Last error: {}",
+        total_retries,
         content_ids.len(),
-        total_retries
+        formatted_entries,
+        last_error,
     );
-    Err(OxenError::basic_str(err))
+    Err(OxenError::DownloadBatchExhausted {
+        num_files: content_ids.len(),
+        num_retries: total_retries,
+        entries: content_ids.to_vec(),
+        last_error,
+    })
 }
 
 pub async fn try_download_data_from_version_paths(

--- a/crates/lib/src/api/client/versions.rs
+++ b/crates/lib/src/api/client/versions.rs
@@ -190,18 +190,23 @@ async fn create_multipart_large_file_upload(
     })
 }
 
-/// Batch download
+/// Batch download.
+///
+/// `entries` is a list of `(content_hash, source_path)` pairs — only the hash is sent over the wire
+/// (the bulk endpoint identifies blobs by hash); the path is preserved purely for diagnostic
+/// surfaces (errors, logs) so end users can identify which file(s) failed.
 #[tracing::instrument(skip_all)]
 pub async fn download_data_from_version_paths(
     remote_repo: &RemoteRepository,
-    hashes: &[String],
+    entries: &[(String, PathBuf)],
     local_repo: &LocalRepository,
 ) -> Result<u64, OxenError> {
     let total_retries = max_retries().try_into().unwrap_or(max_retries() as u64);
     let mut num_retries = 0;
+    let mut last_err: Option<OxenError> = None;
 
     while num_retries < total_retries {
-        match try_download_data_from_version_paths(remote_repo, hashes, local_repo).await {
+        match try_download_data_from_version_paths(remote_repo, entries, local_repo).await {
             Ok(val) => return Ok(val),
             Err(OxenError::Authentication(val)) => return Err(OxenError::Authentication(val)),
             Err(err) => {
@@ -209,27 +214,48 @@ pub async fn download_data_from_version_paths(
                 // Exponentially back off
                 let sleep_time = num_retries * num_retries;
                 log::warn!("Could not download content {err:?} sleeping {sleep_time}");
+                last_err = Some(err);
                 tokio::time::sleep(std::time::Duration::from_secs(sleep_time)).await;
             }
         }
     }
 
-    let err = format!(
-        "Err: Failed to download {} files after {} retries",
-        hashes.len(),
-        total_retries
+    // Preserve the failing batch's entries (path + hash) and last underlying error so callers
+    // and server logs can identify which file(s) the server couldn't serve. Without this, the
+    // symptom surfaces as a bare "failed to download N files" with no way to map back to
+    // specific files.
+    let last_error = last_err
+        .as_ref()
+        .map(|e| format!("{e}"))
+        .unwrap_or_else(|| "(no attempts made)".to_string());
+    let formatted_entries = entries
+        .iter()
+        .map(|(h, p)| format!("{} (hash: {h})", p.display()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    log::error!(
+        "Bulk download exhausted {} retries for {} entries: [{}]. Last error: {}",
+        total_retries,
+        entries.len(),
+        formatted_entries,
+        last_error,
     );
-    Err(OxenError::basic_str(err))
+    Err(OxenError::DownloadBatchExhausted {
+        num_files: entries.len(),
+        num_retries: total_retries,
+        entries: entries.to_vec(),
+        last_error,
+    })
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn try_download_data_from_version_paths(
     remote_repo: &RemoteRepository,
-    hashes: &[String],
+    entries: &[(String, PathBuf)],
     local_repo: &LocalRepository,
 ) -> Result<u64, OxenError> {
     let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-    for hash in hashes.iter() {
+    for (hash, _path) in entries.iter() {
         let line = format!("{hash}\n");
         // log::debug!("download_data_from_version_paths encoding line: {} path: {:?}", line, path);
         encoder.write_all(line.as_bytes())?;

--- a/crates/lib/src/core/v_latest/fetch.rs
+++ b/crates/lib/src/core/v_latest/fetch.rs
@@ -643,15 +643,11 @@ pub async fn pull_entries_to_versions_dir(
         (Ok(_), Ok(_)) => {
             log::debug!("Successfully synced entries!");
         }
-        (Err(err), Ok(_)) => {
-            let err = format!("Error syncing large entries: {err}");
-            return Err(OxenError::basic_str(err));
+        (Err(err), Ok(_)) | (Ok(_), Err(err)) => return Err(err),
+        (Err(large_err), Err(small_err)) => {
+            log::error!("Large entries sync also failed: {large_err}");
+            return Err(small_err);
         }
-        (Ok(_), Err(err)) => {
-            let err = format!("Error syncing small entries: {err}");
-            return Err(OxenError::basic_str(err));
-        }
-        _ => return Err(OxenError::basic_str("Unknown error syncing entries")),
     }
 
     Ok(())
@@ -878,15 +874,11 @@ pub async fn download_entries_to_working_dir(
         (Ok(_), Ok(_)) => {
             log::debug!("Successfully synced entries!");
         }
-        (Err(err), Ok(_)) => {
-            let err = format!("Error syncing large entries: {err}");
-            return Err(OxenError::basic_str(err));
+        (Err(err), Ok(_)) | (Ok(_), Err(err)) => return Err(err),
+        (Err(large_err), Err(small_err)) => {
+            log::error!("Large entries sync also failed: {large_err}");
+            return Err(small_err);
         }
-        (Ok(_), Err(err)) => {
-            let err = format!("Error syncing small entries: {err}");
-            return Err(OxenError::basic_str(err));
-        }
-        _ => return Err(OxenError::basic_str("Unknown error syncing entries")),
     }
     log::info!("Finished download_entries_to_working_dir");
     Ok(())

--- a/crates/lib/src/core/v_latest/fetch.rs
+++ b/crates/lib/src/core/v_latest/fetch.rs
@@ -759,8 +759,11 @@ async fn pull_small_entries(
         entries.len()
     );
 
-    // Split into chunks, zip up, and post to server
-    type PieceOfWork = (RemoteRepository, Vec<String>, LocalRepository);
+    // Split into chunks, zip up, and post to server. We carry `(hash, path)` pairs through
+    // the queue (rather than just hashes) so the bulk-download client can put the file paths
+    // into its retry-exhausted error message — paths are far more recognizable to end users
+    // than content hashes.
+    type PieceOfWork = (RemoteRepository, Vec<(String, PathBuf)>, LocalRepository);
     type TaskQueue = deadqueue::limited::Queue<PieceOfWork>;
 
     log::debug!(
@@ -770,11 +773,11 @@ async fn pull_small_entries(
     let chunks: Vec<PieceOfWork> = entries
         .chunks(chunk_size)
         .map(|chunk| {
-            let hashes = chunk
+            let entries = chunk
                 .iter()
-                .map(|commit_entry| commit_entry.hash.clone())
+                .map(|commit_entry| (commit_entry.hash.clone(), commit_entry.path.clone()))
                 .collect();
-            (remote_repo.to_owned(), hashes, repo.to_owned())
+            (remote_repo.to_owned(), entries, repo.to_owned())
         })
         .collect();
 

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -409,6 +409,34 @@ pub enum OxenError {
         help: String,
     },
 
+    /// Bulk download (`/versions` QUERY endpoint) failed across all retry attempts. The
+    /// `(hash, path)` pairs in the failing batch and the last underlying error are preserved
+    /// so end users see which file paths failed and operators can map them back to specific
+    /// content blobs. Common cause: a content blob referenced by a commit's tree is absent
+    /// from the server's version store, and the bulk endpoint fail-fasts on the first
+    /// missing hash.
+    #[error(
+        "Failed to download {num_files} files after {num_retries} retries: {last_error}\n{}",
+        format_download_entries(entries)
+    )]
+    DownloadBatchExhausted {
+        num_files: usize,
+        num_retries: u64,
+        entries: Vec<(String, PathBuf)>,
+        last_error: String,
+    },
+
+    /// The version store could not produce a stream for a specific content hash — usually
+    /// because the file is missing on disk (or in object storage) despite the merkle tree
+    /// referencing it. The hash is preserved so the failure can be tied to a specific blob
+    /// during streaming downloads where HTTP 200 has already been sent.
+    #[error("Failed to fetch version {file_hash} from version store")]
+    VersionFetchFailed {
+        file_hash: String,
+        #[source]
+        source: Box<OxenError>,
+    },
+
     // Fallback
     // TODO: remove all uses of `Basic` and replace with specific errors.
     #[error("{0}")]
@@ -416,6 +444,17 @@ pub enum OxenError {
 
     #[error("{0}")]
     InternalError(StringError),
+}
+
+/// Multi-line render for [`OxenError::DownloadBatchExhausted`]. Lists the file path first
+/// (most useful to end users) and the content hash second (most useful to operators chasing
+/// the failure server-side).
+fn format_download_entries(entries: &[(String, PathBuf)]) -> String {
+    let mut out = format!("Failing batch ({} files):", entries.len());
+    for (hash, path) in entries {
+        let _ = write!(out, "\n  {} (hash: {hash})", path.display());
+    }
+    out
 }
 
 /// Multi-line render for [`OxenError::RestoreFailed`]. Each failed file is listed with its
@@ -508,6 +547,9 @@ impl OxenError {
             }
             WorkspaceStagedDbCorrupted { .. } => {
                 "Recreate the workspace: `oxen workspace delete <id>` then re-create it."
+            }
+            DownloadBatchExhausted { .. } => {
+                "If a content blob is missing on the server, run `oxen push --missing-files` from a clone with the full local history to repair it."
             }
             _ => return None,
         }
@@ -866,5 +908,88 @@ where
 impl From<BuildError> for OxenError {
     fn from(e: BuildError) -> Self {
         OxenError::AwsError(Box::new(e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn download_batch_exhausted_display_lists_paths_hashes_and_last_error() {
+        let err = OxenError::DownloadBatchExhausted {
+            num_files: 7,
+            num_retries: 5,
+            entries: vec![
+                (
+                    "b30cefc4eb9ad1c6f3f61047cec5c828".to_string(),
+                    PathBuf::from("parquet/arize-ax-alex_sessions.parquet"),
+                ),
+                (
+                    "d13964d33acc80244980c9e16fe5fc2b".to_string(),
+                    PathBuf::from("parquet/phoenix-lambda2-dal_sessions.parquet"),
+                ),
+            ],
+            last_error: "underlying io error: file not found".to_string(),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("7 files"), "missing num_files: {msg}");
+        assert!(msg.contains("5 retries"), "missing num_retries: {msg}");
+        assert!(
+            msg.contains("parquet/arize-ax-alex_sessions.parquet"),
+            "missing first path: {msg}"
+        );
+        assert!(
+            msg.contains("parquet/phoenix-lambda2-dal_sessions.parquet"),
+            "missing second path: {msg}"
+        );
+        assert!(
+            msg.contains("b30cefc4eb9ad1c6f3f61047cec5c828"),
+            "missing first hash: {msg}"
+        );
+        assert!(
+            msg.contains("d13964d33acc80244980c9e16fe5fc2b"),
+            "missing second hash: {msg}"
+        );
+        assert!(
+            msg.contains("underlying io error"),
+            "missing last_error: {msg}"
+        );
+    }
+
+    #[test]
+    fn download_batch_exhausted_hint_mentions_missing_files_recovery() {
+        let err = OxenError::DownloadBatchExhausted {
+            num_files: 1,
+            num_retries: 5,
+            entries: vec![("abc".to_string(), PathBuf::from("foo.txt"))],
+            last_error: "io error".to_string(),
+        };
+        let hint = err.hint().expect("expected a hint");
+        assert!(
+            hint.contains("--missing-files"),
+            "hint should point at recovery flag: {hint}"
+        );
+    }
+
+    #[test]
+    fn version_fetch_failed_display_names_hash_and_chains_source() {
+        let inner = OxenError::Basic(StringError::from("file not found"));
+        let err = OxenError::VersionFetchFailed {
+            file_hash: "b30cefc4eb9ad1c6f3f61047cec5c828".to_string(),
+            source: Box::new(inner),
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("b30cefc4eb9ad1c6f3f61047cec5c828"),
+            "missing file_hash: {msg}"
+        );
+        // thiserror exposes the wrapped error via std::error::Error::source(), so the underlying
+        // message is reachable for callers that walk the chain (e.g. log::error formatters).
+        let source = std::error::Error::source(&err).expect("expected a source error");
+        assert!(
+            source.to_string().contains("file not found"),
+            "source chain missing inner message: {source}"
+        );
     }
 }

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -430,7 +430,7 @@ pub enum OxenError {
     /// because the file is missing on disk (or in object storage) despite the merkle tree
     /// referencing it. The hash is preserved so the failure can be tied to a specific blob
     /// during streaming downloads where HTTP 200 has already been sent.
-    #[error("Failed to fetch version {file_hash} from version store")]
+    #[error("Failed to fetch version {file_hash} from version store: {source}")]
     VersionFetchFailed {
         file_hash: String,
         #[source]
@@ -973,7 +973,7 @@ mod tests {
     }
 
     #[test]
-    fn version_fetch_failed_display_names_hash_and_chains_source() {
+    fn version_fetch_failed_display_includes_hash_and_inner_cause() {
         let inner = OxenError::Basic(StringError::from("file not found"));
         let err = OxenError::VersionFetchFailed {
             file_hash: "b30cefc4eb9ad1c6f3f61047cec5c828".to_string(),
@@ -984,8 +984,14 @@ mod tests {
             msg.contains("b30cefc4eb9ad1c6f3f61047cec5c828"),
             "missing file_hash: {msg}"
         );
-        // thiserror exposes the wrapped error via std::error::Error::source(), so the underlying
-        // message is reachable for callers that walk the chain (e.g. log::error formatters).
+        // The inner cause must appear in Display itself — many callers (e.g. format_restore_failures)
+        // render errors via to_string() without walking the source chain, so omitting it here would
+        // hide why the fetch failed.
+        assert!(
+            msg.contains("file not found"),
+            "Display should include the wrapped cause: {msg}"
+        );
+        // Source chain remains walkable for callers that prefer structured access.
         let source = std::error::Error::source(&err).expect("expected a source error");
         assert!(
             source.to_string().contains("file not found"),

--- a/crates/server/src/controllers/versions.rs
+++ b/crates/server/src/controllers/versions.rs
@@ -242,7 +242,12 @@ pub async fn stream_versions_tar_gz(
                         Ok(size) => size,
                         Err(e) => {
                             log::error!("Failed to get version file size for {file_hash}: {e}");
-                            error_tx.send(e).ok();
+                            error_tx
+                                .send(OxenError::VersionFetchFailed {
+                                    file_hash: file_hash.clone(),
+                                    source: Box::new(e),
+                                })
+                                .ok();
                             had_error = true;
                             break;
                         }
@@ -279,7 +284,16 @@ pub async fn stream_versions_tar_gz(
                 }
                 Err(e) => {
                     log::error!("Failed to get version {file_hash}: {e}");
-                    error_tx.send(e).ok();
+                    // Wrap with the hash so the streaming-response error names the specific
+                    // content blob that couldn't be served. The HTTP 200 has already been sent
+                    // by the time we reach this branch, so this is the only way the client side
+                    // (and server logs further upstream) can identify the failing object.
+                    error_tx
+                        .send(OxenError::VersionFetchFailed {
+                            file_hash: file_hash.clone(),
+                            source: Box::new(e),
+                        })
+                        .ok();
                     had_error = true;
                     break;
                 }
@@ -365,7 +379,12 @@ pub async fn stream_versions_zip(
                 Ok(size) => size,
                 Err(e) => {
                     log::error!("Failed to get version file size for {hash}: {e}");
-                    error_tx.send(e).ok();
+                    error_tx
+                        .send(OxenError::VersionFetchFailed {
+                            file_hash: hash.clone(),
+                            source: Box::new(e),
+                        })
+                        .ok();
                     had_error = true;
                     break;
                 }
@@ -413,7 +432,12 @@ pub async fn stream_versions_zip(
                 }
                 Err(e) => {
                     log::error!("Failed to get version {hash}: {e}");
-                    error_tx.send(OxenError::IO(std::io::Error::other(e))).ok();
+                    error_tx
+                        .send(OxenError::VersionFetchFailed {
+                            file_hash: hash.clone(),
+                            source: Box::new(e),
+                        })
+                        .ok();
                     had_error = true;
                     break;
                 }


### PR DESCRIPTION
When the bulk small-entries download path exhausted retries, the client error was "Err: Failed to download N files after M retries" with no indication of which files were in the batch or what the underlying error was. Server-side, the streaming bulk endpoints logged the failing hash to stderr but sent a generic error through the response stream — by the time HTTP 200 had been returned for the streaming body, there was no way to communicate which blob the server couldn't serve.

This PR makes it so that a pretty error with file paths and hashes is output to the user.