### PR TITLE
Distinguish unrestorable files from modified files in `oxen status`

### DIFF
--- a/crates/lib/src/core/v_latest/status.rs
+++ b/crates/lib/src/core/v_latest/status.rs
@@ -11,6 +11,7 @@ use crate::model::{
     Commit, LocalRepository, MerkleHash, StagedData, StagedDirStats, StagedEntry,
     StagedEntryStatus, StagedSchema, SummarizedStagedDirStats,
 };
+use crate::storage::VersionStore;
 use crate::{repositories, util};
 
 use ignore::gitignore::Gitignore;
@@ -22,6 +23,7 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::core::v_latest::index::CommitMerkleTree;
@@ -74,6 +76,7 @@ pub async fn status_from_opts(
     staged_data.untracked_dirs = out.untracked.dirs.into_iter().collect();
     staged_data.untracked_files = out.untracked.files;
     staged_data.modified_files = out.modified;
+    staged_data.unrestorable_files = out.unrestorable;
     staged_data.removed_files = out.removed;
 
     // Find merge conflicts
@@ -149,6 +152,7 @@ pub async fn status_from_opts_and_staged_data(
     staged_data.unsynced_dirs = out.unsynced.dirs.into_iter().collect();
     staged_data.unsynced_files = out.unsynced.files;
     staged_data.modified_files = out.modified;
+    staged_data.unrestorable_files = out.unrestorable;
     staged_data.removed_files = out.removed;
 
     // Find merge conflicts
@@ -494,6 +498,11 @@ struct WalkOutput {
     untracked: UntrackedData,
     unsynced: UnsyncedData,
     modified: HashSet<PathBuf>,
+    /// Subset of "modified" semantics: working copy differs from HEAD AND HEAD's expected blob is
+    /// missing from the local version store. The user can't fix these with `oxen restore` alone;
+    /// status surfaces them separately so the user knows to run `oxen fetch --missing-files` first.
+    /// Mutually exclusive with `modified` for the same path.
+    unrestorable: HashSet<PathBuf>,
     removed: HashSet<PathBuf>,
 }
 
@@ -503,6 +512,7 @@ impl WalkOutput {
             untracked: UntrackedData::new(),
             unsynced: UnsyncedData::new(),
             modified: HashSet::new(),
+            unrestorable: HashSet::new(),
             removed: HashSet::new(),
         }
     }
@@ -511,6 +521,7 @@ impl WalkOutput {
         self.untracked.merge(other.untracked);
         self.unsynced.merge(other.unsynced);
         self.modified.extend(other.modified);
+        self.unrestorable.extend(other.unrestorable);
         self.removed.extend(other.removed);
     }
 }
@@ -574,6 +585,8 @@ struct DirState {
     untracked: UntrackedData,
     unsynced: UnsyncedData,
     modified: HashSet<PathBuf>,
+    /// See [`WalkOutput::unrestorable`].
+    unrestorable: HashSet<PathBuf>,
     removed: HashSet<PathBuf>,
     untracked_count: usize,
     /// The merkle node this path resolves to, if any. Read at FinalizeDir time both to
@@ -607,6 +620,7 @@ async fn walk_status(
     missing: MissingClassification,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
     gitignore: &Option<Gitignore>,
+    version_store: &Arc<dyn VersionStore>,
     progress: &ProgressBar,
     total_entries: &mut usize,
 ) -> Result<WalkOutput, OxenError> {
@@ -646,6 +660,7 @@ async fn walk_status(
                     untracked: UntrackedData::new(),
                     unsynced: UnsyncedData::new(),
                     modified: HashSet::new(),
+                    unrestorable: HashSet::new(),
                     removed: HashSet::new(),
                     untracked_count: 0,
                     search_node: search_node.clone(),
@@ -696,7 +711,15 @@ async fn walk_status(
                                 .await?;
                             log::debug!("is_modified {is_modified} {relative_path:?}");
                             if is_modified {
-                                current.modified.insert(relative_path.clone());
+                                // Modified working copy: distinguish "user can fix with restore"
+                                // from "HEAD's blob is missing locally, so user must fetch first"
+                                // — different remediation paths.
+                                let blob_hash = file_node.hash().to_string();
+                                if version_store.version_exists(&blob_hash).await? {
+                                    current.modified.insert(relative_path.clone());
+                                } else {
+                                    current.unrestorable.insert(relative_path.clone());
+                                }
                             }
                         }
                     } else {
@@ -711,7 +734,12 @@ async fn walk_status(
                                 .is_modified_from_node_with_metadata(&path, file_node, &metadata)
                                 .await?
                             {
-                                current.modified.insert(relative_path.clone());
+                                let blob_hash = file_node.hash().to_string();
+                                if version_store.version_exists(&blob_hash).await? {
+                                    current.modified.insert(relative_path.clone());
+                                } else {
+                                    current.unrestorable.insert(relative_path.clone());
+                                }
                             }
                         }
                         log::debug!("walk_status found_file {found_file:?} {path:?}");
@@ -872,12 +900,14 @@ async fn walk_status(
                     parent.untracked.merge(dir_state.untracked);
                     parent.unsynced.merge(dir_state.unsynced);
                     parent.modified.extend(dir_state.modified);
+                    parent.unrestorable.extend(dir_state.unrestorable);
                     parent.removed.extend(dir_state.removed);
                 } else {
                     return Ok(WalkOutput {
                         untracked: dir_state.untracked,
                         unsynced: dir_state.unsynced,
                         modified: dir_state.modified,
+                        unrestorable: dir_state.unrestorable,
                         removed: dir_state.removed,
                     });
                 }
@@ -902,6 +932,8 @@ async fn walk_paths(
     progress: &ProgressBar,
 ) -> Result<WalkOutput, OxenError> {
     let gitignore: Option<Gitignore> = oxenignore::create(repo);
+    // Get the version-store handle so walk_status can check existence of version files.
+    let version_store = repo.version_store()?;
     let mut total_entries = 0;
     let mut out = WalkOutput::empty();
     for dir in opts.paths.iter() {
@@ -914,6 +946,7 @@ async fn walk_paths(
             missing,
             dir_hashes,
             &gitignore,
+            &version_store,
             progress,
             &mut total_entries,
         )

--- a/crates/lib/src/model/staged_data.rs
+++ b/crates/lib/src/model/staged_data.rs
@@ -99,6 +99,12 @@ pub struct StagedData {
     pub modified_files: HashSet<PathBuf>,
     pub moved_files: Vec<(PathBuf, PathBuf, String)>,
     pub removed_files: HashSet<PathBuf>,
+    /// Files whose working copy differs from HEAD AND whose HEAD-expected blob is missing
+    /// from the local version store. The user can't fix these with `oxen restore` alone —
+    /// they'd hit `RestoreFailed` / `VersionStoreDataMissing` because there's nothing to
+    /// restore from. Surfaced separately so the user knows to run `oxen fetch
+    /// --missing-files` first.
+    pub unrestorable_files: HashSet<PathBuf>,
     pub merge_conflicts: Vec<EntryMergeConflict>,
 }
 
@@ -114,6 +120,7 @@ impl StagedData {
             unsynced_files: vec![],
             modified_files: HashSet::new(),
             removed_files: HashSet::new(),
+            unrestorable_files: HashSet::new(),
             moved_files: vec![],
             merge_conflicts: vec![],
         }
@@ -128,12 +135,13 @@ impl StagedData {
             && self.untracked_dirs.is_empty()
             && self.modified_files.is_empty()
             && self.removed_files.is_empty()
+            && self.unrestorable_files.is_empty()
             && self.merge_conflicts.is_empty()
             && self.moved_files.is_empty()
     }
 
     pub fn has_modified_entries(&self) -> bool {
-        !self.modified_files.is_empty()
+        !self.modified_files.is_empty() || !self.unrestorable_files.is_empty()
     }
 
     pub fn has_merge_conflicts(&self) -> bool {
@@ -167,6 +175,7 @@ impl StagedData {
         self.staged_files(&mut outputs, opts);
         self.staged_schemas(&mut outputs, opts);
         self.__collect_modified_files(&mut outputs, opts);
+        self.collect_unrestorable_files(&mut outputs, opts);
         self.__collect_merge_conflicts(&mut outputs, opts);
         self.__collect_unsynced_dirs(&mut outputs, opts);
         self.__collect_unsynced_files(&mut outputs, opts);
@@ -464,6 +473,35 @@ impl StagedData {
                 vec![
                     "  modified: ".to_string().yellow(),
                     format!("{}\n", file.to_str().unwrap()).yellow().bold(),
+                ]
+            },
+            outputs,
+            opts,
+        );
+        outputs.push("\n".normal());
+    }
+
+    fn collect_unrestorable_files(&self, outputs: &mut Vec<ColoredString>, opts: &StagedDataOpts) {
+        if self.unrestorable_files.is_empty() {
+            return;
+        }
+
+        outputs.push("Unrestorable files:".to_string().normal());
+        outputs.push(
+            "  (run \"oxen fetch --missing-files\" to re-fetch HEAD's expected blobs, then \"oxen restore\")\n"
+                .to_string()
+                .normal(),
+        );
+
+        let mut files: Vec<PathBuf> = self.unrestorable_files.iter().cloned().collect();
+        files.sort();
+
+        self.__collapse_outputs(
+            &files,
+            |file| {
+                vec![
+                    "  unrestorable: ".to_string().red(),
+                    format!("{}\n", file.to_str().unwrap()).red().bold(),
                 ]
             },
             outputs,

--- a/crates/lib/src/repositories/status.rs
+++ b/crates/lib/src/repositories/status.rs
@@ -106,6 +106,71 @@ mod tests {
     }
 
     #[tokio::test]
+    /// Regression: a file whose working copy differs from HEAD AND whose HEAD-expected
+    /// blob is missing from the local version store should be reported as "unrestorable",
+    /// not "modified". The two have different remediation paths (`oxen restore` vs.
+    /// `oxen fetch --missing-files`); status used to lump them together, leaving users
+    /// (Kaga, in the Nex stuck-pull saga) running restore in a loop while it silently
+    /// no-op'd.
+    async fn test_status_distinguishes_unrestorable_from_modified() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let path = repo.path.join("hello.txt");
+            util::fs::write_to_path(&path, "Hello World")?;
+            repositories::add(&repo, &path).await?;
+            let commit = repositories::commit(&repo, "Add hello.txt")?;
+
+            // Drift the working copy.
+            util::fs::write_to_path(&path, "drifted")?;
+
+            // Sanity: status flags it as plain `modified` while the blob is still in
+            // the local version store.
+            let status_before = repositories::status(&repo).await?;
+            assert!(
+                status_before
+                    .modified_files
+                    .iter()
+                    .any(|p| p.ends_with("hello.txt"))
+            );
+            assert!(status_before.unrestorable_files.is_empty());
+
+            // Wipe the blob HEAD expects for hello.txt. After this, `oxen restore` would
+            // hit `RestoreFailed` / `VersionStoreDataMissing`.
+            let head_node = repositories::tree::get_node_by_path(&repo, &commit, "hello.txt")?
+                .expect("hello.txt must be in HEAD's tree");
+            let blob_hash = head_node.hash.to_string();
+            let version_store = repo.version_store()?;
+            let blob_path = version_store.get_version_path(&blob_hash).await?;
+            assert!(blob_path.exists());
+            util::fs::remove_file(&*blob_path)?;
+
+            let status_after = repositories::status(&repo).await?;
+            assert!(
+                status_after
+                    .unrestorable_files
+                    .iter()
+                    .any(|p| p.ends_with("hello.txt")),
+                "expected hello.txt under unrestorable_files, got: {:?}",
+                status_after.unrestorable_files
+            );
+            assert!(
+                !status_after
+                    .modified_files
+                    .iter()
+                    .any(|p| p.ends_with("hello.txt")),
+                "expected hello.txt NOT under modified_files (it's unrestorable), got: {:?}",
+                status_after.modified_files
+            );
+            // is_clean and has_modified_entries should account for unrestorable files
+            // the same as modified ones.
+            assert!(!status_after.is_clean());
+            assert!(status_after.has_modified_entries());
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
     async fn test_command_status_nothing_staged_full_directory() -> Result<(), OxenError> {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             let repo_status = repositories::status(&repo).await?;


### PR DESCRIPTION
`oxen status` now prints a separate "Unrestorable files:" section with a hint pointing at `oxen fetch --missing-files` when there are modified files whose base file is not stored in the local version file storage.

`oxen status` reports a file as "modified" whenever the working copy doesn't match `HEAD`. That conflates two cases with different remediation paths:

  - Genuine modification: user edited the file. Remedy: commit, or `oxen restore <path>` to discard.
  - Working copy differs from HEAD AND HEAD's expected blob is missing from the local version store. `oxen restore` fails with `RestoreFailed` / `VersionStoreDataMissing`. Remedy: `oxen fetch --missing-files` first, then `oxen restore`.

PR #521 made restore distinguish the two via error variants. This is the complementary fix: surface the distinction in status so users pick the right remedy from the start.

Cost: one additional `version_exists` call per modified file. No extra work for unmodified files (the existing size+mtime fast path short-circuits before we get to the version-store check).

Refs ENG-1002