### PR TITLE
Recreate tracked empty directories in `oxen restore <dir>`

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,6 +6,16 @@ This file provides guidance to AI agents when working with code in this reposito
 
 Oxen is a fast, unstructured data version control system written in Rust. It's designed to version large machine learning datasets efficiently and provides both a CLI tool and server implementation.
 
+# How Oxen Differs from Git
+
+Oxen's user-facing model is close to Git's (commits, branches, push, pull, status, restore), but a few non-obvious differences trip up Git intuition. Don't apply Git assumptions blindly. Expand this section when you discover a new difference.
+
+- **Empty directories are first-class, tracked content.** Git ignores empty directories; Oxen treats each directory as an entry in the merkle tree on its own. Consequences:
+  + `oxen add <empty-dir>` followed by commit puts the empty dir in the tree.
+  + `oxen rm <only-file-in-dir>` followed by commit leaves the now-empty parent directory tracked as an intentionally-empty entry. By design, not a bug.
+  + If a tracked directory is missing on disk, `oxen status` correctly reports it as `removed`, and `oxen restore <dir>` should recreate it on disk (mkdir, even if it contains no files).
+  + Files placed in a tracked-but-empty directory are still untracked relative to HEAD; `oxen clean -f` will delete them. That is correct behavior.
+
 # Project Organization
 
 The Cargo workspace lives at the repository root, with crates under `crates/`:

--- a/crates/lib/src/core/v_latest/index/restore.rs
+++ b/crates/lib/src/core/v_latest/index/restore.rs
@@ -172,22 +172,46 @@ fn open_staged_db(db_path: &Path) -> Result<Option<DBWithThreadMode<SingleThread
 async fn restore_dir(
     repo: &LocalRepository,
     dir: MerkleTreeNode,
-    path: &PathBuf,
+    path: &Path,
     version_store: &Arc<dyn VersionStore>,
 ) -> Result<Vec<(PathBufError, Box<OxenError>)>, OxenError> {
     log::debug!("restore::restore_dir: start");
-    let file_nodes_with_paths = repositories::tree::dir_entries_with_paths(&dir, path)?;
+    let entries = repositories::tree::dir_entries_with_paths(&dir, path);
     log::debug!(
-        "restore::restore_dir: got {} entries",
-        file_nodes_with_paths.len()
+        "restore::restore_dir: got {} file entries, {} directory entries",
+        entries.files.len(),
+        entries.dirs.len()
     );
 
-    let msg = format!("Restoring Directory: {path:?}");
-    let bar =
-        util::progress_bar::oxen_progress_bar_with_msg(file_nodes_with_paths.len() as u64, &msg);
-
     let mut failures: Vec<(PathBufError, Box<OxenError>)> = Vec::new();
-    for (file_node, file_path) in file_nodes_with_paths.iter() {
+
+    // `path` is "" when the user ran `oxen restore .` (path_relative_to_dir collapses "."
+    // to ""). Render it as "." instead of blank.
+    let label = if path.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        path.display().to_string()
+    };
+    let msg = format!("Restoring {label}");
+    let total = (entries.dirs.len() + entries.files.len()) as u64;
+    let bar = util::progress_bar::oxen_progress_bar_with_msg(total, &msg);
+
+    // Materialize every tracked directory in the subtree first. Files inside non-empty
+    // dirs would otherwise rely on `restore_file`'s `create_dir_all(parent)` side-effect,
+    // but empty dirs (first-class in Oxen — see CLAUDE.md "How Oxen Differs from Git")
+    // have no files to drive that, and would be silently skipped (ENG-1003).
+    for dir_path in &entries.dirs {
+        let working_dir_path = repo.path.join(dir_path);
+        if let Err(e) = tokio::fs::create_dir_all(&working_dir_path).await {
+            log::error!(
+                "restore::restore_dir: error creating directory {working_dir_path:?}: {e:?}"
+            );
+            failures.push((dir_path.clone().into(), Box::new(OxenError::IO(e))));
+        }
+        bar.inc(1);
+    }
+
+    for (file_node, file_path) in entries.files.iter() {
         match restore_file(repo, file_node, file_path, version_store).await {
             Ok(_) => log::debug!("restore::restore_dir: entry restored successfully"),
             Err(e) => {

--- a/crates/lib/src/repositories/restore.rs
+++ b/crates/lib/src/repositories/restore.rs
@@ -358,6 +358,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_restore_recreates_tracked_empty_directory() -> Result<(), OxenError> {
+        // This is a regression test for ENG-1003: `restore_dir` only iterates File children and
+        // silently no-ops on empty directories.
+        //
+        // Oxen tracks directories as first-class. After `oxen rm` removes the only file in a
+        // directory and the removal is committed, the now-empty parent directory remains
+        // tracked in the merkle tree. If the user then loses that directory on disk (e.g. manual
+        // `rmdir`), `oxen status` correctly reports it as `removed` and `oxen restore <dir>` is the
+        // documented way to bring the working tree back in line with HEAD.
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let subdir_rel = PathBuf::from("subdir");
+            let subdir = repo.path.join(&subdir_rel);
+            util::fs::create_dir_all(&subdir)?;
+            util::fs::write_to_path(subdir.join("a.txt"), "AAAA")?;
+            repositories::add(&repo, &subdir).await?;
+            repositories::commit(&repo, "Add subdir/a.txt")?;
+
+            // `oxen rm` the only file, then commit. Under Oxen's first-class-directory
+            // model the empty `subdir` remains tracked in the merkle tree.
+            let rm_opts = RmOpts {
+                path: PathBuf::from("subdir/a.txt"),
+                recursive: false,
+                staged: false,
+            };
+            repositories::rm(&repo, &rm_opts).await?;
+            repositories::commit(&repo, "Remove subdir/a.txt")?;
+
+            // Remove the empty directory to recreate the situation.
+            util::fs::remove_dir_all(&subdir)?;
+            assert!(
+                !subdir.exists(),
+                "test setup: subdir must be gone from disk"
+            );
+
+            // Sanity: status should correctly report subdir as removed (it IS missing
+            // relative to HEAD's tracked tree).
+            let status_before = repositories::status(&repo).await?;
+            assert!(
+                status_before.removed_files.contains(&subdir_rel),
+                "test setup: status should report subdir as removed before restore; \
+                 got removed_files={:?}",
+                status_before.removed_files
+            );
+
+            // The bug under test: `oxen restore <empty-dir>` should recreate the tracked
+            // empty directory on disk so the working tree matches HEAD.
+            repositories::restore::restore(&repo, RestoreOpts::from_path(&subdir_rel)).await?;
+
+            assert!(
+                subdir.exists(),
+                "oxen restore <empty-dir> must recreate the tracked empty directory on disk"
+            );
+
+            // After restore, status should be clean, and the directory should really exist again.
+            let status_after = repositories::status(&repo).await?;
+            assert!(
+                status_after.is_clean(),
+                "after restoring tracked empty dir, status should be clean; got {status_after:?}"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
     async fn test_restore_directory_preserves_untracked_files() -> Result<(), OxenError> {
         // `oxen restore <dir>` must not delete untracked files that happen to live
         // inside the restored directory. It only overwrites tracked files.

--- a/crates/lib/src/repositories/tree.rs
+++ b/crates/lib/src/repositories/tree.rs
@@ -548,41 +548,50 @@ pub async fn list_missing_file_hashes_from_commits(
     list_missing_file_hashes_from_hashes(repo, &candidate_hashes).await
 }
 
-pub fn dir_entries_with_paths(
-    node: &MerkleTreeNode,
-    base_path: &PathBuf,
-) -> Result<HashSet<(FileNode, PathBuf)>, OxenError> {
-    let mut entries = HashSet::new();
+/// Files and directories collected from a merkle subtree walk. `oxen restore <dir>` needs
+/// both: file entries to call `restore_file` on, and directory paths so it can `mkdir -p`
+/// every tracked directory (including empty ones, which are first-class in Oxen — see
+/// CLAUDE.md "How Oxen Differs from Git"). Empty dirs have no files to drive
+/// `restore_file`'s `create_dir_all(parent)` side-effect, so without an explicit dir list
+/// they'd be silently skipped (ENG-1003).
+#[derive(Debug, Default)]
+pub struct DirEntries {
+    pub files: HashSet<(FileNode, PathBuf)>,
+    pub dirs: HashSet<PathBuf>,
+}
 
-    match &node.node {
-        EMerkleTreeNode::Directory(_) | EMerkleTreeNode::VNode(_) | EMerkleTreeNode::Commit(_) => {
-            for child in &node.children {
-                match &child.node {
-                    EMerkleTreeNode::File(file_node) => {
-                        let file_path = base_path.join(file_node.name());
-                        entries.insert((file_node.clone(), file_path));
-                    }
-                    EMerkleTreeNode::Directory(dir_node) => {
-                        let new_base_path = base_path.join(dir_node.name());
-                        entries.extend(dir_entries_with_paths(child, &new_base_path)?);
-                    }
-                    EMerkleTreeNode::VNode(_vnode) => {
-                        entries.extend(dir_entries_with_paths(child, base_path)?);
-                    }
-                    _ => {}
-                }
+/// Walk `node`'s merkle subtree and collect every File entry and every Directory path,
+/// with `base_path` interpreted as the path of `node` itself. Infallible: unexpected node
+/// types contribute nothing.
+pub fn dir_entries_with_paths(node: &MerkleTreeNode, base_path: &Path) -> DirEntries {
+    let mut out = DirEntries::default();
+
+    if matches!(&node.node, EMerkleTreeNode::Directory(_)) {
+        out.dirs.insert(base_path.to_path_buf());
+    }
+
+    for child in &node.children {
+        match &child.node {
+            EMerkleTreeNode::File(file_node) => {
+                let file_path = base_path.join(file_node.name());
+                out.files.insert((file_node.clone(), file_path));
             }
-        }
-        EMerkleTreeNode::File(_) => {}
-        _ => {
-            return Err(OxenError::basic_str(format!(
-                "Unexpected node type: {:?}",
-                node.node.node_type()
-            )));
+            EMerkleTreeNode::Directory(dir_node) => {
+                let new_base_path = base_path.join(dir_node.name());
+                let sub = dir_entries_with_paths(child, &new_base_path);
+                out.files.extend(sub.files);
+                out.dirs.extend(sub.dirs);
+            }
+            EMerkleTreeNode::VNode(_) => {
+                let sub = dir_entries_with_paths(child, base_path);
+                out.files.extend(sub.files);
+                out.dirs.extend(sub.dirs);
+            }
+            _ => {}
         }
     }
 
-    Ok(entries)
+    out
 }
 
 /// Get HashMap of all entries that aren't present in shared_hashes


### PR DESCRIPTION
Oxen tracks directories as first-class citizens, so an empty directory created via `oxen add <empty-dir>` (or left behind by `oxen rm` of the only file in a directory) is a real entry in the merkle tree. Once such a directory is missing on disk (e.g. a user deletes the empty directory), `oxen status` correctly reports it as `removed`, but `restore_dir` only iterated file nodes, so missing empty directories were being ignored by `oxen status` and the user was stuck with a permanently dirty status and no recovery path.

`dir_entries_with_paths` now returns both file and directory entries. `restore_dir` creates every directory in the subtree before the file loop, so empty directories at any depth are materialized on disk. `mkdir` failures accumulate into the same per-path failures vector as file-restore failures.

I also improved the `restore_dir` progress bar: the message used `{path:?}` which printed quoted paths and rendered as `Restoring Directory: ""` for `oxen restore .`. It now reads `Restoring .` or `Restoring some/path`, and the bar's total counts both directories and files so a purely-empty directory tree no longer shows `0/0`.

I added a regression test to make sure this stays fixed.

I also added a section in `.claude/CLAUDE.md` noting Oxen's first-class-directory model so future sessions don't apply Git intuition here.

Closes ENG-1003