### PR TITLE
Flush DuckDB connection cache on graceful shutdown

### DIFF
--- a/crates/lib/src/core/db/data_frames/df_db.rs
+++ b/crates/lib/src/core/db/data_frames/df_db.rs
@@ -68,6 +68,58 @@ pub fn remove_df_db_from_cache_with_children(
     Ok(())
 }
 
+/// Drain the connection cache, running CHECKPOINT on each connection before
+/// dropping it. Intended to be called once during graceful shutdown.
+///
+/// The cache is held in a `static LazyLock`. Rust does not drop statics at
+/// process exit, so without this call the cached connections never run their
+/// drop-time `close()` and DuckDB's default end-of-session CHECKPOINT never
+/// fires — uncheckpointed work stays in WAL files until the next open, where
+/// it must go through the WAL-recovery path in `get_connection`.
+///
+/// Skips (with a warning) any connection whose mutex is currently held. The
+/// caller is expected to have stopped its own use of the cache before
+/// calling — anything still locked is a safety-net case, not the norm.
+pub fn flush_all_df_db_connections() {
+    let entries: Vec<(PathBuf, Arc<Mutex<duckdb::Connection>>)> = {
+        let mut instances = DF_DB_INSTANCES.write();
+        std::iter::from_fn(|| instances.pop_lru()).collect()
+    };
+
+    let total = entries.len();
+    if total == 0 {
+        log::info!("flush_all_df_db_connections: cache empty, nothing to flush");
+        return;
+    }
+    log::info!("flush_all_df_db_connections: flushing {total} cached DuckDB connection(s)");
+
+    let mut checkpointed = 0usize;
+    let mut failed = 0usize;
+    let mut skipped = 0usize;
+    for (path, conn_lock) in entries {
+        match conn_lock.try_lock() {
+            Some(conn) => match conn.execute_batch("CHECKPOINT") {
+                Ok(()) => checkpointed += 1,
+                Err(e) => {
+                    failed += 1;
+                    log::warn!("flush_all_df_db_connections: CHECKPOINT failed for {path:?}: {e}");
+                }
+            },
+            None => {
+                skipped += 1;
+                log::warn!(
+                    "flush_all_df_db_connections: connection for {path:?} still in use — skipping CHECKPOINT"
+                );
+            }
+        }
+        // Connection drops here once the guard is released, releasing the
+        // file lock so subsequent processes can open the db cleanly.
+    }
+    log::info!(
+        "flush_all_df_db_connections: checkpointed={checkpointed} failed={failed} skipped={skipped}"
+    );
+}
+
 #[derive(Clone)]
 pub struct DfDBManager {
     df_db: Arc<Mutex<duckdb::Connection>>,
@@ -1135,6 +1187,72 @@ mod tests {
         let db_path = Path::new("/some/dir/db");
         let wal = wal_path_for(db_path);
         assert_eq!(wal, PathBuf::from("/some/dir/db.wal"));
+    }
+
+    #[test]
+    fn test_flush_all_df_db_connections_drains_cache_and_checkpoints() -> Result<(), OxenError> {
+        // Simulates the server-shutdown path: cached connection has uncheckpointed
+        // work, we call flush_all_df_db_connections, and the data must be in the
+        // main db file (not just the WAL) by the time we reopen.
+        test::run_empty_dir_test(|data_dir| {
+            let db_file = data_dir.join("flush_test.db");
+            let wal_file = data_dir.join("flush_test.db.wal");
+
+            // Open through the cache so the connection lands in DF_DB_INSTANCES.
+            with_df_db_manager(&db_file, |manager| {
+                manager.with_conn(|conn| {
+                    // Disable DuckDB's drop-time CHECKPOINT so the only way the
+                    // WAL gets flushed in this test is via our explicit flush.
+                    conn.execute_batch("PRAGMA disable_checkpoint_on_shutdown")?;
+                    conn.execute(
+                        &format!("CREATE TABLE {TABLE_NAME} (id INTEGER, name VARCHAR)"),
+                        [],
+                    )?;
+                    conn.execute(&format!("INSERT INTO {TABLE_NAME} VALUES (1, 'test')"), [])?;
+                    Ok(())
+                })
+            })?;
+
+            assert!(
+                wal_file.exists(),
+                "WAL should exist before flush — disable_checkpoint_on_shutdown is set"
+            );
+            let cache_len_before = DF_DB_INSTANCES.read().len();
+            assert!(
+                cache_len_before > 0,
+                "cache should have the entry we just opened"
+            );
+
+            flush_all_df_db_connections();
+
+            // Cache must be drained — every Arc removed, every connection dropped.
+            assert_eq!(
+                DF_DB_INSTANCES.read().len(),
+                0,
+                "cache should be empty after flush"
+            );
+
+            // Reopen WITHOUT going through recovery (no stale-WAL handling needed
+            // because flush already CHECKPOINTed): data must still be present.
+            let conn = duckdb::Connection::open(&db_file)?;
+            let count: i64 =
+                conn.query_row(&format!("SELECT COUNT(*) FROM {TABLE_NAME}"), [], |r| {
+                    r.get(0)
+                })?;
+            assert_eq!(
+                count, 1,
+                "row inserted before flush should still be readable"
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_flush_all_df_db_connections_on_empty_cache_is_noop() {
+        // Empty cache should not panic, error, or log a warning loudly. Just
+        // exercises the early-return branch.
+        flush_all_df_db_connections();
     }
 
     #[test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -540,7 +540,13 @@ async fn start(
     }
     log::info!("Syncing to directory: {}", sync_dir.display());
 
-    HttpServer::new(move || {
+    // Actix handles SIGTERM/SIGINT/SIGQUIT by default and drains in-flight
+    // requests within `shutdown_timeout`. We cap that here so that, after
+    // `.run().await` returns, there is still time to perform other cleanup
+    // operations before a supervisor force-kills the process.
+    const ACTIX_SHUTDOWN_TIMEOUT_SECS: u64 = 30;
+
+    let server_result = HttpServer::new(move || {
         App::new()
             .app_data(data.clone())
             .route(
@@ -583,8 +589,15 @@ async fn start(
             .wrap(TracingLogger::default())
     })
     .bind((host.to_owned(), port))?
+    .shutdown_timeout(ACTIX_SHUTDOWN_TIMEOUT_SECS)
     .run()
-    .await
+    .await;
+
+    log::info!("HTTP server stopped — flushing DuckDB connection cache");
+    liboxen::core::db::data_frames::df_db::flush_all_df_db_connections();
+    log::info!("DuckDB connection cache flushed — exiting");
+
+    server_result
 }
 
 /// Creates the user and returns their auth token.


### PR DESCRIPTION
The DuckDB connection cache lives in a `static LazyLock` that Rust never drops at process exit, so cached connections never run their drop-time `close()` and DuckDB's end-of-session CHECKPOINT never fires. Uncheckpointed work is left in WAL files, where the next open routes through `get_connection`'s recovery path — and that path can delete both the db and WAL files when retry fails, destroying staged workspace state.

Add `flush_all_df_db_connections` to drain the cache and CHECKPOINT each connection, and call it from oxen-server after `HttpServer::run().await` returns. Cap actix's `shutdown_timeout` so the HTTP drain and the cache flush share the supervisor's stop budget — biased toward the drain so slow writes can finish naturally rather than feeding the dangerous WAL-recovery path.