### PR TITLE
Report each failed request once instead of two or three times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,9 @@ tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.8", features = ["compat", "io", "io-util"] }
 toml = "0.8.19"
 tracing = "0.1"
-tracing-actix-web = "0.7"
+# `emit_event_on_error` (the crate's only default feature) is off; oxen-server reports every
+# failed request itself. See docs/error_handling.md.
+tracing-actix-web = { version = "0.7", default-features = false }
 tracing-appender = "0.2"
 tracing-log = "0.2"
 tracing-opentelemetry = "0.32"

--- a/crates/liboxen/src/namespaces.rs
+++ b/crates/liboxen/src/namespaces.rs
@@ -69,12 +69,12 @@ fn get_storage_for_repo(repo: &LocalRepository) -> Result<u64, OxenError> {
                 Ok(size_file.size)
             }
             repositories::size::SizeStatus::Error => {
-                log::warn!("Size calculation failed, returning 0");
+                tracing::error!(repo = ?repo.path, "Repo size calculation failed");
                 Err(OxenError::basic_str("Size calculation failed"))
             }
         },
         Err(e) => {
-            log::error!("repositories::namespaces::get_storage_for_repo error getting size: {e}");
+            tracing::error!(repo = ?repo.path, cause = ?e, "Error getting repo size");
             Err(e)
         }
     }

--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -119,7 +119,7 @@ pub fn get_by_namespace_and_name(
             OxenError::UnsupportedRepoVersion(version) => {
                 log::warn!("Unsupported repo on-disk version {version} at {repo_dir:?}")
             }
-            _ => log::error!("Error getting repo from dir {repo_dir:?}: {err:?}"),
+            _ => tracing::error!(repo_dir = ?repo_dir, cause = ?err, "Error getting repo from dir"),
         })
         .map(Some)
 }

--- a/crates/oxen-server/src/controllers/namespaces.rs
+++ b/crates/oxen-server/src/controllers/namespaces.rs
@@ -63,8 +63,8 @@ pub async fn show(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
                 log::debug!("404 Could not find namespace: {namespace}");
                 Err(OxenHttpError::NotFound)
             }
-            Err(err) => {
-                log::debug!("Err finding namespace: {namespace} => {err:?}");
+            Err(_) => {
+                // `get_storage_for_repo` reports the failure; it holds the repo that failed.
                 Err(OxenHttpError::InternalServerError)
             }
         }

--- a/crates/oxen-server/src/controllers/repositories.rs
+++ b/crates/oxen-server/src/controllers/repositories.rs
@@ -202,8 +202,8 @@ pub async fn stats(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
                 log::debug!("404 Could not find repo: {name}");
                 Ok(HttpResponse::NotFound().json(StatusMessage::resource_not_found()))
             }
-            Err(err) => {
-                log::debug!("Err finding repo: {name} => {err:?}");
+            Err(_) => {
+                // `get_by_namespace_and_name` reports the failure; it holds the repo directory.
                 Ok(
                     HttpResponse::InternalServerError()
                         .json(StatusMessage::internal_server_error()),

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -115,6 +115,8 @@ impl error::ResponseError for OxenHttpError {
         log::debug!("OxenHttpError: {self:?}");
         match self {
             OxenHttpError::InternalServerError => {
+                // Silent: this variant carries no detail, so the failure is reported before it
+                // is constructed, either at the construction site or by the callee.
                 HttpResponse::InternalServerError().json(StatusMessage::internal_server_error())
             }
             OxenHttpError::MultipartError(_) => {
@@ -823,17 +825,6 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::BadRequest().json(error_json)
                     }
-                    OxenError::Basic(error) | OxenError::InternalError(error) => {
-                        let error_json = json!({
-                            "error": {
-                                "type": MSG_INTERNAL_SERVER_ERROR,
-                                "title": format!("{}", error),
-                            },
-                            "status": STATUS_ERROR,
-                            "status_message": MSG_INTERNAL_SERVER_ERROR,
-                        });
-                        HttpResponse::InternalServerError().json(error_json)
-                    }
                     OxenError::LocalRepoNotFound(path) => {
                         log::debug!("Local repo not found: {path}");
                         let error_json = json!({
@@ -1061,8 +1052,7 @@ mod tests {
     fn test_client_mistakes_are_not_server_errors() {
         // Each of these is something a caller got wrong. As a 5xx each one alerted us and invited
         // the client to retry a request that can never succeed, so the status has to be a terminal
-        // 4xx. `tracing_actix_web` levels its own event off the response status, so getting the
-        // status right is also what stops the Sentry report.
+        // 4xx, reported at `warn!` rather than `error!`.
         let cases = [
             (
                 OxenError::NotAFile(PathBuf::from("some/dir").into()),

--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -88,10 +88,24 @@ and always formats into the message.
 **9. Match the log level to who is at fault.** `error_response` documents the convention: `error!`
 for a server-side defect, `warn!` for a request the caller got wrong, `debug!` when there is no
 identifying detail worth keeping. `error!` is what becomes a reported incident, so a 4xx logged at
-`error!` turns ordinary client traffic into alerts. Note that `tracing_actix_web` derives its own
-level from the response status, so getting the status right usually gets the level right for free.
+`error!` turns ordinary client traffic into alerts.
 
-**10. Test the classification. Never test the definition.**
+**10. Every 5xx is logged at `error!` exactly once, by whoever holds the detail.** Nothing else
+reports one: `tracing-actix-web`'s `emit_event_on_error` is disabled (see the workspace
+`Cargo.toml`), so an unlogged 5xx is **silent**. Where the log goes follows from who has the error:
+
+- The variant carries it: log in the `error_response` arm, the only place with the detail.
+- The variant is empty: the arm stays silent and the failure is reported before the variant is
+  constructed, either at the construction site or by the callee that returned the error.
+  `OxenHttpError::InternalServerError` is this case. A log in that arm would be a contextless
+  duplicate of a report that already carries the detail.
+
+Before adding a log anywhere on a 5xx path, check both directions for one that already exists: the
+callers that construct the error, and the callee that returned it. A liboxen function that logs in
+an `inspect_err` has already reported the failure, so a handler that logs again on the way out
+doubles it. This applies to handlers that build a 500 directly, not just to `error_response`.
+
+**11. Test the classification. Never test the definition.**
 
 Tests are for logic and interactions. A variant constructed directly is exactly what it was
 hard-coded to be, so asserting that proves nothing and costs a test to compile, run, and maintain


### PR DESCRIPTION
A single failure could raise three separate reports: an origin-site log, the error-response arm, and a second event the request middleware emits for every failed request. One condition then appeared as several unrelated issues, each needing its own triage, and event counts read several times busier than the real failure rate.

The middleware's duplicate event is now off. It was enabled only because it is a default feature of the crate, never a deliberate choice, and it added nothing the other reports lack. Request context comes from the per-request binding, so our own events already carry the method, URL, and transaction. Its message also embedded the error's debug output, so an identifier inside one split a single condition across many reports.

Reporting a server error is now the job of whichever code holds the detail. Two repository endpoints logged a failed lookup that the library function they call had already reported, so they now leave it to that function, which names the failing repository more precisely than the endpoint could. The generic internal-error response carried the error but logged nothing at all, leaving those 500s with no record anywhere, so it now reports through the shared path and returns the same body as before. The empty internal-error variant stays silent because it carries nothing worth saying, and every failure that reaches it is already reported.

The reports that remain group by condition rather than by value. Repository and namespace failures in the library interpolated a path and the error text into the message, splitting one condition into a separate issue per repository, and now log a constant message with those values as fields. Namespace size failures gained the repository path they never carried, and a failed size calculation reports at error level rather than warn, where it raised no alert at all.

The error handling doc records the obligation this creates, where the log belongs, and how to check that a report does not already exist.

ENG-1474