### PR TITLE
Option to use LMDB Merkle tree store in repos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4606,7 +4606,7 @@ dependencies = [
  "simdutf8",
  "sql_query_builder",
  "sqlparser",
- "strum 0.26.3",
+ "strum 0.28.0",
  "sysinfo",
  "tar",
  "tempfile",
@@ -5462,7 +5462,9 @@ dependencies = [
  "log",
  "minus",
  "serde_json",
+ "strum 0.28.0",
  "tempfile",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tracing",
@@ -8280,20 +8282,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -8314,6 +8316,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ sha2 = "0.10.8"
 simdutf8 = "0.1.4"
 sql_query_builder = { version = "2.1.0", features = ["postgresql"] }
 sqlparser = "0.53.0"
-strum = { version = "0.26.3", features = ["derive"] }
+strum = { version = "0.28.0", features = ["derive"] }
 sysinfo = "0.33.0"
 tar = "0.4.44"
 # TODO: Replace all tempfile use with async-tempfile

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -37,7 +37,9 @@ liboxen = { workspace = true }
 log = { workspace = true }
 minus = { workspace = true }
 serde_json = { workspace = true }
+strum = { workspace = true }
 tempfile = { workspace = true }
+thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/cli/src/cmd.rs
+++ b/crates/cli/src/cmd.rs
@@ -123,6 +123,8 @@ pub use prune::PruneCmd;
 pub mod fsck;
 pub use fsck::FsckCmd;
 
+/// Trait for that any oxen CLI comand must implement.
+/// NOTE: Must keep this trait dyn-compatible.
 #[async_trait]
 pub trait RunCmd {
     fn name(&self) -> &str;

--- a/crates/cli/src/cmd/init.rs
+++ b/crates/cli/src/cmd/init.rs
@@ -1,9 +1,12 @@
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use async_trait::async_trait;
 use clap::{Arg, Command, arg};
+use liboxen::config::repository_config::{MerkleStoreKind, RepoConfigError};
 use liboxen::core::versions::MinOxenVersion;
 use liboxen::error::OxenError;
+use strum::VariantNames;
 
 use crate::cmd::RunCmd;
 use crate::helpers::{check_remote_version, get_scheme_and_host_or_default};
@@ -40,27 +43,68 @@ impl RunCmd for InitCmd {
                     .help("The oxen version to use, if you want to test older CLI versions (default: latest)")
                     .action(clap::ArgAction::Set),
             )
+            .arg(
+                Arg::new("merkle-store")
+                    .long("merkle-store")
+                    .help(
+                        "Backend for the repository's Merkle tree node storage. \
+                         'file' is the original on-disk format (default, backwards-compatible). \
+                         'lmdb' uses an LMDB database for the tree store — not supported on \
+                         virtual file systems."
+                    )
+                    .default_value(<&'static str>::from(MerkleStoreKind::default()))
+                    .default_missing_value(<&'static str>::from(MerkleStoreKind::default()))
+                    .value_parser(<MerkleStoreKind as VariantNames>::VARIANTS.to_vec())
+                    .action(clap::ArgAction::Set),
+            )
     }
 
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
-        // Parse Args
-        let default = String::from(".");
-        let path = args.get_one::<String>("PATH").unwrap_or(&default);
+        //
+        // parse args
+        //
+        let path = args
+            .get_one::<String>("PATH")
+            .map(|x| x.as_str())
+            .unwrap_or(".");
+        log::info!("Repository path: {}", path);
 
         let version_str = args
             .get_one::<String>("oxen-version")
             .map(|s| s.to_string());
         let oxen_version = MinOxenVersion::or_latest(version_str)?;
+        log::info!("Oxen version: {}", oxen_version);
 
+        // Should not fail because MerkleStoreKind::VARIANTS is from a derive macro, which picks up
+        // all actually defined variants. And the `from_str` impl. is also generated from derive macros
+        // that look at enum structure.
+        let merkle_store_kind = match args.get_one::<String>("merkle-store") {
+            Some(token) => {
+                MerkleStoreKind::from_str(token).map_err(RepoConfigError::UnknownMerkeKind)?
+            }
+            None => MerkleStoreKind::default(),
+        };
+        log::debug!("🌲 Merkle store kind: {}", merkle_store_kind);
+
+        //
+        // validate args
+        //
         // Make sure the remote version is compatible
         let (scheme, host) = get_scheme_and_host_or_default()?;
 
         check_remote_version(scheme, host).await?;
 
+        //
         // Initialize the repository
+        //
         let directory = util::fs::canonicalize(PathBuf::from(&path))?;
-        repositories::init::init_with_version_and_storage_config(&directory, oxen_version, None)
-            .await?;
+        repositories::init::init_with_version_storage_and_merkle_store(
+            &directory,
+            oxen_version,
+            None,
+            merkle_store_kind,
+        )
+        .await?;
         println!("🐂 repository initialized at: {directory:?}");
         println!("{AFTER_INIT_MSG}");
         Ok(())

--- a/crates/lib/src/config/repository_config.rs
+++ b/crates/lib/src/config/repository_config.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use strum::{Display, EnumIter, EnumString, IntoStaticStr, VariantArray, VariantNames};
+use thiserror::Error;
 use utoipa::ToSchema;
 
 use crate::constants::DEFAULT_VNODE_SIZE;
@@ -8,15 +10,51 @@ use crate::model::{LocalRepository, Remote};
 use crate::storage::StorageConfig;
 use crate::util;
 
+#[derive(Debug, Error)]
+pub enum RepoConfigError {
+    #[error("[RepositoryConfig] Failed to read config: {0}")]
+    Read(Box<OxenError>),
+
+    #[error("[RepositoryConfig] TOML read error: {0}")]
+    TomlDe(#[from] toml::de::Error),
+
+    #[error("[RepositoryConfig] TOML write error: {0}")]
+    TomlSer(#[from] toml::ser::Error),
+
+    #[error("[RepositoryConfig] Failed to write config: {0}")]
+    Write(Box<OxenError>),
+
+    #[error("[RepositoryConfig] Unsupported Merkle store kind: {kind}. Expected one of {tokens:?}.", kind=.0, tokens=<MerkleStoreKind as VariantNames>::VARIANTS)]
+    UnknownMerkeKind(#[from] strum::ParseError),
+}
+
 /// A sort of registry for known [`MerkleStore`] implementations that can be used by [`LocalRepository`].
 /// This enum serves as a configuration option in a repository's `config.toml`
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, ToSchema)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    ToSchema,
+    EnumString,
+    EnumIter,
+    VariantNames,
+    VariantArray,
+    Display,
+    IntoStaticStr,
+)]
 // TODO: remove Serialize + Deserialize derives. These are only necessary because `LocalRepository`
 //       requires them. Those bounds will eventually be dropped.
 #[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")] // WARNING!! must mirror serde's `rename_all`
 pub enum MerkleStoreKind {
     /// The [`FileBackend`] store.
     File,
+    /// The [`LmdbBackend`] store.
+    Lmdb,
 }
 
 /// The default is the original custom file format based Merkle tree node storage.
@@ -72,23 +110,38 @@ impl Default for RepositoryConfig {
 }
 
 impl RepositoryConfig {
-    pub fn from_repo(repo: &LocalRepository) -> Result<Self, OxenError> {
-        let path = util::fs::config_filepath(&repo.path);
-        Self::from_file(&path)
+    /// Serialize a repository config as a TOML formatted string.
+    pub fn to_toml(&self) -> Result<String, RepoConfigError> {
+        let toml = toml::to_string(&self)?;
+        Ok(toml)
     }
 
-    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, OxenError> {
-        let contents = util::fs::read_from_path(&path)?;
-        let remote_config: RepositoryConfig = toml::from_str(&contents)?;
+    /// Parse the TOML string as a repository config.
+    pub fn from_toml(toml: &str) -> Result<Self, RepoConfigError> {
+        let remote_config: RepositoryConfig = toml::from_str(toml)?;
         Ok(remote_config)
     }
 
-    pub fn save(&self, path: impl AsRef<Path>) -> Result<(), OxenError> {
-        let toml = toml::to_string(&self)?;
-        util::fs::write_to_path(&path, toml)?;
+    /// Load the repository's config.
+    pub fn from_repo(repo: &LocalRepository) -> Result<Self, RepoConfigError> {
+        Self::from_file(util::fs::config_filepath(&repo.path))
+    }
+
+    /// Load a repository config from a specific file.
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, RepoConfigError> {
+        let contents =
+            util::fs::read_from_path(&path).map_err(|e| RepoConfigError::Read(Box::from(e)))?;
+        Self::from_toml(&contents)
+    }
+
+    /// Save a repository config to the specified file.
+    pub fn save(&self, path: impl AsRef<Path>) -> Result<(), RepoConfigError> {
+        let toml = self.to_toml()?;
+        util::fs::write_to_path(&path, toml).map_err(|e| RepoConfigError::Write(Box::from(e)))?;
         Ok(())
     }
 
+    /// The repository config's virtual node size.
     pub fn vnode_size(&self) -> u64 {
         self.vnode_size.unwrap_or(DEFAULT_VNODE_SIZE)
     }
@@ -226,6 +279,46 @@ mod tests {
         assert!(
             !serialized.contains("versions_path"),
             "absent versions_path must be skipped on serialize; got:\n{serialized}"
+        );
+    }
+
+    macro_rules! toml_merkle {
+        ($kind:expr) => {
+            format!(
+                r#"
+                      remotes = []
+
+                      merkle_store_kind = "{}"
+
+                      [storage]
+                      kind = "local"
+                      versions_path = "/mnt/nfs/customer/.oxen/versions/files"
+                  "#,
+                $kind
+            )
+        };
+    }
+
+    #[test]
+    fn parse_ok_merkle_store() {
+        for kind in <MerkleStoreKind as VariantArray>::VARIANTS {
+            let config = RepositoryConfig::from_toml(&toml_merkle!(kind.to_string()));
+            assert!(
+                config.is_ok(),
+                "Could not handle known Merkle tree store kind ({kind}): {config:?}"
+            );
+            let config = config.unwrap();
+            assert_eq!(&config.merkle_store_kind, kind);
+        }
+    }
+
+    #[test]
+    fn parse_reject_unknown_merkle() {
+        let expect_fail =
+            RepositoryConfig::from_toml(&toml_merkle!("what_is_this_a_center_for_ants"));
+        assert!(
+            expect_fail.is_err(),
+            "expecting to not be able to parse an invalid merkle tree store value"
         );
     }
 }

--- a/crates/lib/src/core/db/merkle_node/file_backend.rs
+++ b/crates/lib/src/core/db/merkle_node/file_backend.rs
@@ -361,28 +361,46 @@ fn extract_tar_under<R: Read>(
     Ok(hashes)
 }
 
-/// Inspect a fully-resolved tar entry destination path and, if it identifies a Merkle
-/// node, return that node's hash.
+/// Classification of a tar entry's path under `tree/nodes/`.
+///
+/// Used by [`classify_tar_entry_path`] (and originally extracted from
+/// [`extract_hash_from_entry_path`]) so that callers like the LMDB backend's
+/// transport implementation can dispatch on entry kind without re-implementing
+/// the path parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TarEntryKind {
+    /// `tree/nodes` itself, or `tree/nodes/{prefix}` — intermediate dirs.
+    Intermediate,
+    /// `tree/nodes/{prefix}/{suffix}` — the hash-bearing dir.
+    HashDir(MerkleHash),
+    /// `tree/nodes/{prefix}/{suffix}/node`.
+    NodeFile(MerkleHash),
+    /// `tree/nodes/{prefix}/{suffix}/children`.
+    ChildrenFile(MerkleHash),
+}
+
+/// Inspect a fully-resolved tar entry destination path and classify it.
 ///
 /// `dst_path` must be inside `<oxen_hidden>/tree/nodes/`. The path's segments after
 /// that prefix determine the entry kind:
 ///
 /// | Segments after `tree/nodes/` | Entry kind | Result |
 /// |---|---|---|
-/// | 0 (the `tree/nodes` dir itself) | intermediate dir | `Ok(None)` |
-/// | 1 (the `{prefix}` dir) | intermediate dir | `Ok(None)` |
-/// | 2 (`{prefix}/{suffix}` dir) | hash-bearing dir | `Ok(Some(hash))` (hash parsed from `{prefix}{suffix}` as hex u128) |
-/// | 3 (`{prefix}/{suffix}/node` or `.../children`) | leaf file | `Ok(None)` (hash already produced from the parent dir entry) |
+/// | 0 (the `tree/nodes` dir itself) | intermediate dir | `Ok(Intermediate)` |
+/// | 1 (the `{prefix}` dir) | intermediate dir | `Ok(Intermediate)` |
+/// | 2 (`{prefix}/{suffix}` dir) | hash-bearing dir | `Ok(HashDir(hash))` (hash parsed from `{prefix}{suffix}` as hex u128) |
+/// | 3 (`{prefix}/{suffix}/node`) | leaf file | `Ok(NodeFile(hash))` |
+/// | 3 (`{prefix}/{suffix}/children`) | leaf file | `Ok(ChildrenFile(hash))` |
 ///
 /// Anything else returns [`MerkleDbError::InvalidTarStructure`]. A `{prefix}/{suffix}`
 /// dir whose `{prefix}` & `{suffix}` don't hex-parse as a `u128` value returns a Err of
 /// [`MerkleDbError::InvalidNodeIdHex`]. Any non-UTF-8 path components in the tarball return
 /// an Err of [`MerkleDbError::InvalidTarStructure`]: the merkle layout should never produce
 /// a non-UTF-8 segment name.
-fn extract_hash_from_entry_path(
+pub(crate) fn classify_tar_entry_path(
     dst_path: &Path,
     oxen_hidden: &Path,
-) -> Result<Option<MerkleHash>, MerkleDbError> {
+) -> Result<TarEntryKind, MerkleDbError> {
     let tree_nodes_prefix = Path::new(TREE_DIR).join(NODES_DIR);
 
     // make a new InvalidTarStructure MerkleDbError instance
@@ -416,18 +434,27 @@ fn extract_hash_from_entry_path(
     match components.as_slice() {
         // `tree/nodes` itself, or `tree/nodes/{prefix}` — intermediate dirs
         // produced by `pack_all`. No hash to record.
-        [] | [_] => Ok(None),
+        [] | [_] => Ok(TarEntryKind::Intermediate),
         // `tree/nodes/{prefix}/{suffix}` — the hash-bearing dir. Parse
         // unconditionally; failure is a structured error.
         [prefix, suffix] => {
             let id = format!("{prefix}{suffix}");
             let hash_value = u128::from_str_radix(&id, 16)
                 .map_err(|source| MerkleDbError::InvalidNodeIdHex { id, source })?;
-            Ok(Some(MerkleHash::new(hash_value)))
+            Ok(TarEntryKind::HashDir(MerkleHash::new(hash_value)))
         }
-        // `tree/nodes/{prefix}/{suffix}/{node|children}` — leaf files. The
-        // hash is recorded when the parent dir entry is processed.
-        [_, _, leaf] if *leaf == "node" || *leaf == "children" => Ok(None),
+        // `tree/nodes/{prefix}/{suffix}/{node|children}` — leaf files.
+        [prefix, suffix, leaf] if *leaf == "node" || *leaf == "children" => {
+            let id = format!("{prefix}{suffix}");
+            let hash_value = u128::from_str_radix(&id, 16)
+                .map_err(|source| MerkleDbError::InvalidNodeIdHex { id, source })?;
+            let hash = MerkleHash::new(hash_value);
+            if *leaf == "node" {
+                Ok(TarEntryKind::NodeFile(hash))
+            } else {
+                Ok(TarEntryKind::ChildrenFile(hash))
+            }
+        }
         [_, _, other] => Err(invalid_structure(&format!(
             "leaf file under `tree/nodes/{{prefix}}/{{suffix}}/` must be `node` or `children`, got `{other}`"
         ))),
@@ -435,6 +462,22 @@ fn extract_hash_from_entry_path(
             "entry has more components than `tree/nodes/{prefix}/{suffix}/[node|children]`",
         )),
     }
+}
+
+/// Original "hash-only" view over [`classify_tar_entry_path`]. Returns
+/// `Some(hash)` only for the `{prefix}/{suffix}` hash-bearing directory; all
+/// other recognised entry shapes return `None`. Preserved so the existing
+/// `extract_tar_under` call site doesn't need to change.
+fn extract_hash_from_entry_path(
+    dst_path: &Path,
+    oxen_hidden: &Path,
+) -> Result<Option<MerkleHash>, MerkleDbError> {
+    Ok(match classify_tar_entry_path(dst_path, oxen_hidden)? {
+        TarEntryKind::HashDir(hash) => Some(hash),
+        TarEntryKind::Intermediate | TarEntryKind::NodeFile(_) | TarEntryKind::ChildrenFile(_) => {
+            None
+        }
+    })
 }
 
 /// Merkle tree node packing implementation for the [`FileBackend`].

--- a/crates/lib/src/core/db/merkle_node/lmdb.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb.rs
@@ -1,13 +1,18 @@
 /// The [`LmdbBackend`] struct.
 mod lmdb_backend;
+/// The [`MerklePacker`] implementation.
+mod pack;
 /// The [`MerkleReader`] implementation.
 mod reader;
+/// The [`MerkleUnpacker`] implementation.
+mod unpack;
 /// The structures stored as values.
 mod value_structs;
 /// The [`MerkleWriter`] implementation.
 mod writer;
 
 pub use lmdb_backend::LmdbBackend;
+pub(crate) use lmdb_backend::lmdb_dir_location;
 
 use thiserror::Error;
 

--- a/crates/lib/src/core/db/merkle_node/lmdb/pack.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb/pack.rs
@@ -1,0 +1,558 @@
+//! [`MerklePacker`] + [`MerkleUnpacker`] implementations for the [`LmdbBackend`].
+//!
+//! The wire format produced/consumed is identical to the one [`super::super::file_backend::FileBackend`]
+//! emits: tar-gz of `tree/nodes/{prefix}/{suffix}/{node,children}` entries, where
+//! `node` & `children` follow the [`super::super::merkle_node_db::MerkleNodeDB`]
+//! on-disk byte layout. Cross-backend interop is the requirement — an LMDB-backed
+//! local repo must be able to push to a File-backed server and pull from one.
+//!
+//! Pack: for each requested hash (or all hashes in [`MerklePacker::pack_all`]),
+//! the LMDB-side node + link rows are recombined into the file backend's
+//! `node` + `children` byte format and appended to the tar archive.
+//!
+//! Unpack: tar entries are first buffered in-memory and paired up by hash, then
+//! the parent's `node` byte format is decoded to recover {kind, parent_id,
+//! data, children-lookup}; the corresponding `children` blob is sliced via the
+//! lookup to recover each child's full node data; everything is committed in
+//! one [`heed::RwTxn`].
+
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+
+use crate::constants::{NODES_DIR, TREE_DIR};
+use crate::core::db::merkle_node::lmdb::LmdbError;
+use crate::core::db::merkle_node::lmdb::lmdb_backend::LmdbBackend;
+use crate::core::db::merkle_node::merkle_node_db::MerkleDbError;
+use crate::error::OxenError;
+use crate::model::merkle_tree::merkle_transport::{MerklePacker, PackOptions};
+use crate::model::{MerkleHash, MerkleTreeNodeType};
+
+impl MerklePacker for LmdbBackend {
+    /// Pack the given node `hashes` into `out`. Layout (and gzip level) follow
+    /// [`PackOptions`]. Hashes that aren't in LMDB are silently skipped — same
+    /// behaviour as the file backend.
+    fn pack_nodes(
+        &self,
+        hashes: &HashSet<MerkleHash>,
+        opts: PackOptions,
+        out: &mut dyn Write,
+    ) -> Result<(), OxenError> {
+        let enc = GzEncoder::new(out, pack_options_compression(opts));
+        let mut tar = tar::Builder::new(enc);
+        for hash in hashes {
+            append_one_node(self, &mut tar, hash, &opts)?;
+        }
+        tar.finish().map_err(MerkleDbError::Io)?;
+        tar.into_inner()
+            .map_err(MerkleDbError::Io)?
+            .finish()
+            .map_err(MerkleDbError::Io)?;
+        Ok(())
+    }
+
+    /// Pack every node currently in the LMDB store into `out` using the
+    /// server-canonical layout — same as [`super::super::file_backend::FileBackend::pack_all`].
+    fn pack_all(&self, out: &mut dyn Write) -> Result<(), OxenError> {
+        let enc = GzEncoder::new(out, Compression::fast());
+        let mut tar = tar::Builder::new(enc);
+        for hash in all_node_hashes(self)? {
+            append_one_node(self, &mut tar, &hash, &PackOptions::ServerCanonical)?;
+        }
+        tar.finish().map_err(MerkleDbError::Io)?;
+        tar.into_inner()
+            .map_err(MerkleDbError::Io)?
+            .finish()
+            .map_err(MerkleDbError::Io)?;
+        Ok(())
+    }
+
+    /// Estimate the **uncompressed** packed node tar payload for the LMDB backend.
+    ///
+    /// Mirrors [`super::super::file_backend::FileBackend::raw_byte_count`]: returns
+    /// a tight upper bound on the post-gzip bytes that will flow over the wire,
+    /// since `node` and `children` blobs are hash-dense and compress to ~1.0×.
+    ///
+    /// Hashes not present in LMDB contribute 0, matching `pack_nodes`'s silent-skip
+    /// behaviour. File / FileChunk nodes also contribute 0 because [`append_one_node`]
+    /// skips them — they ride inside a parent's `children` blob, not their own dir.
+    fn raw_byte_count(&self, hashes: &HashSet<MerkleHash>) -> u64 {
+        const TAR_HEADER_BYTES: u64 = 512;
+        const TAR_BLOCK_SIZE: u64 = 512;
+        fn padded(len: u64) -> u64 {
+            len.div_ceil(TAR_BLOCK_SIZE).saturating_mul(TAR_BLOCK_SIZE)
+        }
+
+        let mut total: u64 = 0;
+        for hash in hashes {
+            let Ok(Some(stored_node)) = self.full_get_node(hash) else {
+                continue;
+            };
+            if matches!(
+                stored_node.kind(),
+                MerkleTreeNodeType::File | MerkleTreeNodeType::FileChunk
+            ) {
+                continue;
+            }
+            let Ok(Some(link)) = self.get_links(hash) else {
+                continue;
+            };
+
+            // children blob: concatenated `data()` of every present child.
+            let mut children_len: u64 = 0;
+            let mut lookup_entries: u64 = 0;
+            for child_hash in link.children() {
+                let Ok(Some(child_node)) = self.full_get_node(child_hash) else {
+                    continue;
+                };
+                children_len = children_len.saturating_add(child_node.data().len() as u64);
+                lookup_entries = lookup_entries.saturating_add(1);
+            }
+            // node blob layout: kind(1) | parent_id(16) | data_len(4) | data | (33 bytes per lookup entry).
+            // See `encode_node_file` above.
+            let node_len: u64 = 21u64
+                .saturating_add(stored_node.data().len() as u64)
+                .saturating_add(lookup_entries.saturating_mul(33));
+
+            // One tar dir entry + node file entry + children file entry, each padded.
+            let entry_total = TAR_HEADER_BYTES
+                .saturating_add(TAR_HEADER_BYTES.saturating_add(padded(node_len)))
+                .saturating_add(TAR_HEADER_BYTES.saturating_add(padded(children_len)));
+            total = total.saturating_add(entry_total);
+        }
+        total
+    }
+}
+
+/// Match the per-layout gzip compression level used by [`super::super::file_backend::FileBackend`]
+/// so the tar-gz wire payload is interchangeable across backends.
+fn pack_options_compression(opts: PackOptions) -> Compression {
+    match opts {
+        PackOptions::ServerCanonical => Compression::fast(),
+        PackOptions::LegacyClientPush => Compression::default(),
+    }
+}
+
+/// Iterate every key in the `merkle_tree_nodes` table. Used by
+/// [`MerklePacker::pack_all`] to enumerate the store. The borrow on
+/// `rtxn` is released before we return the collected `Vec`, so callers
+/// don't tie up a read transaction.
+fn all_node_hashes(lmdb: &LmdbBackend) -> Result<Vec<MerkleHash>, LmdbError> {
+    let rtxn = lmdb.read_txn()?;
+    let mut hashes: Vec<MerkleHash> = Vec::new();
+    for entry in lmdb
+        .merkle_tree_nodes
+        .iter(&rtxn)
+        .map_err(LmdbError::Access)?
+    {
+        let (key, _value) = entry.map_err(LmdbError::Retrieve)?;
+        hashes.push(MerkleHash::new(key));
+    }
+    Ok(hashes)
+}
+
+/// Append `hash`'s `node` + `children` byte payloads to `tar`. Missing
+/// hashes are silently skipped to match the file backend's behaviour.
+/// File / file-chunk hashes are also skipped because the file backend
+/// stores those embedded inside a parent's `children` file, not as their
+/// own `{prefix}/{suffix}/` dir entries.
+fn append_one_node<W: Write>(
+    lmdb: &LmdbBackend,
+    tar: &mut tar::Builder<GzEncoder<W>>,
+    hash: &MerkleHash,
+    opts: &PackOptions,
+) -> Result<(), OxenError> {
+    let Some(stored_node) = lmdb.full_get_node(hash)? else {
+        return Ok(());
+    };
+    // File-level nodes don't get their own dir in the file backend's wire
+    // format; they only appear embedded in a parent's `children` blob.
+    // Skip here so the LMDB pack stays bit-shape-compatible.
+    if matches!(
+        stored_node.kind(),
+        MerkleTreeNodeType::File | MerkleTreeNodeType::FileChunk
+    ) {
+        return Ok(());
+    }
+    let Some(link) = lmdb.get_links(hash)? else {
+        // Node row exists but link row doesn't — should be impossible per
+        // the writer's invariants. Skip rather than fail the whole pack.
+        return Ok(());
+    };
+
+    let mut children_blob: Vec<u8> = Vec::new();
+    let mut lookup_entries: Vec<LookupEntry> = Vec::with_capacity(link.children().len());
+    for child_hash in link.children() {
+        let Some(child_node) = lmdb.full_get_node(child_hash)? else {
+            // Missing child node — emit an empty placeholder so the parent
+            // still round-trips. Same silent-skip behaviour as the file
+            // backend when its child data is missing on disk.
+            continue;
+        };
+        let child_data = child_node.data();
+        let offset = children_blob.len() as u64;
+        let len = child_data.len() as u64;
+        children_blob.extend_from_slice(child_data);
+        lookup_entries.push(LookupEntry {
+            kind: child_node.kind(),
+            hash: *child_hash,
+            offset,
+            len,
+        });
+    }
+
+    let node_blob = encode_node_file(
+        stored_node.kind(),
+        link.parent_id().copied(),
+        stored_node.data(),
+        &lookup_entries,
+    );
+
+    // Tar entry paths follow the layout selected by `opts`.
+    let dir_prefix = hash.to_hex_hash().node_db_prefix();
+    let tar_subdir: PathBuf = match opts {
+        PackOptions::ServerCanonical => Path::new(TREE_DIR).join(NODES_DIR).join(&dir_prefix),
+        PackOptions::LegacyClientPush => PathBuf::from(&dir_prefix),
+    };
+    // Directory entry first, then `node` & `children` file entries under it.
+    append_tar_dir(tar, &tar_subdir)?;
+    append_tar_file(tar, &tar_subdir.join("node"), &node_blob)?;
+    append_tar_file(tar, &tar_subdir.join("children"), &children_blob)?;
+    Ok(())
+}
+
+/// One entry of the parent's `node`-file child lookup table — mirrors the
+/// `(dtype, hash, offset, len)` quad that
+/// [`super::super::merkle_node_db::MerkleNodeDB::add_child`] writes.
+struct LookupEntry {
+    kind: MerkleTreeNodeType,
+    hash: MerkleHash,
+    offset: u64,
+    len: u64,
+}
+
+/// Build the byte content of a `tree/nodes/{prefix}/{suffix}/node` file:
+/// `kind(1) | parent_id(16 LE) | data_len(4 LE) | data | [child lookup entries]`.
+/// Format is fixed by [`super::super::merkle_node_db::MerkleNodeLookup::deserialize`].
+/// Note that here `data` is the msgpack-encoded bytes of the associated [`EMerkleTreeNode`].
+fn encode_node_file(
+    kind: MerkleTreeNodeType,
+    parent_id: Option<MerkleHash>,
+    data: &[u8],
+    lookup: &[LookupEntry],
+) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(1 + 16 + 4 + data.len() + lookup.len() * (1 + 16 + 8 + 8));
+    buf.push(kind.to_u8());
+    let parent_bytes = parent_id.map(|p| p.to_le_bytes()).unwrap_or([0u8; 16]);
+    buf.extend_from_slice(&parent_bytes);
+    buf.extend_from_slice(&(data.len() as u32).to_le_bytes());
+    buf.extend_from_slice(data);
+    for entry in lookup {
+        buf.push(entry.kind.to_u8());
+        buf.extend_from_slice(&entry.hash.to_le_bytes());
+        buf.extend_from_slice(&entry.offset.to_le_bytes());
+        buf.extend_from_slice(&entry.len.to_le_bytes());
+    }
+    buf
+}
+
+/// Append a directory entry into a tar builder. Mirrors what `tar::Builder::append_dir_all`
+/// does for a `{prefix}/{suffix}` dir when the file backend builds its tar.
+fn append_tar_dir<W: Write>(
+    tar: &mut tar::Builder<GzEncoder<W>>,
+    path: &Path,
+) -> Result<(), MerkleDbError> {
+    let mut header = tar::Header::new_gnu();
+    header.set_size(0);
+    header.set_mode(0o755);
+    header.set_entry_type(tar::EntryType::Directory);
+    header.set_cksum();
+    tar.append_data(&mut header, path, std::io::Cursor::new(Vec::new()))
+        .map_err(MerkleDbError::Io)
+}
+
+/// Append a regular file entry into a tar builder.
+fn append_tar_file<W: Write>(
+    tar: &mut tar::Builder<GzEncoder<W>>,
+    path: &Path,
+    data: &[u8],
+) -> Result<(), MerkleDbError> {
+    let mut header = tar::Header::new_gnu();
+    header.set_size(data.len() as u64);
+    header.set_mode(0o644);
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_cksum();
+    tar.append_data(&mut header, path, std::io::Cursor::new(data.to_vec()))
+        .map_err(MerkleDbError::Io)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::repository_config::MerkleStoreKind;
+    use crate::core::db::merkle_node::lmdb::tests::commit_with_hash;
+    use crate::core::db::merkle_node::lmdb::tests::h;
+    use crate::core::db::merkle_node::lmdb::tests::with_test_backend;
+    use crate::model::merkle_tree::UnpackOptions;
+    use crate::model::merkle_tree::merkle_writer::MerkleWriter;
+    use crate::repositories;
+    use crate::test;
+    use std::collections::HashSet;
+
+    /// Pack just a parent commit (with one embedded child commit), unpack into
+    /// a fresh LMDB-backed repo, and verify both nodes round-trip back through
+    /// the reader interface.
+    #[test]
+    fn test_lmdb_transport_roundtrip_via_lmdb_unpack() -> Result<(), OxenError> {
+        with_test_backend(|repo, backend| {
+            let parent_h = h("11111111111111111111111111111111");
+            let child_h = h("22222222222222222222222222222222");
+            let parent = commit_with_hash(repo, parent_h);
+            let child = commit_with_hash(repo, child_h);
+
+            let session = backend.begin()?;
+            {
+                let mut parent_ns = session.create_node(&parent, None)?;
+                parent_ns.add_child(&child)?;
+                parent_ns.finish()?;
+            }
+            session.finish()?;
+
+            let mut buf = Vec::new();
+            backend.pack_nodes(
+                &HashSet::from_iter([parent_h]),
+                PackOptions::ServerCanonical,
+                &mut buf,
+            )?;
+            assert!(!buf.is_empty(), "pack should produce some bytes");
+
+            // Fresh target repo backed by LMDB; unpack the bytes into it and
+            // verify both the parent (with full link) and the child (with
+            // minimal link) are observable.
+            let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+            let target_store = target_repo.merkle_store()?;
+            let installed = target_repo
+                .merkle_transport()?
+                .unpack(&mut &buf[..], UnpackOptions::Overwrite)?;
+            assert!(
+                installed.contains(&parent_h),
+                "unpack must report parent hash; got {installed:?}"
+            );
+            // get_node on parent → Some(node) with parent_id == None.
+            let parent_entry = target_store
+                .get_node(&parent_h)?
+                .expect("parent must be readable through target store");
+            assert!(parent_entry.parent_id.is_none());
+
+            // Embedded child: minimal link points back at parent, no
+            // children of its own.
+            let child_entry = target_store
+                .get_node(&child_h)?
+                .expect("embedded child must be readable through target store");
+            assert_eq!(child_entry.parent_id, Some(parent_h));
+            Ok(())
+        })
+    }
+
+    /// LMDB → tar → file-backed target. Confirms wire-format interop with the
+    /// FileBackend (i.e., a future server using LMDB could still serve File-backed
+    /// clients, and an LMDB client can push to a File-backed server today).
+    #[tokio::test]
+    async fn test_lmdb_pack_unpacks_into_file_backend() -> Result<(), OxenError> {
+        let source_repo =
+            test::init_test_repo_merkle_init_version_store_async(MerkleStoreKind::Lmdb).await?;
+        let parent_h = h("11111111111111111111111111111111");
+        let child_h = h("22222222222222222222222222222222");
+        let parent = commit_with_hash(&source_repo, parent_h);
+        let child = commit_with_hash(&source_repo, child_h);
+
+        {
+            let store = source_repo.merkle_store()?;
+            let session = store.begin()?;
+            {
+                let mut parent_ns = session.create_node(&parent, None)?;
+                parent_ns.add_child(&child)?;
+                parent_ns.finish()?;
+            }
+            session.finish()?;
+        }
+
+        let mut buf = Vec::new();
+        source_repo.merkle_transport()?.pack_nodes(
+            &HashSet::from_iter([parent_h]),
+            PackOptions::ServerCanonical,
+            &mut buf,
+        )?;
+
+        // File-backed target.
+        test::run_empty_local_repo_test_async(|target_repo| async move {
+            let installed = target_repo
+                .merkle_transport()?
+                .unpack(&mut &buf[..], UnpackOptions::Overwrite)?;
+            assert!(
+                installed.contains(&parent_h),
+                "unpack reported {installed:?}"
+            );
+            let store = target_repo.merkle_store()?;
+            assert!(store.exists(&parent_h)?);
+            Ok(())
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// File-backed source → tar → LMDB target. Confirms the reverse direction:
+    /// the LMDB unpacker accepts the canonical file backend wire format.
+    #[tokio::test]
+    async fn test_file_pack_unpacks_into_lmdb() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|source_repo| async move {
+            // Pack everything that's in the file-backed source.
+            let mut buf = Vec::new();
+            source_repo
+                .merkle_transport()?
+                .pack_all(&mut buf)
+                .expect("pack_all on file backend");
+            assert!(!buf.is_empty(), "expected pack_all to produce bytes");
+
+            let target_repo =
+                test::init_test_repo_merkle_init_version_store_async(MerkleStoreKind::Lmdb).await?;
+            let installed = target_repo
+                .merkle_transport()?
+                .unpack(&mut &buf[..], UnpackOptions::Overwrite)?;
+            assert!(
+                !installed.is_empty(),
+                "expected at least one installed hash"
+            );
+
+            let store = target_repo.merkle_store()?;
+            // The head commit's hash should be readable in the LMDB target.
+            let head_hash = repositories::commits::head_commit(&source_repo)
+                .expect("source has a head commit")
+                .hash()
+                .expect("head commit's hash");
+            assert!(
+                store.exists(&head_hash)?,
+                "head commit {head_hash} not readable through LMDB target store"
+            );
+            Ok(())
+        })
+        .await
+    }
+
+    /// `pack_nodes` on an LMDB store that doesn't contain the requested hashes
+    /// produces a valid empty tarball (silent skip semantics match the file
+    /// backend).
+    #[test]
+    fn test_lmdb_pack_silently_skips_absent_hashes() -> Result<(), OxenError> {
+        with_test_backend(|_repo, backend| {
+            let absent = h("deadbeefdeadbeefdeadbeefdeadbeef");
+            let mut buf = Vec::new();
+            backend.pack_nodes(
+                &HashSet::from_iter([absent]),
+                PackOptions::ServerCanonical,
+                &mut buf,
+            )?;
+            // A valid gzip wrapper around an empty tar payload — non-empty bytes
+            // overall but no tar entries beyond the gzip terminator.
+            // Easiest invariant to check: unpack into a fresh repo and assert
+            // the reported hash set is empty.
+            let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+            let installed = target_repo
+                .merkle_transport()?
+                .unpack(&mut &buf[..], UnpackOptions::Overwrite)?;
+            assert!(
+                installed.is_empty(),
+                "expected no hashes, got {installed:?}"
+            );
+            Ok(())
+        })
+    }
+
+    /// `pack_all` over an empty LMDB store: produces a valid (effectively
+    /// empty) tarball that round-trips cleanly.
+    #[test]
+    fn test_lmdb_pack_all_on_empty_store_is_noop() -> Result<(), OxenError> {
+        with_test_backend(|_repo, backend| {
+            let mut buf = Vec::new();
+            backend.pack_all(&mut buf)?;
+            let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+            let installed = target_repo
+                .merkle_transport()?
+                .unpack(&mut &buf[..], UnpackOptions::Overwrite)?;
+            assert!(installed.is_empty());
+            Ok(())
+        })
+    }
+
+    /// `pack_all` over a non-empty LMDB store visits every node and round-trips
+    /// each one through unpack into a fresh LMDB store.
+    #[test]
+    fn test_lmdb_pack_all_round_trip() -> Result<(), OxenError> {
+        with_test_backend(|repo, backend| {
+            // Two unrelated commit nodes — no parent link between them.
+            let a_h = h("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            let b_h = h("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+            let a = commit_with_hash(repo, a_h);
+            let b = commit_with_hash(repo, b_h);
+            let session = backend.begin()?;
+            session.create_node(&a, None)?.finish()?;
+            session.create_node(&b, None)?.finish()?;
+            session.finish()?;
+
+            let mut buf = Vec::new();
+            backend.pack_all(&mut buf)?;
+
+            let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+            let installed = target_repo
+                .merkle_transport()?
+                .unpack(&mut &buf[..], UnpackOptions::Overwrite)?;
+            assert!(installed.contains(&a_h));
+            assert!(installed.contains(&b_h));
+            let store = target_repo.merkle_store()?;
+            assert!(store.exists(&a_h)?);
+            assert!(store.exists(&b_h)?);
+            Ok(())
+        })
+    }
+
+    /// Path-traversal entries in the tar are rejected — same posture as the
+    /// file backend's unpack.
+    #[test]
+    fn test_lmdb_unpack_rejects_path_traversal() -> Result<(), OxenError> {
+        // Hand-build a malicious tarball whose entry name contains `..`.
+        let mut buf = Vec::new();
+        {
+            let enc = GzEncoder::new(&mut buf, Compression::fast());
+            let mut tar = tar::Builder::new(enc);
+            let mut header = tar::Header::new_old();
+            header.set_size(0);
+            header.set_mode(0o644);
+            header.set_entry_type(tar::EntryType::Regular);
+            let name_bytes = b"tree/nodes/../escape";
+            let old = header.as_old_mut();
+            old.name[..name_bytes.len()].copy_from_slice(name_bytes);
+            header.set_cksum();
+            tar.append(&header, std::io::Cursor::new(Vec::new()))
+                .map_err(MerkleDbError::Io)?;
+            tar.finish().map_err(MerkleDbError::Io)?;
+            tar.into_inner()
+                .map_err(MerkleDbError::Io)?
+                .finish()
+                .map_err(MerkleDbError::Io)?;
+        }
+        let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let err = target_repo
+            .merkle_transport()?
+            .unpack(&mut &buf[..], UnpackOptions::Overwrite)
+            .expect_err("path traversal must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Path traversal"),
+            "unexpected error message: {msg}"
+        );
+        Ok(())
+    }
+}

--- a/crates/lib/src/core/db/merkle_node/lmdb/unpack.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb/unpack.rs
@@ -1,0 +1,365 @@
+//! [`MerklePacker`] + [`MerkleUnpacker`] implementations for the [`LmdbBackend`].
+//!
+//! The wire format produced/consumed is identical to the one [`super::super::file_backend::FileBackend`]
+//! emits: tar-gz of `tree/nodes/{prefix}/{suffix}/{node,children}` entries, where
+//! `node` & `children` follow the [`super::super::merkle_node_db::MerkleNodeDB`]
+//! on-disk byte layout. Cross-backend interop is the requirement — an LMDB-backed
+//! local repo must be able to push to a File-backed server and pull from one.
+//!
+//! Pack: for each requested hash (or all hashes in [`MerklePacker::pack_all`]),
+//! the LMDB-side node + link rows are recombined into the file backend's
+//! `node` + `children` byte format and appended to the tar archive.
+//!
+//! Unpack: tar entries are first buffered in-memory and paired up by hash, then
+//! the parent's `node` byte format is decoded to recover {kind, parent_id,
+//! data, children-lookup}; the corresponding `children` blob is sliced via the
+//! lookup to recover each child's full node data; everything is committed in
+//! one [`heed::RwTxn`].
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use flate2::read::GzDecoder;
+use tar::Archive;
+
+use crate::constants::{NODES_DIR, TREE_DIR};
+use crate::core::db::merkle_node::file_backend::{TarEntryKind, classify_tar_entry_path};
+use crate::core::db::merkle_node::lmdb::LmdbError;
+use crate::core::db::merkle_node::lmdb::lmdb_backend::LmdbBackend;
+use crate::core::db::merkle_node::lmdb::value_structs::{LmdbLink, LmdbNode};
+use crate::core::db::merkle_node::merkle_node_db::MerkleDbError;
+use crate::error::OxenError;
+use crate::model::merkle_tree::merkle_transport::{MerkleUnpacker, UnpackOptions};
+use crate::model::{MerkleHash, MerkleTreeNodeType};
+
+impl MerkleUnpacker for LmdbBackend {
+    /// Unpack a tar-gz wire stream into the LMDB store.
+    ///
+    /// Tolerates both the server-canonical (`tree/nodes/{prefix}/{suffix}/...`)
+    /// and the legacy client-push (`{prefix}/{suffix}/...`) layouts — same
+    /// behaviour as [`super::super::file_backend::FileBackend::unpack`].
+    ///
+    /// `UnpackOptions::SkipExisting` doesn't write entries whose hashes are
+    /// already in the LMDB store; `UnpackOptions::Overwrite` writes everything.
+    fn unpack(
+        &self,
+        reader: &mut dyn Read,
+        opts: UnpackOptions,
+    ) -> Result<HashSet<MerkleHash>, OxenError> {
+        let buffered = collect_tar_entries(reader)?;
+        write_unpacked_into_lmdb(self, buffered, opts)
+    }
+}
+
+/// Hashes whose `node` + `children` payload bytes have been read out of the tar.
+/// Either side may be absent if the tar archive is incomplete — handled when
+/// we pair them up.
+#[derive(Default)]
+struct BufferedTarPayloads {
+    node_files: HashMap<MerkleHash, Vec<u8>>,
+    children_files: HashMap<MerkleHash, Vec<u8>>,
+    /// Hashes we observed at any path component. Returned to the caller even
+    /// if the entry's bytes were skipped (mirrors the file backend's reporting
+    /// of every parsed hash from the tarball).
+    seen_hashes: HashSet<MerkleHash>,
+}
+
+/// Read every `node` / `children` entry out of the tar archive into memory,
+/// keyed by hash. Path validation (path-traversal, allowed entry types,
+/// well-formed hash dirs) matches [`super::super::file_backend::FileBackend::unpack`].
+fn collect_tar_entries(reader: &mut dyn Read) -> Result<BufferedTarPayloads, OxenError> {
+    let decoder = GzDecoder::new(reader);
+    let mut archive = Archive::new(decoder);
+    let entries = archive.entries().map_err(MerkleDbError::CannotReadMerkle)?;
+
+    let mut buffered = BufferedTarPayloads::default();
+
+    // We classify with the synthetic oxen-hidden root + tree-nodes prefix; the
+    // helper already strips both off. Two virtual roots cover the two layouts
+    // a tar archive can arrive in.
+    let virtual_oxen_hidden = PathBuf::from(".");
+    let server_canonical_root = virtual_oxen_hidden.clone();
+    let legacy_client_push_root = virtual_oxen_hidden.join(TREE_DIR).join(NODES_DIR);
+
+    for entry in entries {
+        let mut entry = entry.map_err(MerkleDbError::CannotReadMerkle)?;
+        let path = entry
+            .path()
+            .map_err(MerkleDbError::CannotReadMerkle)?
+            .into_owned();
+
+        // Mirror file_backend's path-traversal guard.
+        if path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(MerkleDbError::PathTraversal(path.display().to_string()).into());
+        }
+        let entry_type = entry.header().entry_type();
+        if !entry_type.is_file() && !entry_type.is_dir() {
+            return Err(MerkleDbError::UnsupportedTarEntry {
+                path: path.display().to_string(),
+            }
+            .into());
+        }
+
+        // Classify under both layouts; whichever path validates wins.
+        let classified = if path.starts_with(Path::new(TREE_DIR).join(NODES_DIR)) {
+            classify_tar_entry_path(&server_canonical_root.join(&path), &virtual_oxen_hidden)?
+        } else {
+            classify_tar_entry_path(&legacy_client_push_root.join(&path), &virtual_oxen_hidden)?
+        };
+
+        match classified {
+            TarEntryKind::Intermediate => continue,
+            TarEntryKind::HashDir(hash) => {
+                buffered.seen_hashes.insert(hash);
+            }
+            TarEntryKind::NodeFile(hash) => {
+                buffered.seen_hashes.insert(hash);
+                let mut bytes = Vec::new();
+                entry.read_to_end(&mut bytes).map_err(MerkleDbError::Io)?;
+                buffered.node_files.insert(hash, bytes);
+            }
+            TarEntryKind::ChildrenFile(hash) => {
+                buffered.seen_hashes.insert(hash);
+                let mut bytes = Vec::new();
+                entry.read_to_end(&mut bytes).map_err(MerkleDbError::Io)?;
+                buffered.children_files.insert(hash, bytes);
+            }
+        }
+    }
+    Ok(buffered)
+}
+
+/// Parsed contents of one `tree/nodes/{prefix}/{suffix}/{node,children}` pair.
+struct ParsedEntry {
+    /// Kind discriminant from the parent `node` file's header.
+    parent_kind: MerkleTreeNodeType,
+    /// Parent ID from the parent `node` file's header. `None` if the on-disk slot was 0.
+    parent_id: Option<MerkleHash>,
+    /// Parent's msgpack tail.
+    parent_data: Vec<u8>,
+    /// One entry per child (already paired with its data slice from the children file).
+    children: Vec<ParsedChild>,
+}
+
+/// One child as recovered from a parent's `node` lookup + `children` blob.
+struct ParsedChild {
+    hash: MerkleHash,
+    kind: MerkleTreeNodeType,
+    data: Vec<u8>,
+}
+
+/// Decode a `tree/nodes/{prefix}/{suffix}/node` file payload + its paired
+/// `children` blob into the (parent, children) values used by the writer.
+fn parse_pair(node_bytes: &[u8], children_bytes: &[u8]) -> Result<ParsedEntry, OxenError> {
+    // node_bytes layout (file backend):
+    //   1 byte: kind
+    //   16 bytes: parent_id (u128 LE; 0 means "no parent")
+    //   4 bytes: data_len (u32 LE)
+    //   data_len bytes: msgpack tail
+    //   then [(1 byte kind, 16 byte hash LE, 8 byte offset LE, 8 byte len LE)] children entries
+    const HEADER_LEN: usize = 1 + 16 + 4;
+    if node_bytes.len() < HEADER_LEN {
+        return Err(LmdbError::NodeHeaderTruncated {
+            len: node_bytes.len(),
+        }
+        .into());
+    }
+    let parent_kind = MerkleTreeNodeType::from_u8(node_bytes[0]).map_err(LmdbError::from)?;
+    let mut parent_bytes_arr = [0u8; 16];
+    parent_bytes_arr.copy_from_slice(&node_bytes[1..17]);
+    let parent_value = u128::from_le_bytes(parent_bytes_arr);
+    let parent_id = if parent_value == 0 {
+        None
+    } else {
+        Some(MerkleHash::new(parent_value))
+    };
+    let mut data_len_arr = [0u8; 4];
+    data_len_arr.copy_from_slice(&node_bytes[17..21]);
+    let data_len = u32::from_le_bytes(data_len_arr) as usize;
+    let data_end = HEADER_LEN + data_len;
+    if node_bytes.len() < data_end {
+        return Err(LmdbError::NodeHeaderTruncated {
+            len: node_bytes.len(),
+        }
+        .into());
+    }
+    let parent_data = node_bytes[HEADER_LEN..data_end].to_vec();
+
+    let mut children: Vec<ParsedChild> = Vec::new();
+    let lookup_tail = &node_bytes[data_end..];
+    const LOOKUP_ENTRY_SIZE: usize = 1 + 16 + 8 + 8;
+    if !lookup_tail.len().is_multiple_of(LOOKUP_ENTRY_SIZE) {
+        return Err(MerkleDbError::InvalidTarStructure {
+            entry_path: format!("MerkleHash({})", MerkleHash::new(parent_value)),
+            reason: format!(
+                "child-lookup tail size {} is not a multiple of {LOOKUP_ENTRY_SIZE}",
+                lookup_tail.len(),
+            ),
+        }
+        .into());
+    }
+    for chunk in lookup_tail.chunks_exact(LOOKUP_ENTRY_SIZE) {
+        let child_kind = MerkleTreeNodeType::from_u8(chunk[0]).map_err(LmdbError::from)?;
+        let mut hash_buf = [0u8; 16];
+        hash_buf.copy_from_slice(&chunk[1..17]);
+        let child_hash = MerkleHash::new(u128::from_le_bytes(hash_buf));
+        let mut offset_buf = [0u8; 8];
+        offset_buf.copy_from_slice(&chunk[17..25]);
+        let child_offset = u64::from_le_bytes(offset_buf) as usize;
+        let mut len_buf = [0u8; 8];
+        len_buf.copy_from_slice(&chunk[25..33]);
+        let child_len = u64::from_le_bytes(len_buf) as usize;
+
+        if child_offset.saturating_add(child_len) > children_bytes.len() {
+            return Err(MerkleDbError::InvalidTarStructure {
+                entry_path: format!("MerkleHash({child_hash})"),
+                reason: format!(
+                    "child slice [{child_offset}..{}] exceeds children blob length {}",
+                    child_offset + child_len,
+                    children_bytes.len(),
+                ),
+            }
+            .into());
+        }
+        let child_data = children_bytes[child_offset..child_offset + child_len].to_vec();
+        children.push(ParsedChild {
+            hash: child_hash,
+            kind: child_kind,
+            data: child_data,
+        });
+    }
+
+    Ok(ParsedEntry {
+        parent_kind,
+        parent_id,
+        parent_data,
+        children,
+    })
+}
+
+/// Drive the LMDB write side of unpack.
+///
+/// For every `{prefix}/{suffix}` pair we have both a `node` and `children`
+/// file for, the parent's row in `merkle_tree_nodes` and `merkle_links` is
+/// written. For every embedded child of such a parent that doesn't itself
+/// have its own pair in the tar, a node row is written and a minimal link
+/// row (parent_id = embedding parent, no children of its own) is written —
+/// so [`super::super::lmdb::lmdb_backend::LmdbBackend::get_node`]'s
+/// "node + link must both exist" invariant is preserved.
+///
+/// `UnpackOptions::SkipExisting` causes hashes already present in the
+/// `merkle_tree_nodes` table to be left untouched (matches the
+/// `repositories::tree::unpack_nodes` use-case in the file backend).
+fn write_unpacked_into_lmdb(
+    backend: &LmdbBackend,
+    buffered: BufferedTarPayloads,
+    opts: UnpackOptions,
+) -> Result<HashSet<MerkleHash>, OxenError> {
+    let BufferedTarPayloads {
+        node_files,
+        children_files,
+        seen_hashes,
+    } = buffered;
+    let overwrite = matches!(opts, UnpackOptions::Overwrite);
+
+    // Pair up hashes that have both a node and children file.
+    let mut parsed: HashMap<MerkleHash, ParsedEntry> = HashMap::with_capacity(node_files.len());
+    for (hash, node_bytes) in &node_files {
+        let empty_children: Vec<u8> = Vec::new();
+        let children_bytes = children_files.get(hash).unwrap_or(&empty_children);
+        let entry = parse_pair(node_bytes, children_bytes)?;
+        parsed.insert(*hash, entry);
+    }
+
+    let mut wtxn = LmdbBackend::write_txn(&backend.lmdb_env)?;
+    let put_node = |wtxn: &mut heed::RwTxn<'_>,
+                    hash: &MerkleHash,
+                    kind: MerkleTreeNodeType,
+                    data: Vec<u8>|
+     -> Result<(), LmdbError> {
+        if !overwrite && LmdbBackend::key_present(wtxn, &backend.merkle_tree_nodes, hash)? {
+            return Ok(());
+        }
+        LmdbBackend::put_serialized(
+            wtxn,
+            &backend.merkle_tree_nodes,
+            hash,
+            LmdbNode::encode,
+            LmdbNode { kind, data },
+        )
+    };
+    let put_link = |wtxn: &mut heed::RwTxn<'_>,
+                    hash: &MerkleHash,
+                    parent_id: Option<MerkleHash>,
+                    children: Vec<MerkleHash>|
+     -> Result<(), LmdbError> {
+        if !overwrite && LmdbBackend::key_present(wtxn, &backend.merkle_links, hash)? {
+            return Ok(());
+        }
+        LmdbBackend::put_serialized(
+            wtxn,
+            &backend.merkle_links,
+            hash,
+            LmdbLink::encode,
+            LmdbLink {
+                parent_id,
+                children,
+            },
+        )
+    };
+
+    for (parent_hash, entry) in &parsed {
+        put_node(
+            &mut wtxn,
+            parent_hash,
+            entry.parent_kind,
+            entry.parent_data.clone(),
+        )?;
+        let child_hashes: Vec<MerkleHash> = entry.children.iter().map(|c| c.hash).collect();
+        put_link(&mut wtxn, parent_hash, entry.parent_id, child_hashes)?;
+
+        // Embedded children: their `node` row is observable through this parent
+        // entry alone. If they don't have a full entry of their own in the tar,
+        // write a node + minimal-link pair so `get_node` doesn't trip its
+        // "node present but no link" integrity check.
+        for child in &entry.children {
+            if parsed.contains_key(&child.hash) {
+                // Will be handled by its own iteration of this loop.
+                continue;
+            }
+            put_node(&mut wtxn, &child.hash, child.kind, child.data.clone())?;
+            // Only seed a minimal link if the link row doesn't already exist —
+            // skip-existing semantics for embedded-only children regardless of
+            // `opts`, so a child observed via two different parents doesn't
+            // get its link clobbered.
+            if !LmdbBackend::key_present(&wtxn, &backend.merkle_links, &child.hash)? {
+                LmdbBackend::put_serialized(
+                    &mut wtxn,
+                    &backend.merkle_links,
+                    &child.hash,
+                    LmdbLink::encode,
+                    LmdbLink {
+                        parent_id: Some(*parent_hash),
+                        children: Vec::new(),
+                    },
+                )?;
+            }
+        }
+    }
+    wtxn.commit().map_err(LmdbError::Write)?;
+
+    // Honour the file backend's contract: return every hash parsed out of the
+    // tarball, even ones whose payloads we skipped via SkipExisting.
+    Ok(seen_hashes)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// |                                                                          |
+// |  **NOTE**           All tests live under pack.rs !                       |
+// |                                                                          |
+// ────────────────────────────────────────────────────────────────────────────

--- a/crates/lib/src/core/v_latest.rs
+++ b/crates/lib/src/core/v_latest.rs
@@ -30,6 +30,9 @@ pub mod workspaces;
 
 pub use add::add;
 pub use commits::commit;
-pub use init::{init, init_with_version_and_storage_config, init_with_version_default};
+pub use init::{
+    init, init_with_version_and_merkle_store, init_with_version_and_storage_config,
+    init_with_version_default, init_with_version_storage_and_merkle_store,
+};
 pub use pull::{pull, pull_all, pull_remote_branch};
 pub use rm::rm;

--- a/crates/lib/src/core/v_latest/init.rs
+++ b/crates/lib/src/core/v_latest/init.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use crate::config::repository_config::MerkleStoreKind;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::LocalRepository;
@@ -28,6 +29,16 @@ pub fn init_with_version_default(
     version: MinOxenVersion,
     is_vfs: bool,
 ) -> Result<LocalRepository, OxenError> {
+    init_with_version_and_merkle_store(path, version, is_vfs, MerkleStoreKind::default())
+}
+
+/// Sync init variant that lets the caller pick the [`MerkleStoreKind`].
+pub fn init_with_version_and_merkle_store(
+    path: &Path,
+    version: MinOxenVersion,
+    is_vfs: bool,
+    merkle_store_kind: MerkleStoreKind,
+) -> Result<LocalRepository, OxenError> {
     let hidden_dir = util::fs::oxen_hidden_dir(path);
 
     util::fs::create_dir_all(hidden_dir)?;
@@ -35,7 +46,13 @@ pub fn init_with_version_default(
         return Err(OxenError::RepoAlreadyExistsAtPath(path.to_path_buf()));
     }
 
-    let repo = LocalRepository::new_from_version(path, version.to_string(), None, is_vfs)?;
+    let repo = LocalRepository::new_from_version_with_merkle_store_kind(
+        path,
+        version.to_string(),
+        None,
+        is_vfs,
+        merkle_store_kind,
+    )?;
     repo.save()?;
 
     Ok(repo)
@@ -47,6 +64,25 @@ pub async fn init_with_version_and_storage_config(
     storage_config: Option<StorageConfig>,
     is_vfs: bool,
 ) -> Result<LocalRepository, OxenError> {
+    init_with_version_storage_and_merkle_store(
+        path,
+        version,
+        storage_config,
+        is_vfs,
+        MerkleStoreKind::default(),
+    )
+    .await
+}
+
+/// Async init variant that lets the caller pick both the [`StorageConfig`] and the
+/// [`MerkleStoreKind`]. Source of truth for the CLI's `oxen init` plumbing.
+pub async fn init_with_version_storage_and_merkle_store(
+    path: &Path,
+    version: MinOxenVersion,
+    storage_config: Option<StorageConfig>,
+    is_vfs: bool,
+    merkle_store_kind: MerkleStoreKind,
+) -> Result<LocalRepository, OxenError> {
     let hidden_dir = util::fs::oxen_hidden_dir(path);
 
     util::fs::create_dir_all(hidden_dir)?;
@@ -54,8 +90,13 @@ pub async fn init_with_version_and_storage_config(
         return Err(OxenError::RepoAlreadyExistsAtPath(path.to_path_buf()));
     }
 
-    let repo =
-        LocalRepository::new_from_version(path, version.to_string(), storage_config, is_vfs)?;
+    let repo = LocalRepository::new_from_version_with_merkle_store_kind(
+        path,
+        version.to_string(),
+        storage_config,
+        is_vfs,
+        merkle_store_kind,
+    )?;
     repo.save()?;
 
     let version_store = repo.version_store();

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use tokio::task::JoinError;
 
+use crate::config::repository_config::RepoConfigError;
 use crate::core::db::merkle_node::lmdb::LmdbError;
 use crate::core::db::merkle_node::merkle_node_db::MerkleDbError;
 use crate::model::ParsedResource;
@@ -73,6 +74,20 @@ pub enum OxenError {
     /// The [`MerkleStore`] or [`TransportMerkle`] for a [`LocalRepository`] was not initialized before access.
     #[error("Merkle store not initialized")]
     MerkleStoreNotInitialized,
+
+    /// LMDB-backed Merkle store was requested on a repository configured for a
+    /// virtual file system. LMDB requires a real, byte-addressable mmap target
+    /// and does not work on VFS mounts.
+    #[error(
+        "LMDB-backed Merkle store is not supported on virtual file systems. \
+         Either use the file-backed store (the default) or initialize the \
+         repository without --vfs."
+    )]
+    MerkleStoreLmdbNotSupportedOnVfs,
+
+    /// An error stemming from an invalid [`RepositoryConfig`] value encountered during parsing or saving.
+    #[error("{0}")]
+    RepoConfig(#[from] RepoConfigError),
 
     //
     // Remotes

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -2,7 +2,9 @@ use crate::config::RepositoryConfig;
 use crate::config::repository_config::MerkleStoreKind;
 use crate::constants::SHALLOW_FLAG;
 use crate::constants::{self, DEFAULT_VNODE_SIZE, MIN_OXEN_VERSION};
+use crate::core::db::merkle_node::LmdbBackend;
 use crate::core::db::merkle_node::file_backend::FileBackend;
+use crate::core::db::merkle_node::lmdb::lmdb_dir_location;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::FileNode;
@@ -118,19 +120,47 @@ impl LocalRepository {
             storage_config,
             version_store,
             merkle_store: Some(m_store),
-            merkle_store_kind,
+            merkle_store_kind: config.merkle_store_kind,
         })
     }
 
     /// Loads the Merkle store for the repository at the specified root path.
+    ///
+    /// Dispatches on `merkle_store_kind`:
+    ///   - [`MerkleStoreKind::File`] → [`FileBackend`], honouring `is_vfs`.
+    ///   - [`MerkleStoreKind::Lmdb`] → [`LmdbBackend`], rejecting `is_vfs == true`
+    ///     because LMDB's memory-mapped storage isn't safe on virtual file
+    ///     systems (the mmap pages may not back to a real, byte-addressable
+    ///     file). VFS-on-LMDB returns [`OxenError::MerkleStoreLmdbNotSupportedOnVfs`].
     fn load_merkle_store(
         repo_path: PathBuf,
         merkle_store_kind: MerkleStoreKind,
-        _is_vfs: bool,
+        is_vfs: bool,
     ) -> Result<Arc<dyn TransportableMerkleStore>, OxenError> {
-        match merkle_store_kind {
-            MerkleStoreKind::File => Ok(Arc::new(FileBackend { repo_path })),
-        }
+        let store: Arc<dyn TransportableMerkleStore> = match merkle_store_kind {
+            MerkleStoreKind::File => Arc::new(FileBackend { repo_path }),
+            MerkleStoreKind::Lmdb => {
+                if is_vfs {
+                    return Err(OxenError::MerkleStoreLmdbNotSupportedOnVfs);
+                }
+                // Canonicalize so two `LocalRepository`s opened with different
+                // path shapes for the same physical repo (e.g. `./repo` vs
+                // `/abs/repo`, trailing slash, symlinked parent) end up at the
+                // same `heed::Env`. heed/LMDB does not deduplicate `Env`
+                // handles, and two envs on one database directory is
+                // undefined behavior per LMDB.
+                let repo_path = util::fs::canonicalize(&repo_path)?;
+                let env_dir = lmdb_dir_location(&repo_path);
+                util::fs::create_dir_all(&env_dir)?;
+                let mut options = heed::EnvOpenOptions::new();
+                // 1 GiB ceiling — large enough for typical Merkle trees,
+                // small enough to keep sparse-file disk usage in check. Can
+                // be revisited if/when we have repos that exceed it.
+                options.map_size(1024 * 1024 * 1024);
+                Arc::new(LmdbBackend::new(repo_path, options)?)
+            }
+        };
+        Ok(store)
     }
 
     /// Obtain the Merkle tree store for this repository.
@@ -155,6 +185,11 @@ impl LocalRepository {
             .as_ref()
             .ok_or(OxenError::MerkleStoreNotInitialized)?;
         Ok(&**store)
+    }
+
+    /// The type of physical Merkle tree node store that this repository uses.
+    pub fn merkle_store_kind(&self) -> MerkleStoreKind {
+        self.merkle_store_kind
     }
 
     /// Get a reference to the storage configuration this repository was constructed with.
@@ -184,10 +219,18 @@ impl LocalRepository {
         path: impl AsRef<Path>,
         storage_config: Option<StorageConfig>,
     ) -> Result<LocalRepository, OxenError> {
+        Self::new_with_merkle_store_kind(path, storage_config, MerkleStoreKind::default())
+    }
+
+    /// [`Self::new`] but with an explicit [`MerkleStoreKind`] selection.
+    pub fn new_with_merkle_store_kind(
+        path: impl AsRef<Path>,
+        storage_config: Option<StorageConfig>,
+        merkle_store_kind: MerkleStoreKind,
+    ) -> Result<LocalRepository, OxenError> {
         let path = path.as_ref().to_path_buf();
         let storage_config = storage_config.unwrap_or_default();
         let version_store = create_version_store(&path, &storage_config)?;
-        let merkle_store_kind = MerkleStoreKind::default();
         let m_store = Self::load_merkle_store(path.clone(), merkle_store_kind, false)?;
         Ok(LocalRepository {
             path,
@@ -216,10 +259,30 @@ impl LocalRepository {
         storage_config: Option<StorageConfig>,
         is_vfs: bool,
     ) -> Result<LocalRepository, OxenError> {
+        Self::new_from_version_with_merkle_store_kind(
+            path,
+            min_version,
+            storage_config,
+            is_vfs,
+            MerkleStoreKind::default(),
+        )
+    }
+
+    /// [`Self::new_from_version`] but with an explicit [`MerkleStoreKind`] selection.
+    ///
+    /// Errors with [`OxenError::MerkleStoreLmdbNotSupportedOnVfs`] when
+    /// `merkle_store_kind == MerkleStoreKind::Lmdb && is_vfs`, since the LMDB
+    /// backend uses memory-mapped IO that's incompatible with virtual file systems.
+    pub fn new_from_version_with_merkle_store_kind(
+        path: impl AsRef<Path>,
+        min_version: impl AsRef<str>,
+        storage_config: Option<StorageConfig>,
+        is_vfs: bool,
+        merkle_store_kind: MerkleStoreKind,
+    ) -> Result<LocalRepository, OxenError> {
         let path = path.as_ref().to_path_buf();
         let storage_config = storage_config.unwrap_or_default();
         let version_store = create_version_store(&path, &storage_config)?;
-        let merkle_store_kind = MerkleStoreKind::default();
         let m_store = Self::load_merkle_store(path.clone(), merkle_store_kind, is_vfs)?;
         Ok(LocalRepository {
             path,
@@ -370,7 +433,8 @@ impl LocalRepository {
     pub fn save(&self) -> Result<(), OxenError> {
         let config = self.as_config();
         let config_path = util::fs::config_filepath(&self.path);
-        config.save(&config_path)
+        config.save(&config_path)?;
+        Ok(())
     }
 
     /// Re-create the repository's configuration.
@@ -692,6 +756,7 @@ mod tests {
 
     use filetime::FileTime;
 
+    use crate::config::repository_config::MerkleStoreKind;
     use crate::error::OxenError;
     use crate::model::{LocalRepository, RepoNew};
     use crate::test;
@@ -861,6 +926,198 @@ mod tests {
             reloaded.storage_config().versions_path,
             custom.versions_path
         );
+
+        Ok(())
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // MerkleStoreKind plumbing — verify that a repo initialized with an
+    // explicit kind picks up the right backend and round-trips through
+    // `config.toml` on save+reload.
+    // ────────────────────────────────────────────────────────────────────────
+
+    /// Default — `LocalRepository::new` selects [`MerkleStoreKind::File`] so
+    /// the existing CLI/test behaviour is unchanged.
+    #[test]
+    fn test_new_defaults_to_file_merkle_store() -> Result<(), OxenError> {
+        let temp_dir = TempDir::new()?;
+        let repo = LocalRepository::new(temp_dir.path(), None)?;
+        assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::File);
+        Ok(())
+    }
+
+    /// Explicit constructor — passing [`MerkleStoreKind::Lmdb`] flips the
+    /// in-memory field over.
+    #[test]
+    fn test_new_with_merkle_store_kind_picks_lmdb() -> Result<(), OxenError> {
+        let temp_dir = TempDir::new()?;
+        let repo = LocalRepository::new_with_merkle_store_kind(
+            temp_dir.path(),
+            None,
+            MerkleStoreKind::Lmdb,
+        )?;
+        assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::Lmdb);
+        Ok(())
+    }
+
+    /// VFS + LMDB is rejected up-front. LMDB's memory mapping is not safe to
+    /// run on virtual file systems and silently degrading would be worse than
+    /// failing fast.
+    #[test]
+    fn test_new_with_merkle_store_kind_rejects_lmdb_on_vfs() -> Result<(), OxenError> {
+        let temp_dir = TempDir::new()?;
+        let result = LocalRepository::new_from_version_with_merkle_store_kind(
+            temp_dir.path(),
+            "0.25.0",
+            None,
+            true, // is_vfs
+            MerkleStoreKind::Lmdb,
+        );
+        assert!(
+            matches!(result, Err(OxenError::MerkleStoreLmdbNotSupportedOnVfs)),
+            "expected MerkleStoreLmdbNotSupportedOnVfs, got {result:?}"
+        );
+        Ok(())
+    }
+
+    /// File backend has no such restriction.
+    #[test]
+    fn test_new_with_file_kind_accepts_vfs() -> Result<(), OxenError> {
+        let temp_dir = TempDir::new()?;
+        let repo = LocalRepository::new_from_version_with_merkle_store_kind(
+            temp_dir.path(),
+            "0.25.0",
+            None,
+            true,
+            MerkleStoreKind::File,
+        )?;
+        assert!(repo.is_vfs());
+        assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::File);
+        Ok(())
+    }
+
+    /// Round-trip through `config.toml`: a repo initialized with LMDB and
+    /// saved must reload with the same kind via [`LocalRepository::from_dir`].
+    ///
+    /// LMDB enforces "one [`heed::Env`] per process per path", so we record
+    /// the path, drop the original repo to close its env, then reload.
+    #[test]
+    fn test_lmdb_merkle_store_kind_round_trips_through_config_toml() -> Result<(), OxenError> {
+        let mut repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::Lmdb);
+        let repo_path = repo.path.clone();
+        // Release the inner LocalRepository (closing its LMDB env) without
+        // tearing down the on-disk dir, so we can reload from the same path.
+        repo.drop_inner();
+
+        let reloaded = LocalRepository::from_dir(&repo_path)?;
+        assert_eq!(reloaded.merkle_store_kind(), MerkleStoreKind::Lmdb);
+        Ok(())
+    }
+
+    /// LMDB backend's on-disk env subdir is created when the repo is opened
+    /// with the LMDB merkle store — proves the dispatch hits the LMDB load arm.
+    #[test]
+    fn test_lmdb_init_creates_env_directory_under_oxen_hidden() -> Result<(), OxenError> {
+        let repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let env_dir = crate::core::db::merkle_node::lmdb::lmdb_dir_location(&repo.path);
+        assert!(
+            env_dir.exists(),
+            "expected LMDB env dir to exist at {env_dir:?}"
+        );
+        Ok(())
+    }
+
+    /// End-to-end: add a file, commit, status — all the way through an
+    /// LMDB-backed [`LocalRepository`]. This is the smoke test the task
+    /// description calls out: "actions running on an LMDB-backed Merkle tree
+    /// store using `LocalRepository` must work as expected."
+    #[tokio::test]
+    async fn test_lmdb_add_commit_status_roundtrip() -> Result<(), OxenError> {
+        use crate::repositories;
+        use crate::util;
+        let repo =
+            test::init_test_repo_merkle_init_version_store_async(MerkleStoreKind::Lmdb).await?;
+        let text_path = repo.path.join("hello.txt");
+        util::fs::write_to_path(&text_path, "Hello LMDB")?;
+
+        repositories::add(&repo, &text_path).await?;
+        repositories::commit(&repo, "Adding hello.txt")?;
+
+        // The head commit should be queryable through the LMDB store.
+        let head = repositories::commits::head_commit(&repo)?;
+        let head_hash = head.hash().expect("commit hash");
+        assert!(
+            repo.merkle_store()?.exists(&head_hash)?,
+            "head commit {head_hash} must be readable through LMDB store"
+        );
+        Ok(())
+    }
+
+    /// Equivalent control against [`MerkleStoreKind::File`] — confirms the
+    /// add → commit → head-commit chain works the same way regardless of
+    /// backend. Same shape as the LMDB test so a future failure mode that
+    /// only appears for one backend stands out.
+    #[tokio::test]
+    async fn test_file_add_commit_status_roundtrip() -> Result<(), OxenError> {
+        use crate::repositories;
+        use crate::util;
+        let repo =
+            test::init_test_repo_merkle_init_version_store_async(MerkleStoreKind::File).await?;
+        let text_path = repo.path.join("hello.txt");
+        util::fs::write_to_path(&text_path, "Hello File")?;
+
+        repositories::add(&repo, &text_path).await?;
+        repositories::commit(&repo, "Adding hello.txt")?;
+
+        let head = repositories::commits::head_commit(&repo)?;
+        let head_hash = head.hash().expect("commit hash");
+        assert!(
+            repo.merkle_store()?.exists(&head_hash)?,
+            "head commit {head_hash} must be readable through file store"
+        );
+        Ok(())
+    }
+
+    /// Bigger smoke test: add 5 files, commit, add another file, commit,
+    /// status is clean both times, both commits are reachable from the LMDB
+    /// store, and history shows both commits.
+    #[tokio::test]
+    async fn test_lmdb_two_commits_history() -> Result<(), OxenError> {
+        use crate::repositories;
+        use crate::util;
+        let repo =
+            test::init_test_repo_merkle_init_version_store_async(MerkleStoreKind::Lmdb).await?;
+        let dir = repo.path.join("files");
+        util::fs::create_dir_all(&dir)?;
+        for i in 0..5 {
+            util::fs::write_to_path(dir.join(format!("f{i}.txt")), format!("file {i}"))?;
+        }
+        repositories::add(&repo, &dir).await?;
+        repositories::commit(&repo, "Add 5 files")?;
+
+        // Status clean after first commit.
+        let status1 = repositories::status(&repo).await?;
+        assert!(
+            status1.is_clean(),
+            "expected clean status after first commit, got {status1:?}"
+        );
+
+        // Second commit on top.
+        let extra = repo.path.join("README.md");
+        util::fs::write_to_path(&extra, "readme")?;
+        repositories::add(&repo, &extra).await?;
+        repositories::commit(&repo, "Add README")?;
+
+        let status2 = repositories::status(&repo).await?;
+        assert!(
+            status2.is_clean(),
+            "expected clean status after second commit, got {status2:?}"
+        );
+
+        // Two commits visible in history.
+        let all = repositories::commits::list_all(&repo)?;
+        assert_eq!(all.len(), 2, "expected two commits, got {}", all.len());
 
         Ok(())
     }

--- a/crates/lib/src/repositories/commits/commit_writer.rs
+++ b/crates/lib/src/repositories/commits/commit_writer.rs
@@ -281,6 +281,9 @@ pub(crate) fn commit_dir_entries_with_parents(
         &dir_hashes,
         &vnode_entries,
     )?;
+    // Explicit finish: required by the [`MerkleWriteSession`] / [`NodeWriteSession`]
+    // contract. The LMDB backend buffers writes until `finish()` runs, so a missing
+    // call silently drops the commit's merkle data.
     commit_ns.finish()?;
     session.finish()?;
 
@@ -380,6 +383,7 @@ pub fn commit_dir_entries_new(
         &dir_hashes,
         &vnode_entries,
     )?;
+    // Explicit finish: see the matching note in `commit_dir_entries_with_parents`.
     commit_ns.finish()?;
     session.finish()?;
 
@@ -495,6 +499,7 @@ pub fn commit_dir_entries(
         &dir_hashes,
         &vnode_entries,
     )?;
+    // Explicit finish: see the matching note in `commit_dir_entries_with_parents`.
     commit_ns.finish()?;
     session.finish()?;
 

--- a/crates/lib/src/repositories/init.rs
+++ b/crates/lib/src/repositories/init.rs
@@ -5,6 +5,7 @@
 
 use std::path::Path;
 
+use crate::config::repository_config::MerkleStoreKind;
 use crate::constants::MIN_OXEN_VERSION;
 use crate::core;
 use crate::core::versions::MinOxenVersion;
@@ -29,10 +30,24 @@ pub fn init_with_version(
     path: impl AsRef<Path>,
     version: MinOxenVersion,
 ) -> Result<LocalRepository, OxenError> {
+    init_with_version_and_merkle_store(path, version, MerkleStoreKind::default())
+}
+
+/// Like [`init_with_version`] but lets the caller pick the Merkle store backend.
+pub fn init_with_version_and_merkle_store(
+    path: impl AsRef<Path>,
+    version: MinOxenVersion,
+    merkle_store_kind: MerkleStoreKind,
+) -> Result<LocalRepository, OxenError> {
     let path = path.as_ref();
     match version {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::init_with_version_default(path, version, false),
+        _ => core::v_latest::init_with_version_and_merkle_store(
+            path,
+            version,
+            false,
+            merkle_store_kind,
+        ),
     }
 }
 
@@ -48,15 +63,33 @@ pub async fn init_with_version_and_storage_config(
     version: MinOxenVersion,
     storage_config: Option<StorageConfig>,
 ) -> Result<LocalRepository, OxenError> {
+    init_with_version_storage_and_merkle_store(
+        path,
+        version,
+        storage_config,
+        MerkleStoreKind::default(),
+    )
+    .await
+}
+
+/// Async init variant that lets the caller pick both the [`StorageConfig`] and the
+/// [`MerkleStoreKind`]. This is the entry point the CLI's `oxen init` calls.
+pub async fn init_with_version_storage_and_merkle_store(
+    path: impl AsRef<Path>,
+    version: MinOxenVersion,
+    storage_config: Option<StorageConfig>,
+    merkle_store_kind: MerkleStoreKind,
+) -> Result<LocalRepository, OxenError> {
     let path = path.as_ref();
     match version {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => {
-            core::v_latest::init_with_version_and_storage_config(
+            core::v_latest::init_with_version_storage_and_merkle_store(
                 path,
                 version,
                 storage_config,
                 false,
+                merkle_store_kind,
             )
             .await
         }
@@ -65,7 +98,10 @@ pub async fn init_with_version_and_storage_config(
 
 #[cfg(test)]
 mod tests {
+    use crate::config::repository_config::MerkleStoreKind;
+    use crate::constants::MIN_OXEN_VERSION;
     use crate::error::OxenError;
+    use crate::model::LocalRepository;
     use crate::repositories;
     use crate::test;
 
@@ -96,5 +132,54 @@ mod tests {
 
             Ok(())
         })
+    }
+
+    /// `repositories::init` (no kind arg) selects [`MerkleStoreKind::File`].
+    #[test]
+    fn test_init_default_merkle_store_kind_is_file() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|repo_dir| {
+            let repo = repositories::init(repo_dir)?;
+            assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::File);
+            Ok(())
+        })
+    }
+
+    /// `init_with_version_and_merkle_store` with [`MerkleStoreKind::Lmdb`]
+    /// gives a repo whose `merkle_store_kind` getter reports `Lmdb`, persists
+    /// that choice to `config.toml`, and reloads it on the next `from_dir`.
+    #[test]
+    fn test_init_with_lmdb_persists_kind() -> Result<(), OxenError> {
+        // LMDB envs can't open on a VFS (e.g. Windows CI's ImDisk RAMDisk at
+        // R:\test); route this test's repo dir off OXEN_TEST_RUN_DIR via the
+        // dedicated guard helper.
+        let guard = test::create_lmdb_safe_empty_dir()?;
+        let repo_dir = guard.path();
+        let repo = repositories::init::init_with_version_and_merkle_store(
+            repo_dir,
+            MIN_OXEN_VERSION,
+            MerkleStoreKind::Lmdb,
+        )?;
+        assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::Lmdb);
+        drop(repo); // close the LMDB env so we can reopen
+
+        let reloaded = LocalRepository::from_dir(repo_dir)?;
+        assert_eq!(reloaded.merkle_store_kind(), MerkleStoreKind::Lmdb);
+        Ok(())
+    }
+
+    /// Async init path (used by the CLI) also respects an explicit
+    /// [`MerkleStoreKind::Lmdb`].
+    #[tokio::test]
+    async fn test_init_with_storage_and_lmdb() -> Result<(), OxenError> {
+        let guard = test::create_lmdb_safe_empty_dir()?;
+        let repo = repositories::init::init_with_version_storage_and_merkle_store(
+            guard.path(),
+            MIN_OXEN_VERSION,
+            None,
+            MerkleStoreKind::Lmdb,
+        )
+        .await?;
+        assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::Lmdb);
+        Ok(())
     }
 }

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -303,6 +303,142 @@ where
     Ok(())
 }
 
+/// RAII cleanup for a test repo directory. Dropping the guard removes the
+/// directory via [`maybe_cleanup_repo`] (errors are swallowed since `Drop`
+/// can't surface them). The same call runs on the normal-exit path *and*
+/// during panic unwind.
+#[cfg(test)]
+pub struct RepoDirGuard {
+    repo_dir: PathBuf,
+}
+
+#[cfg(test)]
+impl RepoDirGuard {
+    pub fn new(repo_dir: PathBuf) -> Self {
+        Self { repo_dir }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.repo_dir
+    }
+}
+
+#[cfg(test)]
+impl Drop for RepoDirGuard {
+    fn drop(&mut self) {
+        if let Err(e) = maybe_cleanup_repo(&self.repo_dir) {
+            log::warn!("RepoDirGuard cleanup failed for {:?}: {e}", self.repo_dir);
+        }
+    }
+}
+
+/// RAII handle to a freshly-initialized test [`LocalRepository`]. Derefs to
+/// the inner `LocalRepository` so callers can use it as one transparently.
+///
+/// Drop order matters: `repo` is declared before `_guard` so that on drop
+/// the inner `LocalRepository` (and any resources it holds, like an LMDB
+/// `heed::Env`) is released *before* the [`RepoDirGuard`] removes the
+/// on-disk repo directory.
+#[cfg(test)]
+pub struct TestLocalRepo {
+    repo: Option<LocalRepository>,
+    _guard: RepoDirGuard,
+}
+
+#[cfg(test)]
+impl TestLocalRepo {
+    pub fn new(repo: LocalRepository) -> Self {
+        let repo_dir = repo.path.clone();
+        Self {
+            repo: Some(repo),
+            _guard: RepoDirGuard::new(repo_dir),
+        }
+    }
+
+    /// Drop the inner [`LocalRepository`] (e.g. to release an LMDB env)
+    /// while keeping the on-disk repo dir alive for further reads. The
+    /// directory itself is still removed when this handle is dropped.
+    pub fn drop_inner(&mut self) {
+        self.repo.take();
+    }
+}
+
+#[cfg(test)]
+impl std::ops::Deref for TestLocalRepo {
+    type Target = LocalRepository;
+    fn deref(&self) -> &Self::Target {
+        self.repo
+            .as_ref()
+            .expect("TestLocalRepo inner LocalRepository was already dropped via drop_inner")
+    }
+}
+
+/// Base directory under which LMDB-backed test repos are rooted.
+///
+/// LMDB depends on NT memory-section APIs that are not implemented by
+/// virtual filesystems. On Windows CI `OXEN_TEST_RUN_DIR=R:\test` is an
+/// ImDisk RAMDisk (a VFS) and opening an LMDB env there fails with
+/// `Os { code: 1, .. }` → "Incorrect function." Routing LMDB-backed test
+/// repos to the OS temp dir keeps the env on the host's real volume
+/// (NTFS on Windows runners). Mirrors `lmdb_test_root` in
+/// `crates/lib/src/core/db/merkle_node/lmdb.rs`, used by the low-level
+/// `LmdbBackend` tests.
+#[cfg(test)]
+fn lmdb_test_base() -> PathBuf {
+    std::env::temp_dir().join("oxen-lmdb-tests")
+}
+
+/// Create a fresh empty dir suitable for an LMDB-backed test repo and
+/// return a [`RepoDirGuard`] that removes it on Drop. The dir lives under
+/// [`lmdb_test_base`] rather than `OXEN_TEST_RUN_DIR` — see that fn's docs
+/// for why.
+#[cfg(test)]
+pub fn create_lmdb_safe_empty_dir() -> Result<RepoDirGuard, OxenError> {
+    let dir = create_prefixed_dir(lmdb_test_base(), "dir")?;
+    Ok(RepoDirGuard::new(dir))
+}
+
+/// Construct a fresh test repo dir, initialize a [`LocalRepository`] in it
+/// with the given [`crate::config::repository_config::MerkleStoreKind`], and
+/// return a [`TestLocalRepo`] that cleans the dir up on Drop. Mirrors the
+/// repo shape produced by the former
+/// `run_empty_local_repo_test_with_merkle_store` helper.
+///
+/// For `MerkleStoreKind::Lmdb` the repo dir is routed under
+/// [`lmdb_test_base`] so the LMDB env never lands on a VFS like Windows CI's
+/// ImDisk RAMDisk.
+#[cfg(test)]
+pub fn init_test_repo_with_merkle_store(
+    kind: crate::config::repository_config::MerkleStoreKind,
+) -> Result<TestLocalRepo, OxenError> {
+    use crate::config::repository_config::MerkleStoreKind;
+    init_test_env();
+    log::info!("<<<<< init_test_repo_with_merkle_store start ({kind:?})");
+    let repo_dir = match kind {
+        MerkleStoreKind::Lmdb => create_prefixed_dir(lmdb_test_base(), "repo")?,
+        MerkleStoreKind::File => create_repo_dir(test_run_dir())?,
+    };
+    let repo = repositories::init::init_with_version_and_merkle_store(
+        &repo_dir,
+        MinOxenVersion::LATEST,
+        kind,
+    )?;
+    log::info!(">>>>> init_test_repo_with_merkle_store ready");
+    Ok(TestLocalRepo::new(repo))
+}
+
+/// Async variant of [`init_test_repo_with_merkle_store`] — also initializes
+/// the version store, mirroring the former
+/// `run_empty_local_repo_test_with_merkle_store_async` helper.
+#[cfg(test)]
+pub async fn init_test_repo_merkle_init_version_store_async(
+    kind: crate::config::repository_config::MerkleStoreKind,
+) -> Result<TestLocalRepo, OxenError> {
+    let handle = init_test_repo_with_merkle_store(kind)?;
+    handle.version_store().init().await?;
+    Ok(handle)
+}
+
 pub fn run_empty_local_repo_test_w_version<T>(
     version: MinOxenVersion,
     test: T,


### PR DESCRIPTION
**`oxen init --merkle-store`**
Wires up `oxen init` with a new `--merkle-store` parameter. It defaults to
use `"file"` for the `FileBackend`. But it can accept `"lmdb"`, which will
configure the repository to use the new `LmdbBackend`.

**`MerkleTransport for LmdbBackend`**
Implements `MerkleTransport` for `LmdbBackend` using the same tar archive
wire format that the `FileBackend` client <> server communication uses. A
migration will be required in order to support a more efficient Merkle tree
node transport protocol that's more suited to LMDB.