### PR TITLE
Stop CI's Python job from racing oxen-server startup

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -264,7 +264,20 @@ jobs:
 
       - name: Start oxen-server (Linux/macOS)
         if: matrix.platform != 'windows'
-        run: ./target/debug/oxen-server start &
+        run: |
+          ./target/debug/oxen-server start > oxen-server.log 2>&1 &
+          # Wait for the server to accept connections before any test needs one. Without this the
+          # CLI tests race startup, and the loser reports a connection error that reads like a
+          # product bug rather than a server that was not up yet.
+          for i in $(seq 1 100); do
+            if curl -sf http://localhost:3000/api/health >/dev/null 2>&1; then break; fi
+            if [ "$i" -eq 100 ]; then
+              echo "oxen-server did not become healthy"
+              cat oxen-server.log
+              exit 1
+            fi
+            sleep 0.1
+          done
 
       # CLI Tests
       - name: Run CLI tests (Linux/macOS)


### PR DESCRIPTION
The job started the server and went straight to the tests, so whether they passed depended on the server binding before the first request. It takes about two seconds locally, which is usually less than the dependency sync that follows, which is why this failed only occasionally and looked like a product bug: the tests reported a refused connection from create-remote.

The job now waits for /api/health the way the Rust job already does, and prints the server log if it never comes up.