### PR TITLE
Set retry policy on client for S3 mock to fix flaky test

### DIFF
--- a/crates/liboxen/src/storage/s3.rs
+++ b/crates/liboxen/src/storage/s3.rs
@@ -1215,6 +1215,8 @@ mod tests {
                 "test", "test", None, None, "test",
             ))
             .force_path_style(true)
+            // Production's client comes from aws_config and retries 5xx; a direct config must opt in.
+            .retry_config(aws_sdk_s3::config::retry::RetryConfig::standard())
             .build();
         Client::from_conf(config)
     }


### PR DESCRIPTION
Set retry policy on the client for the S3 mock to try fixing a flaky test. I'm not certain this is going to fix the problem, but it's worth trying and certainly won't hurt the test.

ENG-1543