### PR TITLE
Group small-entry transfers with div_ceil so exact-multiple sizes stop overshooting by a chunk

### DIFF
--- a/crates/liboxen/src/core/v_latest/fetch.rs
+++ b/crates/liboxen/src/core/v_latest/fetch.rs
@@ -731,7 +731,7 @@ async fn pull_small_entries(
     // Never zero: `chunk_size` below divides by `num_chunks`.
     let num_chunks = total_size.div_ceil(stream_segment_size()).max(1) as usize;
 
-    let mut chunk_size = entries.len() / num_chunks;
+    let mut chunk_size = entries.len().div_ceil(num_chunks);
     if num_chunks > entries.len() {
         chunk_size = entries.len();
     }
@@ -974,7 +974,7 @@ async fn download_small_entries(
     // Never zero: `chunk_size` below divides by `num_chunks`.
     let num_chunks = total_size.div_ceil(stream_segment_size()).max(1) as usize;
 
-    let mut chunk_size = entries.len() / num_chunks;
+    let mut chunk_size = entries.len().div_ceil(num_chunks);
     if num_chunks > entries.len() {
         chunk_size = entries.len();
     }

--- a/crates/liboxen/src/core/v_latest/fetch.rs
+++ b/crates/liboxen/src/core/v_latest/fetch.rs
@@ -728,8 +728,8 @@ async fn pull_small_entries(
 
     let total_size = repositories::entries::compute_entries_size(&entries)?;
 
-    // Compute num chunks
-    let num_chunks = ((total_size / stream_segment_size()) + 1) as usize;
+    // Never zero: `chunk_size` below divides by `num_chunks`.
+    let num_chunks = total_size.div_ceil(stream_segment_size()).max(1) as usize;
 
     let mut chunk_size = entries.len() / num_chunks;
     if num_chunks > entries.len() {
@@ -971,8 +971,8 @@ async fn download_small_entries(
 
     let total_size = repositories::entries::compute_entries_size(&entries)?;
 
-    // Compute num chunks
-    let num_chunks = ((total_size / stream_segment_size()) + 1) as usize;
+    // Never zero: `chunk_size` below divides by `num_chunks`.
+    let num_chunks = total_size.div_ceil(stream_segment_size()).max(1) as usize;
 
     let mut chunk_size = entries.len() / num_chunks;
     if num_chunks > entries.len() {


### PR DESCRIPTION
Both `pull_small_entries` and `download_small_entries` sized their chunk groups with the `(total / segment) + 1` idiom the repo guidelines warn against. When `total_size` is an exact multiple of the segment size it asked for one more group than needed, yielding marginally smaller groups. 

Swapping in `div_ceil` on its own would have introduced a panic: it returns 0 when every entry is zero bytes, and the next line divides `entries.len()` by that count. The `.max(1)` floor keeps the divisor non-zero, which the `+ 1` form had been providing by accident.

Fixed a similar problem with `chunk_size`, where it should only be `0` when the number of entries is `0`.

ENG-1229