### PR TITLE
Return a client error instead of a server failure for a malformed data frame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5694,6 +5694,7 @@ dependencies = [
  "mockito",
  "os_path",
  "percent-encoding",
+ "polars",
  "regex",
  "rocksdb",
  "sanitize-filename",

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -8,6 +8,7 @@ use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use aws_smithy_runtime_api::client::result::SdkError;
 use duckdb::arrow::error::ArrowError;
 use http::Uri;
+use polars::prelude::PolarsError;
 use std::fmt::Write;
 use std::io;
 use std::num::ParseIntError;
@@ -18,6 +19,7 @@ use tokio::task::JoinError;
 use crate::api::requests::RepoNew;
 use crate::command::migrate::Direction;
 use crate::config::repository_config::RepoConfigError;
+use crate::core::db::data_frames::DataFrameError;
 use crate::core::db::merkle_node::merkle_node_db::MerkleDbError;
 use crate::lmdb::LmdbLayerError;
 use crate::model::MerkleHash;
@@ -892,6 +894,19 @@ impl OxenError {
         matches!(self, OxenError::ImageError(image::ImageError::Limits(_)))
     }
 
+    /// Did a polars operation fail on the server's own IO rather than on the caller's data? Every
+    /// other polars failure describes something wrong with the data or the query. Lives here for
+    /// the same reason as [`OxenError::is_unsupported_image_format`], and looks through
+    /// `PolarsError::Context`, which wraps the real error behind one layer per pipeline stage.
+    pub fn is_polars_io_error(&self) -> bool {
+        let error = match self {
+            OxenError::PolarsError(error) => error,
+            OxenError::DataFrameError(DataFrameError::Polars(error)) => error,
+            _ => return false,
+        };
+        matches!(innermost_polars_error(error), PolarsError::IO { .. })
+    }
+
     /// Is this error considered as something not existing?
     pub fn is_not_found(&self) -> bool {
         matches!(
@@ -932,6 +947,11 @@ impl OxenError {
             OxenError::VersionStoreDataMissing { .. } => true,
             OxenError::VersionStoreBlobMissing { .. } => true,
             OxenError::UnknownRemoteResponseStatus(_) => true,
+            // A malformed file or an unsatisfiable query reads the same way every time. Only the
+            // IO case can resolve on its own.
+            OxenError::PolarsError(_) | OxenError::DataFrameError(DataFrameError::Polars(_)) => {
+                !self.is_polars_io_error()
+            }
             _ => false,
         }
     }
@@ -1220,6 +1240,15 @@ impl From<JoinError> for OxenError {
     }
 }
 
+/// The error at the center of any `PolarsError::Context` wrappers, which polars adds one per
+/// pipeline stage. Returns the error itself when it carries no context.
+fn innermost_polars_error(mut error: &PolarsError) -> &PolarsError {
+    while let PolarsError::Context { error: inner, .. } = error {
+        error = inner;
+    }
+    error
+}
+
 // Manual From impls for types that need transformation
 impl From<String> for OxenError {
     fn from(error: String) -> Self {
@@ -1247,6 +1276,35 @@ impl From<BuildError> for OxenError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    /// Wraps `error` the way polars does, one `Context` layer per pipeline stage.
+    fn with_pipeline_context(error: PolarsError) -> PolarsError {
+        ["'parquet scan'", "'slice'", "'sink'"]
+            .into_iter()
+            .fold(error, |error, stage| PolarsError::Context {
+                error: Box::new(error),
+                msg: stage.into(),
+            })
+    }
+
+    #[test]
+    fn polars_io_failure_is_seen_through_the_pipeline_context() {
+        let buried = OxenError::PolarsError(with_pipeline_context(PolarsError::IO {
+            error: Arc::new(io::Error::from(io::ErrorKind::PermissionDenied)),
+            msg: None,
+        }));
+        assert!(buried.is_polars_io_error());
+
+        // A malformed file the caller supplied arrives wrapped the same way, and the wrapper is
+        // all these two have in common.
+        let malformed = OxenError::DataFrameError(DataFrameError::Polars(with_pipeline_context(
+            PolarsError::ComputeError(
+                "parquet: File out of specification: The file must end with PAR1".into(),
+            ),
+        )));
+        assert!(!malformed.is_polars_io_error());
+    }
 
     #[test]
     fn download_batch_exhausted_display_lists_paths_hashes_and_last_error() {

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -1288,22 +1288,43 @@ mod tests {
             })
     }
 
-    #[test]
-    fn polars_io_failure_is_seen_through_the_pipeline_context() {
-        let buried = OxenError::PolarsError(with_pipeline_context(PolarsError::IO {
+    /// Reading the stored file failed on the server's own IO, buried under the pipeline context.
+    fn buried_polars_io_failure() -> OxenError {
+        OxenError::PolarsError(with_pipeline_context(PolarsError::IO {
             error: Arc::new(io::Error::from(io::ErrorKind::PermissionDenied)),
             msg: None,
-        }));
-        assert!(buried.is_polars_io_error());
+        }))
+    }
 
-        // A malformed file the caller supplied arrives wrapped the same way, and the wrapper is
-        // all these two have in common.
-        let malformed = OxenError::DataFrameError(DataFrameError::Polars(with_pipeline_context(
+    /// A malformed file the caller supplied, wrapped the same way. The wrapper is all this and
+    /// [`buried_polars_io_failure`] have in common.
+    fn buried_malformed_data_frame() -> OxenError {
+        OxenError::DataFrameError(DataFrameError::Polars(with_pipeline_context(
             PolarsError::ComputeError(
                 "parquet: File out of specification: The file must end with PAR1".into(),
             ),
-        )));
-        assert!(!malformed.is_polars_io_error());
+        )))
+    }
+
+    #[test]
+    fn polars_io_failure_is_seen_through_the_pipeline_context() {
+        assert!(buried_polars_io_failure().is_polars_io_error());
+        assert!(!buried_malformed_data_frame().is_polars_io_error());
+    }
+
+    #[test]
+    fn only_a_polars_io_failure_is_worth_retrying() {
+        // `is_fatal_for_retry` short-circuits on auth and not-found before reaching the polars
+        // arm, and the arm inverts the IO question rather than answering it directly, so what a
+        // caller gets depends on three functions agreeing.
+        assert!(
+            !buried_polars_io_failure().is_fatal_for_retry(),
+            "an IO failure can resolve on its own, so a retry is worth paying for"
+        );
+        assert!(
+            buried_malformed_data_frame().is_fatal_for_retry(),
+            "a malformed file reads the same way every time, so backoff only delays the answer"
+        );
     }
 
     #[test]

--- a/crates/oxen-server/Cargo.toml
+++ b/crates/oxen-server/Cargo.toml
@@ -81,6 +81,9 @@ actix-multipart-test = { workspace = true }
 image = { workspace = true }
 liboxen = { workspace = true, features = ["test-utils"] }
 mockito = { workspace = true }
+# Only so the error-mapping tests can construct a `PolarsError`; the crate itself reaches data
+# frame handling through liboxen.
+polars = { workspace = true }
 # "test" swaps in a capturing transport, so the `tasks` tests can assert what reaches Sentry. Kept a
 # dev-dependency feature so the resolver leaves it out of the shipped binary.
 sentry = { workspace = true, features = ["test"] }

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -706,10 +706,14 @@ impl error::ResponseError for OxenHttpError {
                         HttpResponse::BadRequest().json(error_json)
                     }
                     OxenError::DUCKDB(error) => handle_duckdb(error),
-                    OxenError::PolarsError(error) => handle_polars(error),
-                    OxenError::DataFrameError(error) => match error {
+                    OxenError::PolarsError(polars_error) => {
+                        handle_polars(polars_error, error.is_polars_io_error())
+                    }
+                    OxenError::DataFrameError(data_frame_error) => match data_frame_error {
                         DataFrameError::DuckDb(error) => handle_duckdb(error),
-                        DataFrameError::Polars(error) => handle_polars(error),
+                        DataFrameError::Polars(polars_error) => {
+                            handle_polars(polars_error, error.is_polars_io_error())
+                        }
                         DataFrameError::SerdeJson(_) => handle_serde(),
                         DataFrameError::ColumnNameAlreadyExists(column_name) => {
                             log::warn!("Column Name Already Exists: {column_name}");
@@ -996,9 +1000,16 @@ fn handle_duckdb(error: &impl std::error::Error) -> HttpResponse {
     HttpResponse::BadRequest().json(error_json)
 }
 
-/// Convert a [`polars::error::PolarsError`] into a HTTP 500 error.
-fn handle_polars(error: &impl std::error::Error) -> HttpResponse {
-    log::error!("Polars error: {error:?}");
+/// Convert a [`polars::error::PolarsError`] into a HTTP 400, or a 500 when the failure was the
+/// server's own IO rather than the caller's data.
+fn handle_polars(error: &impl std::error::Error, is_server_side: bool) -> HttpResponse {
+    let status_message = if is_server_side {
+        tracing::error!(cause = ?error, "Polars error reading a data frame");
+        MSG_INTERNAL_SERVER_ERROR
+    } else {
+        tracing::warn!(cause = ?error, "Malformed data frame or query");
+        MSG_BAD_REQUEST
+    };
     let error_json = json!({
         "error": {
             "type": "data_frame_error",
@@ -1006,9 +1017,13 @@ fn handle_polars(error: &impl std::error::Error) -> HttpResponse {
             "detail": format!("{}", error),
         },
         "status": STATUS_ERROR,
-        "status_message": MSG_BAD_REQUEST,
+        "status_message": status_message,
     });
-    HttpResponse::InternalServerError().json(error_json)
+    if is_server_side {
+        HttpResponse::InternalServerError().json(error_json)
+    } else {
+        HttpResponse::BadRequest().json(error_json)
+    }
 }
 
 /// Convert a [`serde_json::Error`] into a HTTP bad request error.

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -1036,7 +1036,9 @@ mod tests {
     use super::*;
     use actix_web::ResponseError;
     use actix_web::http::StatusCode;
+    use polars::prelude::PolarsError;
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     #[test]
     fn test_unsupported_repo_version_is_a_client_error() {
@@ -1061,6 +1063,62 @@ mod tests {
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(!status.is_server_error());
+    }
+
+    /// Wraps `error` the way polars does, one `Context` layer per pipeline stage.
+    fn with_pipeline_context(error: PolarsError) -> PolarsError {
+        ["'parquet scan'", "'slice'", "'sink'"]
+            .into_iter()
+            .fold(error, |error, stage| PolarsError::Context {
+                error: Box::new(error),
+                msg: stage.into(),
+            })
+    }
+
+    /// The `status_message` the caller reads out of an error response body.
+    async fn status_message_of(response: HttpResponse) -> String {
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .expect("collect body");
+        let parsed: serde_json::Value = serde_json::from_slice(&body).expect("body parses as JSON");
+        parsed["status_message"]
+            .as_str()
+            .expect("body carries a status_message")
+            .to_string()
+    }
+
+    #[actix_web::test]
+    async fn test_data_frame_io_failure_is_reported_as_a_server_error() {
+        // Reading the stored file failed on our own IO, which the caller cannot act on. The
+        // status and the body have to agree, having once disagreed: a 500 whose body announced a
+        // bad request tells the caller and the reader two different things.
+        let error = OxenHttpError::from(OxenError::PolarsError(with_pipeline_context(
+            PolarsError::IO {
+                error: Arc::new(io::Error::from(io::ErrorKind::PermissionDenied)),
+                msg: None,
+            },
+        )));
+        let response = error.error_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(status_message_of(response).await, MSG_INTERNAL_SERVER_ERROR);
+    }
+
+    #[actix_web::test]
+    async fn test_malformed_data_frame_is_reported_as_a_client_error() {
+        // The caller supplied a file that will never parse. Arrives through `DataFrameError` and
+        // buried under the same pipeline context as the IO case above, so the status turns on
+        // reading through the wrapper rather than on which arm was written.
+        let error = OxenHttpError::from(OxenError::DataFrameError(DataFrameError::Polars(
+            with_pipeline_context(PolarsError::ComputeError(
+                "parquet: File out of specification: The file must end with PAR1".into(),
+            )),
+        )));
+        let response = error.error_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(!response.status().is_server_error());
+        assert_eq!(status_message_of(response).await, MSG_BAD_REQUEST);
     }
 
     #[test]


### PR DESCRIPTION
We were returning a 500 error when a parquet file was malformed. That's the wrong (it's a client problem if they provide a bad parquet file), and led to a retries that could never succeed. Now we return a 400 error, except when the failure was our own IO.

ENG-1539