### PR TITLE
Fail fast in `oxen pull` when the server is missing version blobs

### DIFF
--- a/crates/lib/src/api/client.rs
+++ b/crates/lib/src/api/client.rs
@@ -245,9 +245,12 @@ async fn parse_json_body_with_err_msg(
         ),
         Err(err) => {
             log::debug!("Err: {err}");
-            Err(OxenError::basic_str(format!(
-                "Could not deserialize response from [{url}]\n{status}"
-            )))
+            // Preserve the HTTP status so retry loops can classify the failure even
+            // though the body is opaque (e.g. an HTML 502 page from a proxy).
+            Err(OxenError::HttpDeserializeError {
+                url: url.to_string(),
+                status,
+            })
         }
     }
 }
@@ -264,22 +267,19 @@ fn parse_status_and_message(
         http::STATUS_SUCCESS => {
             log::debug!("Status success: {status}");
             if !status.is_success() {
-                return Err(OxenError::basic_str(format!(
-                    "Err status [{}] from url {} [{}]",
+                // Preserve the HTTP status so retry loops can classify the failure.
+                return Err(OxenError::HttpStatusError {
+                    url: url.to_string(),
                     status,
-                    url,
-                    response.desc_or_msg()
-                )));
+                    message: response.desc_or_msg(),
+                });
             }
 
             Ok(body)
         }
         http::STATUS_WARNING => {
             log::debug!("Status warning: {status}");
-            Err(OxenError::basic_str(format!(
-                "Remote Warning: {}",
-                response.desc_or_msg()
-            )))
+            Err(OxenError::RemoteWarning(response.desc_or_msg().into()))
         }
         http::STATUS_ERROR => {
             log::debug!("Status error: {status}");
@@ -288,12 +288,18 @@ fn parse_status_and_message(
                 && let Some(response_type) = response_type
                 && response.desc_or_msg() == response_type
             {
-                return Err(OxenError::basic_str(msg));
+                return Err(OxenError::authentication(msg));
             }
 
-            Err(OxenError::basic_str(response.full_err_msg()))
+            // Preserve the HTTP status so retry loops can classify the failure
+            // (4xx => fatal, 5xx => retryable) without string-matching the message.
+            Err(OxenError::HttpStatusError {
+                url: url.to_string(),
+                status,
+                message: response.full_err_msg(),
+            })
         }
-        status => Err(OxenError::basic_str(format!("Unknown status [{status}]"))),
+        status => Err(OxenError::UnknownRemoteResponseStatus(status.into())),
     }
 }
 

--- a/crates/lib/src/api/client/entries.rs
+++ b/crates/lib/src/api/client/entries.rs
@@ -803,7 +803,10 @@ pub async fn download_data_from_version_paths(
     while num_retries < total_retries {
         match try_download_data_from_version_paths(remote_repo, content_ids, &dst).await {
             Ok(val) => return Ok(val),
-            Err(OxenError::Authentication(val)) => return Err(OxenError::Authentication(val)),
+            // Short-circuit on errors that won't change on retry (auth failures, 4xx
+            // responses, server-confirmed missing blobs). Without this, a doomed pull
+            // pays the full exponential backoff before surfacing the diagnostic.
+            Err(err) if err.is_fatal_for_retry() => return Err(err),
             Err(err) => {
                 num_retries += 1;
                 // Exponentially back off

--- a/crates/lib/src/api/client/versions.rs
+++ b/crates/lib/src/api/client/versions.rs
@@ -208,7 +208,10 @@ pub async fn download_data_from_version_paths(
     while num_retries < total_retries {
         match try_download_data_from_version_paths(remote_repo, entries, local_repo).await {
             Ok(val) => return Ok(val),
-            Err(OxenError::Authentication(val)) => return Err(OxenError::Authentication(val)),
+            // Short-circuit on errors that won't change on retry (auth failures, 4xx
+            // responses, server-confirmed missing blobs). Without this, a doomed pull
+            // pays the full exponential backoff before surfacing the diagnostic.
+            Err(err) if err.is_fatal_for_retry() => return Err(err),
             Err(err) => {
                 num_retries += 1;
                 // Exponentially back off
@@ -865,6 +868,53 @@ mod tests {
             let version = api::client::versions::get(&remote_repo, result.unwrap().hash).await?;
             assert!(version.is_some());
             assert_eq!(version.unwrap().size, original_file_size);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    /// When the bulk versions download endpoint is asked for hashes that don't exist
+    /// on the server, the server's pre-flight check returns a structured 404 and the
+    /// client's retry loop short-circuits — instead of paying multiple rounds of
+    /// exponential backoff that won't change the outcome.
+    #[tokio::test]
+    async fn test_bulk_download_short_circuits_on_missing_blob_on_server() -> Result<(), OxenError>
+    {
+        test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
+            // A well-formed 32-char hex string that can't possibly exist on the server.
+            let bogus_hash = "deadbeefdeadbeefdeadbeefdeadbeef".to_string();
+            let entries = vec![(bogus_hash.clone(), PathBuf::from("does-not-exist.txt"))];
+
+            let result = api::client::versions::download_data_from_version_paths(
+                &remote_repo,
+                &entries,
+                &local_repo,
+            )
+            .await;
+
+            let err = result.expect_err("expected error for missing hash");
+            // The short-circuit returns the underlying fatal error directly — *not*
+            // DownloadBatchExhausted, which is only emitted after the retry loop runs
+            // out of attempts. Seeing DownloadBatchExhausted here would mean the loop
+            // retried on a 4xx and slept its way through backoff.
+            assert!(
+                !matches!(&err, OxenError::DownloadBatchExhausted { .. }),
+                "should have short-circuited on the 4xx instead of exhausting retries: {err:?}"
+            );
+            assert!(
+                err.is_fatal_for_retry(),
+                "missing-blob error should classify as fatal: {err:?}"
+            );
+
+            // The rendered error names the missing hash so the user can map it back to
+            // the broken blob. We assert on the surface message rather than the variant
+            // shape since the server's wire-format may evolve.
+            let rendered = err.to_string();
+            assert!(
+                rendered.contains(&bogus_hash),
+                "error should name the missing hash; got: {rendered}"
+            );
 
             Ok(remote_repo)
         })

--- a/crates/lib/src/constants.rs
+++ b/crates/lib/src/constants.rs
@@ -173,6 +173,10 @@ pub const AVG_CHUNK_SIZE: u64 = 1024 * 1024 * 10;
 // Allow up to N concurrent upload tasks
 /// Allow up to N concurrent upload tasks
 pub const MAX_CONCURRENT_UPLOADS: usize = 30;
+/// Cap on parallel `version_exists` probes used when bulk operations need to
+/// check many hashes at once. Sized for network HEAD operations rather than
+/// CPU work, so it's higher than `DEFAULT_NUM_WORKERS`.
+pub const MAX_CONCURRENT_VERSION_PROBES: usize = 32;
 // Limit zip file downloads to batches of size N
 /// Limit zip file downloads to batches of size N
 pub const MAX_ZIP_DOWNLOAD_SIZE: u64 = 1024 * 1024 * 1024; // 1 GB

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -442,6 +442,45 @@ pub enum OxenError {
         source: Box<OxenError>,
     },
 
+    /// An HTTP response from oxen-server arrived with a non-success status and a body
+    /// that parsed as a structured `OxenResponse`. The HTTP status, request URL, and
+    /// human-readable message from the response body are all carried on the variant
+    /// so callers can classify the failure (e.g. 4xx as fatal, 5xx as retryable).
+    #[error("Err status [{status}] from url {url} [{message}]")]
+    HttpStatusError {
+        url: String,
+        status: http::StatusCode,
+        message: String,
+    },
+
+    /// An HTTP response arrived with a non-success status but its body wasn't a
+    /// structured `OxenResponse` — typically because an intermediate proxy returned
+    /// an HTML error page (e.g. a gateway-level 502). Carries the request URL and
+    /// HTTP status so callers can classify the failure even though the body is opaque.
+    #[error("Could not deserialize response from [{url}]\n{status}")]
+    HttpDeserializeError {
+        url: String,
+        status: http::StatusCode,
+    },
+
+    /// The bulk versions download endpoint reported that one or more requested content
+    /// blobs are absent from the server's version store. The full list of missing
+    /// hashes is carried on the variant so the client can surface every missing blob
+    /// to the user in a single error.
+    #[error("{}", format_versions_missing_on_server(hashes))]
+    VersionsMissingOnServer { hashes: Vec<String> },
+
+    /// An `OxenResponse` arrived with `status == "warning"`: the request succeeded but
+    /// the server attached an advisory message.
+    #[error("Remote Warning: {0}")]
+    RemoteWarning(StringError),
+
+    /// An `OxenResponse` arrived with a `status` field that's neither "success",
+    /// "warning", nor "error" — indicating a protocol mismatch between client and
+    /// server, or a server-side bug.
+    #[error("Unknown status [{0}]")]
+    UnknownRemoteResponseStatus(StringError),
+
     // Fallback
     // TODO: remove all uses of `Basic` and replace with specific errors.
     #[error("{0}")]
@@ -458,6 +497,19 @@ fn format_download_entries(entries: &[(String, PathBuf)]) -> String {
     let mut out = format!("Failing batch ({} files):", entries.len());
     for (hash, path) in entries {
         let _ = write!(out, "\n  {} (hash: {hash})", path.display());
+    }
+    out
+}
+
+/// Multi-line render for [`OxenError::VersionsMissingOnServer`]. Lists each missing hash
+/// so the user can map the failure back to specific blobs.
+fn format_versions_missing_on_server(hashes: &[String]) -> String {
+    let mut out = format!(
+        "Server is missing {} version blob(s) requested in this batch:",
+        hashes.len()
+    );
+    for hash in hashes {
+        let _ = write!(out, "\n  {hash}");
     }
     out
 }
@@ -553,7 +605,7 @@ impl OxenError {
             WorkspaceStagedDbCorrupted { .. } => {
                 "Recreate the workspace: `oxen workspace delete <id>` then re-create it."
             }
-            DownloadBatchExhausted { .. } => {
+            DownloadBatchExhausted { .. } | VersionsMissingOnServer { .. } => {
                 "If a content blob is missing on the server, run `oxen push --missing-files` from a clone with the full local history to repair it."
             }
             _ => return None,
@@ -586,6 +638,30 @@ impl OxenError {
                 | OxenError::WorkspaceNotFound(_)
                 | OxenError::QueryableWorkspaceNotFound
         )
+    }
+
+    /// Returns true for errors that won't change on retry: authentication failures,
+    /// 4xx HTTP responses, server-confirmed missing version blobs, and resource-
+    /// not-found variants. Retry loops use this to bail out immediately rather than
+    /// paying exponential backoff for a fixed outcome.
+    ///
+    /// Returns false for 5xx responses and connection errors, which can reflect
+    /// transient infrastructure conditions that resolve on retry.
+    pub fn is_fatal_for_retry(&self) -> bool {
+        if self.is_auth_error() || self.is_not_found() {
+            return true;
+        }
+        match self {
+            OxenError::HttpStatusError { status, .. }
+            | OxenError::HttpDeserializeError { status, .. } => status.is_client_error(),
+            OxenError::HTTP(req_err) => req_err
+                .status()
+                .map(|s| s.is_client_error())
+                .unwrap_or(false),
+            OxenError::VersionsMissingOnServer { .. } => true,
+            OxenError::VersionStoreDataMissing { .. } => true,
+            _ => false,
+        }
     }
 
     //
@@ -1002,5 +1078,103 @@ mod tests {
             source.to_string().contains("file not found"),
             "source chain missing inner message: {source}"
         );
+    }
+
+    #[test]
+    fn http_status_error_display_includes_url_status_and_message() {
+        let err = OxenError::HttpStatusError {
+            url: "https://hub.example.com/api/repos/x/y/versions".to_string(),
+            status: http::StatusCode::NOT_FOUND,
+            message: "Resource not found".to_string(),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("404"), "missing status: {msg}");
+        assert!(msg.contains("/versions"), "missing url: {msg}");
+        assert!(msg.contains("Resource not found"), "missing message: {msg}");
+    }
+
+    #[test]
+    fn http_deserialize_error_display_includes_url_and_status() {
+        let err = OxenError::HttpDeserializeError {
+            url: "https://hub.example.com/api/repos/x/y/versions".to_string(),
+            status: http::StatusCode::BAD_GATEWAY,
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("502"), "missing status: {msg}");
+        assert!(msg.contains("/versions"), "missing url: {msg}");
+    }
+
+    #[test]
+    fn versions_missing_on_server_display_lists_each_hash() {
+        let err = OxenError::VersionsMissingOnServer {
+            hashes: vec!["abc".to_string(), "def".to_string()],
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("2 version blob"), "missing count: {msg}");
+        assert!(msg.contains("abc"), "missing first hash: {msg}");
+        assert!(msg.contains("def"), "missing second hash: {msg}");
+    }
+
+    #[test]
+    fn is_fatal_for_retry_short_circuits_on_4xx_http_status_error() {
+        let err = OxenError::HttpStatusError {
+            url: "u".to_string(),
+            status: http::StatusCode::NOT_FOUND,
+            message: "nope".to_string(),
+        };
+        assert!(err.is_fatal_for_retry(), "4xx should be fatal");
+    }
+
+    #[test]
+    fn is_fatal_for_retry_retries_on_5xx_http_status_error() {
+        let err = OxenError::HttpStatusError {
+            url: "u".to_string(),
+            status: http::StatusCode::INTERNAL_SERVER_ERROR,
+            message: "blip".to_string(),
+        };
+        assert!(!err.is_fatal_for_retry(), "5xx should be retryable");
+    }
+
+    #[test]
+    fn is_fatal_for_retry_classifies_deserialize_error_by_status() {
+        let four_xx = OxenError::HttpDeserializeError {
+            url: "u".to_string(),
+            status: http::StatusCode::NOT_FOUND,
+        };
+        assert!(
+            four_xx.is_fatal_for_retry(),
+            "4xx deserialize fail is fatal"
+        );
+        let five_xx = OxenError::HttpDeserializeError {
+            url: "u".to_string(),
+            status: http::StatusCode::BAD_GATEWAY,
+        };
+        assert!(
+            !five_xx.is_fatal_for_retry(),
+            "5xx deserialize fail (HTML proxy page) is retryable"
+        );
+    }
+
+    #[test]
+    fn is_fatal_for_retry_short_circuits_on_versions_missing_on_server() {
+        let err = OxenError::VersionsMissingOnServer {
+            hashes: vec!["abc".to_string()],
+        };
+        assert!(err.is_fatal_for_retry());
+    }
+
+    #[test]
+    fn is_fatal_for_retry_short_circuits_on_auth_and_not_found() {
+        assert!(OxenError::authentication("nope").is_fatal_for_retry());
+        assert!(OxenError::resource_not_found("path").is_fatal_for_retry());
+    }
+
+    #[test]
+    fn is_fatal_for_retry_keeps_retrying_on_generic_basic_error() {
+        // Untyped errors (e.g. a network timeout flattened to Basic) shouldn't poison
+        // the retry loop — we only short-circuit when we have positive evidence the
+        // request can't succeed.
+        let err = OxenError::Basic(StringError::from("connection reset"));
+        assert!(!err.is_fatal_for_retry());
     }
 }

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -501,6 +501,17 @@ fn format_download_entries(entries: &[(String, PathBuf)]) -> String {
     out
 }
 
+/// Whether an HTTP status code, if seen on a failed request, indicates the request
+/// won't succeed on retry. 4xx is fatal *except* for 408 (Request Timeout) and 429
+/// (Too Many Requests) — both are conventionally retryable per HTTP semantics.
+fn is_fatal_http_status(status: http::StatusCode) -> bool {
+    if status == http::StatusCode::REQUEST_TIMEOUT || status == http::StatusCode::TOO_MANY_REQUESTS
+    {
+        return false;
+    }
+    status.is_client_error()
+}
+
 /// Multi-line render for [`OxenError::VersionsMissingOnServer`]. Lists each missing hash
 /// so the user can map the failure back to specific blobs.
 fn format_versions_missing_on_server(hashes: &[String]) -> String {
@@ -641,23 +652,21 @@ impl OxenError {
     }
 
     /// Returns true for errors that won't change on retry: authentication failures,
-    /// 4xx HTTP responses, server-confirmed missing version blobs, and resource-
+    /// most 4xx HTTP responses, server-confirmed missing version blobs, and resource-
     /// not-found variants. Retry loops use this to bail out immediately rather than
     /// paying exponential backoff for a fixed outcome.
     ///
-    /// Returns false for 5xx responses and connection errors, which can reflect
-    /// transient infrastructure conditions that resolve on retry.
+    /// Returns false for 5xx responses, connection errors, and the retryable 4xx
+    /// cases (408 Request Timeout, 429 Too Many Requests), all of which can reflect
+    /// transient conditions that resolve on retry.
     pub fn is_fatal_for_retry(&self) -> bool {
         if self.is_auth_error() || self.is_not_found() {
             return true;
         }
         match self {
             OxenError::HttpStatusError { status, .. }
-            | OxenError::HttpDeserializeError { status, .. } => status.is_client_error(),
-            OxenError::HTTP(req_err) => req_err
-                .status()
-                .map(|s| s.is_client_error())
-                .unwrap_or(false),
+            | OxenError::HttpDeserializeError { status, .. } => is_fatal_http_status(*status),
+            OxenError::HTTP(req_err) => req_err.status().is_some_and(is_fatal_http_status),
             OxenError::VersionsMissingOnServer { .. } => true,
             OxenError::VersionStoreDataMissing { .. } => true,
             _ => false,
@@ -1117,12 +1126,25 @@ mod tests {
 
     #[test]
     fn is_fatal_for_retry_short_circuits_on_4xx_http_status_error() {
-        let err = OxenError::HttpStatusError {
+        let make = |status| OxenError::HttpStatusError {
             url: "u".to_string(),
-            status: http::StatusCode::NOT_FOUND,
+            status,
             message: "nope".to_string(),
         };
-        assert!(err.is_fatal_for_retry(), "4xx should be fatal");
+        assert!(
+            make(http::StatusCode::NOT_FOUND).is_fatal_for_retry(),
+            "404 should be fatal"
+        );
+        // 408 (timeout) and 429 (rate limit) are 4xx but retryable per HTTP semantics —
+        // a timed-out request can be re-sent and a rate-limited one should back off.
+        assert!(
+            !make(http::StatusCode::REQUEST_TIMEOUT).is_fatal_for_retry(),
+            "408 should be retryable"
+        );
+        assert!(
+            !make(http::StatusCode::TOO_MANY_REQUESTS).is_fatal_for_retry(),
+            "429 should be retryable"
+        );
     }
 
     #[test]
@@ -1137,21 +1159,26 @@ mod tests {
 
     #[test]
     fn is_fatal_for_retry_classifies_deserialize_error_by_status() {
-        let four_xx = OxenError::HttpDeserializeError {
+        let make = |status| OxenError::HttpDeserializeError {
             url: "u".to_string(),
-            status: http::StatusCode::NOT_FOUND,
+            status,
         };
         assert!(
-            four_xx.is_fatal_for_retry(),
-            "4xx deserialize fail is fatal"
+            make(http::StatusCode::NOT_FOUND).is_fatal_for_retry(),
+            "404 deserialize fail is fatal"
         );
-        let five_xx = OxenError::HttpDeserializeError {
-            url: "u".to_string(),
-            status: http::StatusCode::BAD_GATEWAY,
-        };
         assert!(
-            !five_xx.is_fatal_for_retry(),
+            !make(http::StatusCode::BAD_GATEWAY).is_fatal_for_retry(),
             "5xx deserialize fail (HTML proxy page) is retryable"
+        );
+        // 408 and 429 stay retryable even when the body fails to parse.
+        assert!(
+            !make(http::StatusCode::REQUEST_TIMEOUT).is_fatal_for_retry(),
+            "408 deserialize fail should be retryable"
+        );
+        assert!(
+            !make(http::StatusCode::TOO_MANY_REQUESTS).is_fatal_for_retry(),
+            "429 deserialize fail should be retryable"
         );
     }
 

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -652,9 +652,11 @@ impl OxenError {
     }
 
     /// Returns true for errors that won't change on retry: authentication failures,
-    /// most 4xx HTTP responses, server-confirmed missing version blobs, and resource-
-    /// not-found variants. Retry loops use this to bail out immediately rather than
-    /// paying exponential backoff for a fixed outcome.
+    /// most 4xx HTTP responses, server-confirmed missing version blobs, resource-
+    /// not-found variants, and unrecognized remote response shapes (which signal
+    /// protocol mismatch or a server bug, neither of which retry resolves). Retry
+    /// loops use this to bail out immediately rather than paying exponential
+    /// backoff for a fixed outcome.
     ///
     /// Returns false for 5xx responses, connection errors, and the retryable 4xx
     /// cases (408 Request Timeout, 429 Too Many Requests), all of which can reflect
@@ -669,6 +671,7 @@ impl OxenError {
             OxenError::HTTP(req_err) => req_err.status().is_some_and(is_fatal_http_status),
             OxenError::VersionsMissingOnServer { .. } => true,
             OxenError::VersionStoreDataMissing { .. } => true,
+            OxenError::UnknownRemoteResponseStatus(_) => true,
             _ => false,
         }
     }
@@ -1187,6 +1190,14 @@ mod tests {
         let err = OxenError::VersionsMissingOnServer {
             hashes: vec!["abc".to_string()],
         };
+        assert!(err.is_fatal_for_retry());
+    }
+
+    #[test]
+    fn is_fatal_for_retry_short_circuits_on_unknown_remote_response_status() {
+        // Unrecognized status field indicates protocol mismatch or a server bug —
+        // retrying won't change either.
+        let err = OxenError::UnknownRemoteResponseStatus("not-a-real-status".into());
         assert!(err.is_fatal_for_retry());
     }
 

--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -643,6 +643,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_find_missing_versions_returns_only_absent_hashes() {
+        let (_temp_dir, store) = setup().await;
+        let present = "aaaa1111aaaa1111";
+        let also_present = "bbbb2222bbbb2222";
+        let absent = "cccc3333cccc3333";
+        store.store_version(present, b"x").await.unwrap();
+        store.store_version(also_present, b"y").await.unwrap();
+
+        let missing = store
+            .find_missing_versions(&[
+                present.to_string(),
+                absent.to_string(),
+                also_present.to_string(),
+            ])
+            .await
+            .unwrap();
+        assert_eq!(missing, vec![absent.to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_find_missing_versions_empty_input_returns_empty() {
+        let (_temp_dir, store) = setup().await;
+        let missing = store.find_missing_versions(&[]).await.unwrap();
+        assert!(missing.is_empty());
+    }
+
+    #[tokio::test]
     async fn test_delete_version() {
         let (_temp_dir, store) = setup().await;
         let hash = "abcdef1234567890";

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -6,11 +6,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures_util::StreamExt;
 use serde::{Deserialize, Deserializer, Serialize};
 use tokio::io::AsyncRead;
 use tokio_stream::Stream;
 
 use crate::constants;
+use crate::constants::MAX_CONCURRENT_VERSION_PROBES;
 use crate::error::OxenError;
 use crate::opts::StorageOpts;
 use crate::storage::{LocalVersionStore, S3VersionStore};
@@ -312,6 +314,39 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// # Arguments
     /// * `hash` - The content hash to check
     async fn version_exists(&self, hash: &str) -> Result<bool, OxenError>;
+
+    /// Returns the subset of `hashes` whose blobs are absent from this store. Used by
+    /// bulk endpoints that need to fail fast on missing content before committing to
+    /// a streaming response.
+    ///
+    /// The default implementation probes each hash with `version_exists` in parallel,
+    /// bounded by `MAX_CONCURRENT_VERSION_PROBES`. Backends with cheaper batch-existence
+    /// primitives (e.g. a future inventory-backed store) may override.
+    ///
+    /// # Arguments
+    /// * `hashes` - The content hashes to check
+    async fn find_missing_versions(&self, hashes: &[String]) -> Result<Vec<String>, OxenError> {
+        if hashes.is_empty() {
+            return Ok(Vec::new());
+        }
+        let max_concurrent = MAX_CONCURRENT_VERSION_PROBES.min(hashes.len());
+
+        let mut probes = futures_util::stream::iter(hashes.iter().cloned())
+            .map(|hash| async move {
+                let exists = self.version_exists(&hash).await?;
+                Ok::<_, OxenError>((hash, exists))
+            })
+            .buffer_unordered(max_concurrent);
+
+        let mut missing = Vec::new();
+        while let Some(result) = probes.next().await {
+            let (hash, exists) = result?;
+            if !exists {
+                missing.push(hash);
+            }
+        }
+        Ok(missing)
+    }
 
     /// Delete a version
     ///

--- a/crates/server/src/controllers/versions.rs
+++ b/crates/server/src/controllers/versions.rs
@@ -223,6 +223,24 @@ pub async fn stream_versions_tar_gz(
     file_hashes: Vec<String>,
 ) -> Result<HttpResponse, OxenHttpError> {
     let version_store = repo.version_store()?;
+
+    // Pre-flight existence check before sending response headers. Once we commit to a
+    // 200 streaming response, a missing blob mid-stream truncates the connection and
+    // upstream proxies surface that as a 502 — masking the real cause and triggering
+    // client retries. Verifying every hash up front lets us return a structured 404
+    // listing the missing hashes so the client can fail fast.
+    let missing = version_store.find_missing_versions(&file_hashes).await?;
+    if !missing.is_empty() {
+        log::warn!(
+            "batch_download: {} of {} requested version blob(s) missing on server",
+            missing.len(),
+            file_hashes.len()
+        );
+        return Err(OxenHttpError::InternalOxenError(
+            OxenError::VersionsMissingOnServer { hashes: missing },
+        ));
+    }
+
     let (writer, reader) = tokio::io::duplex(DOWNLOAD_BUFFER_SIZE);
 
     let version_store_clone = version_store.clone();

--- a/crates/server/src/errors.rs
+++ b/crates/server/src/errors.rs
@@ -604,6 +604,31 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::Conflict().json(error_json)
                     }
+                    OxenError::VersionsMissingOnServer { hashes } => {
+                        log::warn!(
+                            "Versions missing on server: {} hash(es) absent from version store",
+                            hashes.len()
+                        );
+                        // Embed the missing hashes both in `detail` (so existing clients
+                        // see them in the rendered error) and as a typed `missing_hashes`
+                        // field (so future clients can parse them programmatically without
+                        // string-extracting from `detail`).
+                        let error_json = json!({
+                            "error": {
+                                "type": "version_blobs_missing",
+                                "title": "Version blobs missing on server",
+                                "detail": format!(
+                                    "Server is missing {} content blob(s) for this batch download. Missing hashes: {}",
+                                    hashes.len(),
+                                    hashes.join(", ")
+                                ),
+                                "missing_hashes": hashes,
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_RESOURCE_NOT_FOUND,
+                        });
+                        HttpResponse::NotFound().json(error_json)
+                    }
                     err => {
                         log::error!("Internal server error: {err:?}");
                         HttpResponse::InternalServerError()


### PR DESCRIPTION
When an `oxen pull` requested a content blob that the server's version store does not have, the client retried the bulk-download batch up to 5 times before surfacing the error — paying full exponential backoff (~57s in production) for an outcome that wouldn't change on retry. There were two root causes:

- The bulk versions endpoint streams its tarball starting from a 200 OK, so a blob missing mid-stream truncates the response. Intermediate proxies translate the truncation to 502 Bad Gateway, masking the real cause.
- The client's retry loop in `download_data_from_version_paths` classified every error other than `Authentication` as retryable, so even definitive 4xx responses paid the full backoff.

Server: `stream_versions_tar_gz` now pre-flights every requested hash via the new `VersionStore::find_missing_versions` trait method before sending response headers. If any are absent it returns a structured 404 (`VersionsMissingOnServer`) listing the missing hashes.

Client: `parse_status_and_message` and `handle_non_json_response` now return typed `HttpStatusError` / `HttpDeserializeError` variants that preserve the HTTP status code. A new `OxenError::is_fatal_for_retry` classifies 4xx responses, auth failures, and server-confirmed missing blobs as non-retryable. Both `download_data_from_version_paths` retry loops short-circuit on fatal errors so users see the diagnostic immediately instead of paying exponential backoff for a fixed outcome.

Closes ENG-1007