### PR TITLE
S3: Rename storage backend identifier to `kind` and rewrite TOML schema (step 13.2)

### DIFF
--- a/crates/lib/src/config/repository_config.rs
+++ b/crates/lib/src/config/repository_config.rs
@@ -70,3 +70,138 @@ impl RepositoryConfig {
         self.vnode_size.unwrap_or(DEFAULT_VNODE_SIZE)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn parse(toml_str: &str) -> RepositoryConfig {
+        toml::from_str(toml_str).expect("test fixture must parse")
+    }
+
+    #[test]
+    fn parses_canonical_storage_section() {
+        let toml = r#"
+            remotes = []
+
+            [storage]
+            kind = "local"
+            versions_path = "/mnt/nfs/customer/.oxen/versions/files"
+        "#;
+        let config = parse(toml);
+        let storage = config.storage.expect("storage section parsed");
+        assert_eq!(storage.kind, "local");
+        assert_eq!(
+            storage.versions_path,
+            Some(PathBuf::from("/mnt/nfs/customer/.oxen/versions/files"))
+        );
+    }
+
+    #[test]
+    fn promotes_legacy_settings_path_to_versions_path() {
+        // The pre-rename TOML shape that customers could have on disk:
+        // `[storage] type = "local"` plus `[storage.settings] path = "..."`.
+        // The custom Deserialize ignores the legacy `type` key (kind defaults
+        // to "local") and promotes `settings.path` into `versions_path`.
+        let toml = r#"
+            remotes = []
+
+            [storage]
+            type = "local"
+
+            [storage.settings]
+            path = "/mnt/nfs/customer/.oxen/versions/files"
+        "#;
+        let config = parse(toml);
+        let storage = config.storage.expect("legacy storage section parsed");
+        assert_eq!(storage.kind, "local");
+        assert_eq!(
+            storage.versions_path,
+            Some(PathBuf::from("/mnt/nfs/customer/.oxen/versions/files"))
+        );
+    }
+
+    #[test]
+    fn legacy_config_round_trips_into_canonical_shape() {
+        // After load+save, the legacy `[storage.settings]` subtable disappears
+        // and `versions_path` shows up in `[storage]`.
+        let legacy = r#"
+            remotes = []
+
+            [storage]
+            type = "local"
+
+            [storage.settings]
+            path = "/mnt/nfs/customer/.oxen/versions/files"
+        "#;
+        let config = parse(legacy);
+        let serialized = toml::to_string(&config).expect("re-serialize");
+
+        assert!(
+            serialized.contains("kind = \"local\""),
+            "expected canonical `kind` key in:\n{serialized}"
+        );
+        assert!(
+            serialized.contains("versions_path = \"/mnt/nfs/customer/.oxen/versions/files\""),
+            "expected promoted `versions_path` in:\n{serialized}"
+        );
+        assert!(
+            !serialized.contains("[storage.settings]"),
+            "legacy subtable must not be re-emitted; got:\n{serialized}"
+        );
+        assert!(
+            !serialized.contains("type ="),
+            "legacy `type` key must not be re-emitted; got:\n{serialized}"
+        );
+    }
+
+    #[test]
+    fn top_level_versions_path_wins_over_legacy_settings_path() {
+        let toml = r#"
+            remotes = []
+
+            [storage]
+            kind = "local"
+            versions_path = "/preferred/path"
+
+            [storage.settings]
+            path = "/should/be/ignored"
+        "#;
+        let config = parse(toml);
+        let storage = config.storage.expect("storage section parsed");
+        assert_eq!(
+            storage.versions_path,
+            Some(PathBuf::from("/preferred/path"))
+        );
+    }
+
+    #[test]
+    fn missing_storage_section_stays_none() {
+        let toml = r#"
+            remotes = []
+        "#;
+        let config = parse(toml);
+        assert!(config.storage.is_none());
+    }
+
+    #[test]
+    fn storage_section_without_versions_path_serializes_kind_only() {
+        let toml = r#"
+            remotes = []
+
+            [storage]
+            kind = "local"
+        "#;
+        let config = parse(toml);
+        let serialized = toml::to_string(&config).expect("re-serialize");
+        assert!(
+            serialized.contains("kind = \"local\""),
+            "expected `kind` in:\n{serialized}"
+        );
+        assert!(
+            !serialized.contains("versions_path"),
+            "absent versions_path must be skipped on serialize; got:\n{serialized}"
+        );
+    }
+}

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -310,7 +310,7 @@ impl LocalRepository {
     pub fn save(&self) -> Result<(), OxenError> {
         let config_path = util::fs::config_filepath(&self.path);
 
-        // Determine the current storage type and settings using the trait methods
+        // Determine the current storage kind and versions_path using the trait methods
         let storage = self
             .version_store
             .as_ref()
@@ -321,28 +321,25 @@ impl LocalRepository {
                         let path = settings.get("path").ok_or_else(|| {
                             OxenError::basic_str("Storage settings missing 'path' key")
                         })?;
-                        let storage_path = if util::fs::is_relative_to_dir(
+                        let versions_path = if util::fs::is_relative_to_dir(
                             path,
                             util::fs::oxen_hidden_dir(&self.path),
                         ) {
                             // If path is within .oxen (default location), use the relative path in case the repo was moved
-                            util::fs::path_relative_to_dir(path, &self.path)
-                                .unwrap()
-                                .to_string_lossy()
-                                .into_owned()
+                            util::fs::path_relative_to_dir(path, &self.path).unwrap()
                         } else {
                             // Otherwise, use the absolute path
-                            path.clone()
+                            PathBuf::from(path)
                         };
 
                         Ok(StorageConfig {
-                            type_: store.storage_type().to_string(),
-                            settings: HashMap::from([("path".to_string(), storage_path)]),
+                            kind: store.storage_type().to_string(),
+                            versions_path: Some(versions_path),
                         })
                     }
                     _ => Ok(StorageConfig {
-                        type_: store.storage_type().to_string(),
-                        settings,
+                        kind: store.storage_type().to_string(),
+                        versions_path: None,
                     }),
                 }
             })

--- a/crates/lib/src/opts/storage_opts.rs
+++ b/crates/lib/src/opts/storage_opts.rs
@@ -10,7 +10,7 @@ use utoipa::ToSchema;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, ToSchema)]
 pub struct StorageOpts {
-    pub type_: String,
+    pub kind: String,
     pub local_storage_opts: Option<LocalStorageOpts>,
     pub s3_opts: Option<S3Opts>,
 }
@@ -20,12 +20,12 @@ impl StorageOpts {
         repo: &LocalRepository,
         config: &StorageConfig,
     ) -> Result<StorageOpts, OxenError> {
-        match config.type_.as_str() {
+        match config.kind.as_str() {
             "local" => {
                 // Take the version store path from the config if specified
                 // Otherwise, default to the repo hidden dir
-                let version_path = if let Some(path) = config.settings.get("path") {
-                    PathBuf::from(path)
+                let version_path = if let Some(path) = &config.versions_path {
+                    path.clone()
                 } else {
                     let repo_path = util::fs::oxen_hidden_dir(&repo.path);
                     repo_path
@@ -38,39 +38,17 @@ impl StorageOpts {
                 };
 
                 Ok(StorageOpts {
-                    type_: "local".to_string(),
+                    kind: "local".to_string(),
                     local_storage_opts: Some(local_storage_opts),
                     s3_opts: None,
                 })
             }
-            "s3" => {
-                let bucket = config
-                    .settings
-                    .get("bucket")
-                    .ok_or_else(|| OxenError::basic_str("S3 bucket not specified"))?;
-
-                let prefix = config
-                    .settings
-                    .get("prefix")
-                    .cloned()
-                    .unwrap_or_else(|| String::from("versions"));
-
-                log::debug!("Storage backend is in S3 Bucket: {bucket}, Prefix: {prefix}",);
-
-                let s3_opts = S3Opts {
-                    bucket: bucket.to_string(),
-                    prefix: Some(prefix),
-                };
-
-                Ok(StorageOpts {
-                    type_: "s3".to_string(),
-                    local_storage_opts: None,
-                    s3_opts: Some(s3_opts),
-                })
-            }
+            "s3" => Err(OxenError::basic_str(
+                "S3 storage backend cannot be configured via repo config; use server-side configuration",
+            )),
             _ => Err(OxenError::basic_str(format!(
                 "Unsupported async storage type: {}",
-                config.type_
+                config.kind
             ))),
         }
     }
@@ -91,7 +69,7 @@ impl StorageOpts {
         };
 
         StorageOpts {
-            type_: "local".to_string(),
+            kind: "local".to_string(),
             local_storage_opts: Some(local_storage_opts),
             s3_opts: None,
         }
@@ -116,7 +94,7 @@ impl StorageOpts {
                             path: Some(PathBuf::from(storage_path)),
                         });
                         Ok(Some(StorageOpts {
-                            type_: "local".to_string(),
+                            kind: "local".to_string(),
                             local_storage_opts,
                             s3_opts: None,
                         }))
@@ -138,7 +116,7 @@ impl StorageOpts {
                     })?;
 
                     Ok(Some(StorageOpts {
-                        type_: "s3".to_string(),
+                        kind: "s3".to_string(),
                         local_storage_opts: None,
                         s3_opts: Some(S3Opts {
                             bucket: bucket.clone(),

--- a/crates/lib/src/repositories/clone.rs
+++ b/crates/lib/src/repositories/clone.rs
@@ -62,7 +62,7 @@ async fn clone_remote(opts: &CloneOpts) -> Result<LocalRepository, OxenError> {
         opts.fetch_opts.subtree_paths,
         opts.fetch_opts.depth,
         opts.fetch_opts.all,
-        opts.storage_opts.type_,
+        opts.storage_opts.kind,
         opts.is_vfs,
         opts.is_remote,
     );

--- a/crates/lib/src/repositories/fork.rs
+++ b/crates/lib/src/repositories/fork.rs
@@ -281,18 +281,13 @@ mod tests {
 
                 let forked_config = RepositoryConfig::from_file(&forked_config_path)?;
                 if let Some(storage) = forked_config.storage {
-                    let storage_path = storage
-                        .settings
-                        .get("path")
-                        .expect("Storage path should exist");
+                    let storage_path = storage.versions_path.expect("Storage path should exist");
                     let expected_path = PathBuf::from(OXEN_HIDDEN_DIR)
                         .join("versions")
-                        .join("files")
-                        .to_string_lossy()
-                        .to_string();
+                        .join("files");
 
                     assert_eq!(
-                        storage_path, &expected_path,
+                        storage_path, expected_path,
                         "Storage path should be default to relative path"
                     );
                 }

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use tokio::io::AsyncRead;
 use tokio_stream::Stream;
 
@@ -74,15 +74,76 @@ impl LocalFilePath {
     }
 }
 
-/// Configuration for version storage backend
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// Configuration for version storage backend.
+///
+/// Persisted in each repo's `config.toml` under `[storage]`. On-disk shape:
+///
+/// ```toml
+/// [storage]
+/// kind = "local"
+/// versions_path = "/mnt/nfs/..."   # only when set
+/// ```
+///
+/// A custom [`Deserialize`] impl also accepts the pre-rename layout
+/// (`[storage.settings] path = "..."`) for backwards compatibility: the legacy
+/// value is promoted into `versions_path` on load. Any path — new or legacy — is
+/// re-emitted as `versions_path` in `[storage]`; `[storage.settings]` goes away on
+/// the first save after upgrade.
+#[derive(Serialize, Debug, Clone)]
 pub struct StorageConfig {
-    /// Storage type: "local" or "s3"
-    #[serde(rename = "type")]
-    pub type_: String,
-    /// Backend-specific settings
-    #[serde(default)]
-    pub settings: HashMap<String, String>,
+    pub kind: String,
+    /// For the "local" backend, the directory where version files are stored. If `None`,
+    /// defaults to `<repo>/.oxen/versions/files`. A `.oxen`-prefixed relative path is
+    /// joined with the repo directory at runtime, so repos stay portable if moved.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub versions_path: Option<PathBuf>,
+}
+
+fn default_storage_kind() -> String {
+    "local".to_string()
+}
+
+impl<'de> Deserialize<'de> for StorageConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct LegacySettings {
+            #[serde(default)]
+            path: Option<PathBuf>,
+        }
+
+        #[derive(Deserialize)]
+        struct Raw {
+            #[serde(default = "default_storage_kind")]
+            kind: String,
+            #[serde(default)]
+            versions_path: Option<PathBuf>,
+            // Pre-rename location; consumed on load for backwards compatibility,
+            // never re-emitted.
+            #[serde(default)]
+            settings: Option<LegacySettings>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        let versions_path = raw
+            .versions_path
+            .or_else(|| raw.settings.and_then(|s| s.path));
+        Ok(StorageConfig {
+            kind: raw.kind,
+            versions_path,
+        })
+    }
+}
+
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
+            kind: default_storage_kind(),
+            versions_path: None,
+        }
+    }
 }
 
 /// Trait defining operations for version file storage backends
@@ -285,7 +346,7 @@ pub fn create_version_store(
     repo_dir: &Path,
     storage_opts: &StorageOpts,
 ) -> Result<Arc<dyn VersionStore>, OxenError> {
-    match storage_opts.type_.as_str() {
+    match storage_opts.kind.as_str() {
         "local" => {
             let Some(ref local_storage_opts) = storage_opts.local_storage_opts else {
                 return Err(OxenError::basic_str("local storage opts not found"));
@@ -321,7 +382,7 @@ pub fn create_version_store(
         }
         _ => Err(OxenError::basic_str(format!(
             "Unsupported async storage type: {}",
-            storage_opts.type_
+            storage_opts.kind
         ))),
     }
 }


### PR DESCRIPTION
This PR simplifies the per-repository config file options for storage.

- `type` in the config (`type_` in the code) was ignored. Renamed to `kind` so that the name could be the same in the code and config. Since it was ignored before, this is completely safe. `kind = s3` will be implemented in a future PR.
- `storage.settings.path` setting was being used before to specify a custom location for the versions storage. Extra care was taken to continue accepting this value, and rewriting it into the new value `storage.versions_path`
- Any write to the config by oxen will write out the new config format. Interactions that prompt writing the config format include moving the repo's location on disk and `oxen config {--set-remote|--remove-remote|--storage-backend}`.

Before:

```toml
[storage]
type = "local"

[storage.settings]
path = "/mnt/nfs/..."
```

After:

```toml
[storage]
kind = "local"
versions_path = "/mnt/nfs/..."
```

Closes ENG-918