### PR TITLE
Stop an unreadable data frame from alerting on every read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4757,9 +4757,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 dependencies = [
  "value-bag",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ libduckdb-sys = { version = "=1.10504.0" }
 # resolve liboxen from crates.io when published.
 liboxen = { path = "crates/liboxen", version = "=0.52.10" }
 lofty = "0.22.2"
-log = "0.4.20"
+log = "0.4.33"
 lru = "0.14.0"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.16"

--- a/crates/liboxen/src/core/v_latest/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/data_frames.rs
@@ -6,8 +6,7 @@ use crate::model::ParsedResource;
 use crate::model::data_frame::{DataFrameSchemaSize, DataFrameSlice, DataFrameSliceSchemas};
 use crate::model::merkle_tree::node::EMerkleTreeNode;
 use crate::model::metadata::generic_metadata::GenericMetadata;
-use crate::model::metadata::metadata_tabular::MetadataTabularImpl;
-use crate::model::{Commit, DataFrameSize, LocalRepository, Schema};
+use crate::model::{Commit, DataFrameSize, EntryDataType, LocalRepository, Schema};
 use crate::opts::DFOpts;
 use crate::repositories;
 use polars::prelude::IntoLazy as _;
@@ -64,20 +63,27 @@ pub async fn get_slice(
 
     log::debug!("get_slice file_node {file_node:?}");
 
-    let metadata: Result<MetadataTabularImpl, OxenError> = match file_node.metadata() {
-        Some(metadata) => match metadata {
-            GenericMetadata::MetadataTabular(metadata) => Ok(metadata.tabular.clone()),
-            _ => {
-                return Err(OxenError::basic_str("Metadata is not tabular"));
-            }
-        },
-        None => {
+    let metadata = match file_node.metadata() {
+        Some(GenericMetadata::MetadataTabular(metadata)) => metadata.tabular.clone(),
+        // Only a tabular node is expected to carry tabular metadata, so any other node type means
+        // the caller asked for a data frame view of a file that is not one. A tabular node with no
+        // metadata is the damaged case, and names itself separately.
+        _ if *file_node.data_type() != EntryDataType::Tabular => {
+            return Err(OxenError::InvalidFileType(
+                format!(
+                    "{} is a {} file, which cannot be read as a data frame",
+                    path.as_ref().display(),
+                    file_node.data_type()
+                )
+                .into(),
+            ));
+        }
+        _ => {
             return Err(OxenError::TabularFileMissingMetadata(
                 path.as_ref().to_path_buf().into(),
             ));
         }
     };
-    let metadata = metadata?;
     log::debug!("get_slice metadata {metadata:?}");
 
     let source_schema = metadata.schema;

--- a/crates/liboxen/src/core/v_latest/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/data_frames.rs
@@ -72,7 +72,9 @@ pub async fn get_slice(
             }
         },
         None => {
-            return Err(OxenError::basic_str("File node does not have metadata"));
+            return Err(OxenError::TabularFileMissingMetadata(
+                path.as_ref().to_path_buf().into(),
+            ));
         }
     };
     let metadata = metadata?;

--- a/crates/liboxen/src/core/v_latest/workspaces/commit.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/commit.rs
@@ -430,7 +430,7 @@ async fn compute_staged_merkle_tree_node(
 
     // A tabular file we cannot parse must never be committed: a FileNode with
     // data_type Tabular and no metadata makes every subsequent read of the
-    // file fail with "File node does not have metadata". This happens when
+    // file fail with `TabularFileMissingMetadata`. This happens when
     // the exported data frame is empty (e.g. all rows were staged as removed
     // — an empty jsonl/csv has no schema to infer). Failing the commit keeps
     // the last good version readable.

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -215,6 +215,12 @@ pub enum OxenError {
     )]
     TabularExportMissingMetadata(PathBuf),
 
+    /// A committed file is typed as tabular but carries no metadata, so it has no schema to serve
+    /// a data frame from. Distinct from [`OxenError::TabularExportMissingMetadata`], which refuses
+    /// the commit that would create such a file.
+    #[error("{0} has no tabular metadata, so it cannot be read as a data frame")]
+    TabularFileMissingMetadata(PathBufError),
+
     /// Adding a file into a workspace
     #[error("{0}")]
     ImportFileError(StringError),
@@ -867,6 +873,9 @@ impl OxenError {
             TabularExportMissingMetadata(_) => {
                 "The data frame has no rows to commit. Add at least one row, or discard the workspace edits, then retry."
             }
+            TabularFileMissingMetadata(_) => {
+                "Commit a new version of this file with at least one row to make it readable as a data frame."
+            }
             _ => return None,
         }
         .to_string();
@@ -956,6 +965,7 @@ impl OxenError {
             OxenError::VersionStoreDataMissing { .. } => true,
             OxenError::VersionStoreBlobMissing { .. } => true,
             OxenError::UnknownRemoteResponseStatus(_) => true,
+            OxenError::TabularFileMissingMetadata(_) => true,
             // A malformed file or an unsatisfiable query reads the same way every time. Only the
             // IO case can resolve on its own.
             OxenError::PolarsError(_) | OxenError::DataFrameError(DataFrameError::Polars(_)) => {

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -966,6 +966,7 @@ impl OxenError {
             OxenError::VersionStoreBlobMissing { .. } => true,
             OxenError::UnknownRemoteResponseStatus(_) => true,
             OxenError::TabularFileMissingMetadata(_) => true,
+            OxenError::InvalidFileType(_) => true,
             // A malformed file or an unsatisfiable query reads the same way every time. Only the
             // IO case can resolve on its own.
             OxenError::PolarsError(_) | OxenError::DataFrameError(DataFrameError::Polars(_)) => {

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -938,7 +938,7 @@ mod tests {
             // Committing now would export an empty jsonl file — no schema can
             // be inferred from it, so the commit must fail instead of writing
             // a Tabular FileNode with no metadata (which would make every
-            // subsequent read fail with "File node does not have metadata").
+            // subsequent read fail with `TabularFileMissingMetadata`).
             let new_commit = NewCommitBody {
                 author: "author".to_string(),
                 email: "email".to_string(),

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -842,6 +842,21 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::BadRequest().json(error_json)
                     }
+                    // A data frame was requested for a file that is not tabular. The file's type
+                    // does not change on retry, so the status is terminal.
+                    OxenError::InvalidFileType(detail) => {
+                        log::warn!("Data frame requested for a non-tabular file: {detail}");
+                        let error_json = json!({
+                            "error": {
+                                "type": "invalid_file_type",
+                                "title": "Not a tabular file",
+                                "detail": format!("{detail}"),
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_BAD_REQUEST,
+                        });
+                        HttpResponse::BadRequest().json(error_json)
+                    }
                     // Terminal, not transient: the file was committed without a schema and no
                     // amount of retrying gives it one, so a 5xx would invite a retry loop that
                     // re-reports the same unreadable file on every attempt.
@@ -1161,6 +1176,21 @@ mod tests {
         let response = error.error_response();
 
         assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(!response.status().is_server_error());
+        assert_eq!(status_message_of(response).await, MSG_BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn test_data_frame_request_for_a_non_tabular_file_is_a_client_error() {
+        // The caller pointed the data frame endpoint at a file that is not a data frame. That is
+        // the caller's own mistake and no retry changes the file's type, so it must be terminal
+        // and must not read as server breakage.
+        let error = OxenHttpError::from(OxenError::InvalidFileType(
+            "photo.png is a image file, which cannot be read as a data frame".into(),
+        ));
+        let response = error.error_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         assert!(!response.status().is_server_error());
         assert_eq!(status_message_of(response).await, MSG_BAD_REQUEST);
     }

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -842,6 +842,22 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::BadRequest().json(error_json)
                     }
+                    // Terminal, not transient: the file was committed without a schema and no
+                    // amount of retrying gives it one, so a 5xx would invite a retry loop that
+                    // re-reports the same unreadable file on every attempt.
+                    OxenError::TabularFileMissingMetadata(path) => {
+                        log::warn!("Data frame read refused, {path} has no tabular metadata");
+                        let error_json = json!({
+                            "error": {
+                                "type": "tabular_metadata_missing",
+                                "title": "File has no tabular metadata",
+                                "detail": format!("{path} was committed without a tabular schema, so it cannot be read as a data frame. Commit a new version of it with at least one row."),
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_BAD_REQUEST,
+                        });
+                        HttpResponse::UnprocessableEntity().json(error_json)
+                    }
                     OxenError::LocalRepoNotFound(path) => {
                         log::debug!("Local repo not found: {path}");
                         let error_json = json!({
@@ -1130,6 +1146,21 @@ mod tests {
         let response = error.error_response();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(!response.status().is_server_error());
+        assert_eq!(status_message_of(response).await, MSG_BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn test_tabular_file_without_metadata_is_terminal_for_the_caller() {
+        // Neither the caller's mistake nor a transient fault: the file was committed without a
+        // schema. A 5xx would alert on every read and invite the retry that repeats it, so the
+        // status has to be terminal even though the caller did nothing wrong.
+        let error = OxenHttpError::from(OxenError::TabularFileMissingMetadata(
+            PathBuf::from("chat_history.jsonl").into(),
+        ));
+        let response = error.error_response();
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
         assert!(!response.status().is_server_error());
         assert_eq!(status_message_of(response).await, MSG_BAD_REQUEST);
     }


### PR DESCRIPTION
A file committed as tabular but without metadata can never be read as a data frame, yet every attempt returned HTTP 500. This was resulting in an unbounded stream of error reports in Sentry.

Now we return a `422 Unprocessable Entity` error. The status is terminal, so a client that retries on 5xx stops re-requesting a file that will never load, and the condition no longer reports as server breakage. The error carries the path, so a report names the affected file rather than describing the condition in the abstract.

Committing such a file has been refused since the `TabularExportMissingMetadata` guard landed.

I also threw in a version bump for the `log` dependency.