### PR TITLE
Merkle LMDB (2.1): Default new repositories to the LMDB merkle node backend

### DIFF
--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
@@ -60,7 +60,7 @@ impl std::str::FromStr for MerkleNodeBackend {
 }
 
 /// The backend a newly created repo uses when the caller doesn't request a specific one.
-pub(crate) const DEFAULT_MERKLE_NODE_BACKEND: MerkleNodeBackend = MerkleNodeBackend::Filesystem;
+pub(crate) const DEFAULT_MERKLE_NODE_BACKEND: MerkleNodeBackend = MerkleNodeBackend::Lmdb;
 
 /// Engine-agnostic persistence for Merkle tree node bytes, keyed by [`MerkleHash`]. A node is two
 /// blobs (`node` + `children`); see the module docs for the layout. Implementations persist and

--- a/crates/liboxen/src/model/repository/local_repository.rs
+++ b/crates/liboxen/src/model/repository/local_repository.rs
@@ -835,6 +835,36 @@ mod tests {
         Ok(())
     }
 
+    /// Changing the backend new repos default to must not change how an existing repo loads: a
+    /// config recording the filesystem backend still resolves to filesystem.
+    #[test]
+    fn test_existing_filesystem_repo_still_loads_as_filesystem() -> Result<(), OxenError> {
+        use crate::core::db::merkle_node::MerkleNodeBackend;
+
+        let temp_dir = TempDir::new()?;
+        let repo = LocalRepository::new(
+            temp_dir.path(),
+            RepositoryConfig {
+                merkle_node_backend: Some(MerkleNodeBackend::Filesystem),
+                ..Default::default()
+            },
+        )?;
+        repo.save()?;
+
+        let reloaded = LocalRepository::from_dir(temp_dir.path())?;
+        assert_eq!(
+            reloaded.merkle_node_backend(),
+            MerkleNodeBackend::Filesystem
+        );
+        assert_ne!(
+            MerkleNodeBackend::Filesystem,
+            DEFAULT_MERKLE_NODE_BACKEND,
+            "this test only proves anything while filesystem is not the create default"
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn test_merkle_node_backend_persists_to_config() -> Result<(), OxenError> {
         use crate::core::db::merkle_node::MerkleNodeBackend;

--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -610,11 +610,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_defaults_to_filesystem_backend() -> Result<(), OxenError> {
+    async fn test_create_defaults_to_lmdb_backend() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|sync_dir| async move {
             let repo_new = RepoNew::from_namespace_name("ns", "repo", None);
             let repo = repositories::create(&sync_dir, repo_new, None).await?;
-            assert_eq!(repo.merkle_node_backend(), MerkleNodeBackend::Filesystem);
+            assert_eq!(repo.merkle_node_backend(), MerkleNodeBackend::Lmdb);
             Ok(())
         })
         .await
@@ -623,10 +623,11 @@ mod tests {
     #[tokio::test]
     async fn test_create_honors_requested_merkle_backend() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|sync_dir| async move {
+            // Requests the non-default backend, so this fails if the request is ignored.
             let mut repo_new = RepoNew::from_namespace_name("ns", "repo", None);
-            repo_new.merkle_node_backend = Some(MerkleNodeBackend::Lmdb);
+            repo_new.merkle_node_backend = Some(MerkleNodeBackend::Filesystem);
             let repo = repositories::create(&sync_dir, repo_new, None).await?;
-            assert_eq!(repo.merkle_node_backend(), MerkleNodeBackend::Lmdb);
+            assert_eq!(repo.merkle_node_backend(), MerkleNodeBackend::Filesystem);
             Ok(())
         })
         .await

--- a/crates/liboxen/src/repositories/fsck.rs
+++ b/crates/liboxen/src/repositories/fsck.rs
@@ -409,7 +409,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_scan_node_format_finds_planted_pre_v0_25_node() -> Result<(), OxenError> {
-        test::run_one_commit_local_repo_test_async(|repo| async move {
+        // Pins the filesystem backend: the planting below rewrites raw bytes under
+        // `.oxen/tree/nodes`, a layout only the pre-0.25 backend produces.
+        test::run_one_commit_local_repo_test_async_fs_backend(|repo| async move {
             let clean = scan_node_format(&repo)?;
             assert!(
                 !clean.is_affected(),


### PR DESCRIPTION
New repositories created by the server and by the client now use LMDB instead of the filesystem backend. Backend resolution reads the persisted config first and falls back to on-disk detection, neither of which consults the create default, and clients can still ask for the filesystem backend explicitly by passing a flag when creating a remote repo with the oxen CLI.

ENG-1357