### PR TITLE
Improve README: route users properly, improve keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ See [FmtSpan Events](crates/oxen-server/README.md#fmtspan-events) for details.
 
 Oxen was built by a team of machine learning engineers, who have spent countless hours in their careers managing datasets. We have used many different tools, but none of them were as easy to use and as ergonomic as we would like.
 
-If you have ever tried [git lfs](https://git-lfs.com/) to version large datasets and became frustrated, we feel your pain. Solutions like git-lfs are too slow when it comes to the scale of data we need for machine learning.
+If you have ever tried Git LFS to version large datasets and became frustrated, we feel your pain. We built Oxen as a fast alternative to Git LFS and DVC, designed for the scale of data AI and ML teams work with.
 
 If you have ever uploaded a large dataset of images, audio, video, or text to a cloud storage bucket with the name:
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ See [FmtSpan Events](crates/oxen-server/README.md#fmtspan-events) for details.
 
 Oxen was built by a team of machine learning engineers, who have spent countless hours in their careers managing datasets. We have used many different tools, but none of them were as easy to use and as ergonomic as we would like.
 
-If you have ever tried Git LFS to version large datasets and became frustrated, we feel your pain. Solutions like Git LFS are unwieldy and painfully slow in practice. We needed a faster alternative to Git LFS and DVC, designed for the scale of data AI and ML teams work with.
+If you have ever tried Git LFS to version large datasets and became frustrated, we feel your pain. Solutions like Git LFS are unwieldy and painfully slow in practice. We needed a faster alternative designed for large datasets.
 
 If you have ever uploaded a large dataset of images, audio, video, or text to a cloud storage bucket with the name:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 Oxen is a lightning fast data version control system for large datasets. We aim to make versioning data as easy as versioning code.
 
-The interface mirrors git, but shines in many areas that git or git-lfs fall short. Oxen is built from the ground up for any data type, and is optimized to handle repositories with millions of files and scales to terabytes of data.
+The interface mirrors git, but shines where git and git-lfs fall short. Oxen is built from the ground up for any data type, from machine learning training data and model weights to game assets and studio media, and is optimized to handle repositories with millions of files and terabytes of data.
 
 ```bash
 oxen init

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ See [FmtSpan Events](crates/oxen-server/README.md#fmtspan-events) for details.
 
 Oxen was built by a team of machine learning engineers, who have spent countless hours in their careers managing datasets. We have used many different tools, but none of them were as easy to use and as ergonomic as we would like.
 
-If you have ever tried Git LFS to version large datasets and became frustrated, we feel your pain. We built Oxen as a fast alternative to Git LFS and DVC, designed for the scale of data AI and ML teams work with.
+If you have ever tried Git LFS to version large datasets and became frustrated, we feel your pain. Solutions like Git LFS are unwieldy and painfully slow in practice. We needed a faster alternative to Git LFS and DVC, designed for the scale of data AI and ML teams work with.
 
 If you have ever uploaded a large dataset of images, audio, video, or text to a cloud storage bucket with the name:
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ oxen commit "Adding 200k images and their corresponding annotations"
 oxen push origin main
 ```
 
-Oxen is comprised of a [command line
-interface](https://docs.oxen.ai/getting-started/cli), as well as bindings for
-[Rust](https://github.com/Oxen-AI/Oxen/tree/main/crates) 🦀, [Python](https://docs.oxen.ai/getting-started/python) 🐍, and [HTTP interfaces](https://docs.oxen.ai/http-api) 🌎 to make it easy to integrate into your workflow.
+Use Oxen through the [oxen CLI](https://docs.oxen.ai/getting-started/cli), the [oxenai](https://docs.oxen.ai/getting-started/python) Python package 🐍, or the [HTTP API](https://docs.oxen.ai/http-api), and host your repositories on [Oxen.ai](https://oxen.ai) or self host the [oxen-server](https://github.com/Oxen-AI/Oxen/tree/main/crates/oxen-server) on your own storage. You can also embed the same [liboxen](https://crates.io/crates/liboxen) crate 🦀 that powers all of it.
 
 ## 🌾 What kind of data?
 


### PR DESCRIPTION
The README is pretty important beyond informing people who stumble across our repo.
* crates.io indexes it for search (weight 0.1)
* agents grep it when they land on the repo
* Google assembles the repo's search snippet from its passages

In particular, we want it to route people towards our website, both for storing their repos and the other features like fine tuning and inference, which we barely did at all before. We also had some keywords missing: "alternative" (think searching "git lfs alternative"), "training", "AI", "ML", "DVC". Also we were linking directly to git LFS for no good reason.

### On the intro

I added examples to the "any data type" sentence (machine learning training data, model weights, game assets, studio media) which both adds concrete use cases to the intro and lets people understand why Oxen might be useful to them. Machine learning previously didn't appear until line 291. I also simplified the grammar in the git comparison sentence.

### Components of oxen

The line about the different things we distribute was not very clear, not effective at routing people where they need to go, and contained filler. Most users should get pointed to the hub (oxen.ai), and everyone else should immediately see the self host path or the actual tool they need.

I made it route people to our actual website for the place they most likely want to store their repositories, provided explicitly as an alternative to self hosting on your own storage. I also reframed the CLI, Python package, and HTTP API as ways to interact with the remote and made it actually explain what the liboxen crate is for.

### Why build Oxen

I tweaked the wording to match terms that people actually search for and mentioned "alternative to" and DVC. Comparison sites and a GitHub topic exist purely to farm "git lfs alternative", and similarly a lot of the comparison articles are to DVC. I also took that opportunity to use the AI and ML keywords.

I removed the link to the git lfs website because (a) it sends a frustrated Git LFS user straight back to Git LFS and (b) it makes no sense for us to give a direct link to our competitor's website.