### PR TITLE
Return 404 for a path a revision does not contain

### DIFF
--- a/crates/liboxen/src/core/v_latest/commits.rs
+++ b/crates/liboxen/src/core/v_latest/commits.rs
@@ -1076,15 +1076,26 @@ pub fn list_by_path_from_paginated(
     // Check if the path is a directory or file
     let _perf_node = crate::perf_guard!("core::commits::get_node_by_path");
     let node = repositories::tree::get_node_by_path(repo, commit, path)?.ok_or_else(|| {
-        OxenError::basic_str(format!("Merkle tree node not found for path: {path:?}"))
+        OxenError::PathNotFoundInRevision {
+            path: path.to_path_buf().into(),
+            revision: commit.id.clone(),
+        }
     })?;
     let last_commit_id = match &node.node {
         EMerkleTreeNode::File(file_node) => file_node.last_commit_id(),
         EMerkleTreeNode::Directory(dir_node) => dir_node.last_commit_id(),
-        _ => {
-            return Err(OxenError::basic_str(format!(
-                "Merkle tree node not found for path: {path:?}"
-            )));
+        // A path resolves through `dir_hashes` to a directory or through `read_file` to a file,
+        // so any other kind here means the tree disagrees with itself rather than that the caller
+        // named something absent.
+        node => {
+            return Err(OxenError::InternalError(
+                format!(
+                    "Path {path:?} in commit {} resolved to a {:?} node, expected a file or directory",
+                    commit.id,
+                    node.node_type()
+                )
+                .into(),
+            ));
         }
     };
     let last_commit_id = last_commit_id.to_string();

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -254,6 +254,14 @@ pub enum OxenError {
     #[error("Resource not found: {0}")]
     ParsedResourceNotFound(PathBufError),
 
+    /// A path was requested in a revision whose tree does not contain it. Names the revision as
+    /// well as the path, so a report separates a mistyped path from the wrong revision.
+    #[error("{path} does not exist in {revision}")]
+    PathNotFoundInRevision {
+        path: PathBufError,
+        revision: String,
+    },
+
     //
     // Versioning
     //
@@ -905,6 +913,7 @@ impl OxenError {
                 | OxenError::QueryableWorkspaceNotFound
                 | OxenError::MerkleNodeNotFound(_)
                 | OxenError::DiffPathInNeitherRevision { .. }
+                | OxenError::PathNotFoundInRevision { .. }
         )
     }
 

--- a/crates/liboxen/src/repositories/commits.rs
+++ b/crates/liboxen/src/repositories/commits.rs
@@ -1453,6 +1453,35 @@ A: Oxen.ai
     }
 
     #[tokio::test]
+    async fn test_list_by_path_from_paginated_names_a_path_the_revision_lacks()
+    -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let commit = repositories::commits::head_commit(&repo)?;
+
+            let err = repositories::commits::list_by_path_from_paginated(
+                &repo,
+                &commit,
+                &PathBuf::from("no/such/path.txt"),
+                PaginateOpts::default(),
+            )
+            .await
+            .expect_err("a path the revision does not contain has no history");
+
+            // Names the revision alongside the path, which is what separates a mistyped path
+            // from asking the right path of the wrong revision.
+            let OxenError::PathNotFoundInRevision { path, revision } = &err else {
+                panic!("expected PathNotFoundInRevision, got {err:?}");
+            };
+            assert_eq!(path.to_string(), "no/such/path.txt");
+            assert_eq!(*revision, commit.id);
+            assert!(err.is_not_found());
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
     async fn test_list_by_path_from_paginated() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async move {
             let target_file_path = PathBuf::from("target_file.txt");

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -405,6 +405,19 @@ impl error::ResponseError for OxenHttpError {
                     // The next four are things a caller got wrong. Each returns a terminal 4xx at
                     // `warn!`, so it stops both the client retrying and the alert that a 5xx at
                     // `error!` raises.
+                    OxenError::PathNotFoundInRevision { path, revision } => {
+                        log::warn!("Path {path} requested in {revision}, which does not have it");
+                        let error_json = json!({
+                            "error": {
+                                "type": MSG_RESOURCE_NOT_FOUND,
+                                "title": "Path not in revision",
+                                "detail": format!("{path} does not exist in {revision}."),
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_RESOURCE_NOT_FOUND,
+                        });
+                        HttpResponse::NotFound().json(error_json)
+                    }
                     OxenError::DiffPathInNeitherRevision { path, base, head } => {
                         log::warn!("Diff requested for {path}, absent from {base} and {head}");
                         let error_json = json!({
@@ -1163,6 +1176,21 @@ mod tests {
             overflow.error_response().status(),
             StatusCode::PAYLOAD_TOO_LARGE
         );
+    }
+
+    #[test]
+    fn test_path_missing_from_a_revision_is_not_found() {
+        // Asking for the history of a path a revision does not contain is the caller naming
+        // something that is not there. As a 500 it alerted us and invited a retry that cannot
+        // change the answer.
+        let error = OxenError::PathNotFoundInRevision {
+            path: PathBuf::from("main").into(),
+            revision: "main".to_string(),
+        };
+        let status = OxenHttpError::from(error).error_response().status();
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert!(!status.is_server_error());
     }
 
     #[test]


### PR DESCRIPTION
Asking for the history of a path that is not in the requested revision returned HTTP 500. That told the caller the server was broken, invited a retry that could never succeed, and made a Sentry issue for a non-fixable problem. It now answers 404, and the error names the revision alongside the path, so a report separates a mistyped path from asking the right path of the wrong revision.

ENG-1559