### PR TITLE
Hash a file without metadata the same way in every writer

### DIFF
--- a/crates/liboxen/src/core/v_latest/data_frames/schemas.rs
+++ b/crates/liboxen/src/core/v_latest/data_frames/schemas.rs
@@ -267,14 +267,14 @@ pub fn add_schema_metadata(
     }
 
     let oxen_metadata = &file_node.metadata();
-    let oxen_metadata_hash = util::hasher::get_metadata_hash(oxen_metadata)?;
+    let oxen_metadata_hash = util::hasher::maybe_get_metadata_hash(oxen_metadata)?;
     let combined_hash =
-        util::hasher::get_combined_hash(Some(oxen_metadata_hash), file_node.hash().to_u128())?;
+        util::hasher::get_combined_hash(oxen_metadata_hash, file_node.hash().to_u128())?;
 
     let mut file_node = staged_entry.node.file()?;
 
     file_node.set_name(path.to_str().unwrap());
-    file_node.set_metadata_hash(Some(MerkleHash::new(oxen_metadata_hash)));
+    file_node.set_metadata_hash(oxen_metadata_hash.map(MerkleHash::new));
     file_node.set_combined_hash(&MerkleHash::new(combined_hash));
 
     staged_entry.node = MerkleTreeNode::from_file(file_node);
@@ -392,15 +392,15 @@ pub fn add_column_metadata(
     }
 
     let oxen_metadata = &file_node.metadata();
-    let oxen_metadata_hash = util::hasher::get_metadata_hash(oxen_metadata)?;
+    let oxen_metadata_hash = util::hasher::maybe_get_metadata_hash(oxen_metadata)?;
     let combined_hash =
-        util::hasher::get_combined_hash(Some(oxen_metadata_hash), file_node.hash().to_u128())?;
+        util::hasher::get_combined_hash(oxen_metadata_hash, file_node.hash().to_u128())?;
 
     let mut file_node = staged_entry.node.file()?;
 
     file_node.set_name(path.to_str().unwrap());
     file_node.set_combined_hash(&MerkleHash::new(combined_hash));
-    file_node.set_metadata_hash(Some(MerkleHash::new(oxen_metadata_hash)));
+    file_node.set_metadata_hash(oxen_metadata_hash.map(MerkleHash::new));
 
     staged_entry.node = MerkleTreeNode::from_file(file_node);
 

--- a/crates/liboxen/src/core/v_latest/workspaces/commit.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/commit.rs
@@ -452,9 +452,12 @@ async fn compute_staged_merkle_tree_node(
             .update_metadata_from_schema(&staged_schema);
     }
 
-    // Compute the metadata hash and combined hash
-    let metadata_hash = util::hasher::get_metadata_hash(&metadata)?;
-    let combined_hash = util::hasher::get_combined_hash(Some(metadata_hash), hash.to_u128())?;
+    // Absent metadata leaves the metadata hash unset and the combined hash equal to the content
+    // hash, the same convention `add` and `FileNode::recompute_metadata_hashes` follow. A file's
+    // combined hash feeds the vnode and dir node hashes, so one convention across every writer is
+    // what keeps identical content under one tree identity.
+    let metadata_hash = util::hasher::maybe_get_metadata_hash(&metadata)?;
+    let combined_hash = util::hasher::get_combined_hash(metadata_hash, hash.to_u128())?;
     let combined_hash = MerkleHash::new(combined_hash);
 
     // Copy file to the version store
@@ -474,7 +477,7 @@ async fn compute_staged_merkle_tree_node(
         name: relative_path_str.to_string(),
         hash,
         combined_hash,
-        metadata_hash: Some(MerkleHash::new(metadata_hash)),
+        metadata_hash: metadata_hash.map(MerkleHash::new),
         num_bytes,
         last_modified_seconds: mtime.unix_seconds(),
         last_modified_nanoseconds: mtime.nanoseconds(),


### PR DESCRIPTION
Three writers computed a file node's metadata and combined hashes, and the two that took an `Option` handled an absent value differently from `add`: they hashed the string "null" and stored it as a real metadata hash, giving identical content two different tree identities depending on which path committed it.

All three now leave the metadata hash unset and the combined hash equal to the content hash when there is no metadata, matching `add` and `FileNode::recompute_metadata_hashes`. Behavior is unchanged when metadata is present.

No behavior changes today: every path reaching these writers is currently gated so that metadata is always present. This removes the trap for whoever relaxes one of those guards, since a combined hash feeds the vnode and dir node hashes and a disagreement there is silent.