### PR TITLE
Repo Integrity (1.17.1): Alert when a repo is missing data it references

### DIFF
--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -891,7 +891,7 @@ impl error::ResponseError for OxenHttpError {
                         HttpResponse::Conflict().json(error_json)
                     }
                     OxenError::VersionsMissingOnServer { hashes } => {
-                        log::warn!(
+                        log::error!(
                             "Versions missing on server: {} hash(es) absent from version store",
                             hashes.len()
                         );


### PR DESCRIPTION
A repo whose server lost a file now raises a Sentry issue the first time anyone asks for that file, instead of staying invisible until a customer reports a clone that will not finish. Until now the only way we learned about a broken repo was someone telling us.

ENG-1567