### PR TITLE
S3 (28): Scope S3 object keys by repository name alone

### DIFF
--- a/SelfHosting.md
+++ b/SelfHosting.md
@@ -82,7 +82,7 @@ s3_region = "us-west-1"      # required iff "s3" is in backends
 ```
 
 - **`backends`** — a list of which storage kinds this server is willing to host. The valid values are `"local"` (local-filesystem version storage) and `"s3"` (S3 version storage), spelled in lowercase. The first element is the server's default: when a client creates a new repo without specifying a kind, the server uses that. Each kind must appear at most once; the list must be non-empty.
-- **`s3_bucket`** — the S3 bucket the server uses for any S3-backed repo. Required when `"s3"` appears in `backends` and rejected when it doesn't. Each repo gets the prefix `{namespace}/{name}/` inside this bucket; the prefix is not configurable per repo.
+- **`s3_bucket`** — the S3 bucket the server uses for any S3-backed repo. Required when `"s3"` appears in `backends` and rejected when it doesn't. Each repo gets the prefix `{name}/` inside this bucket, where `{name}` is the repository name; the prefix is not configurable per repo. Because the namespace is not part of the prefix, moving a repo to another namespace leaves its stored objects where they are.
   - **`s3_region`** — the AWS region the bucket lives in (e.g. `us-west-1`). Required when `"s3"` appears in `backends`. The server uses it to build the S3 client directly rather than detecting it at runtime; if it's wrong, startup fails when the bucket reachability check runs.
 
 Omitting the `[storage]` section entirely is equivalent to:

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -342,13 +342,10 @@ pub enum OxenError {
     )]
     S3BackendMissingServerOpts,
 
-    /// `create_version_store` could not derive the S3 object prefix from the repo path because the
-    /// path lacks the expected `<namespace>/<name>` tail. Server repo paths are always built as
-    /// `<sync_dir>/<namespace>/<name>`, so this only surfaces for malformed callers — but we
-    /// surface it as a structured error rather than panicking.
-    #[error(
-        "Cannot derive S3 object prefix from repo path {0}: expected `<namespace>/<name>` tail"
-    )]
+    /// `create_version_store` could not derive the S3 object prefix from the repo path: the path
+    /// has no final component, or that component is not valid UTF-8. Server repo paths always end
+    /// in the repo directory, so this only surfaces for malformed callers.
+    #[error("Cannot derive S3 object prefix from repo path {0}: expected a UTF-8 directory name")]
     S3PrefixUnresolvable(PathBufError),
 
     /// `oxen restore` finished with one or more file-restore failures. Aggregated rather than

--- a/crates/liboxen/src/storage/s3.rs
+++ b/crates/liboxen/src/storage/s3.rs
@@ -1188,7 +1188,7 @@ mod tests {
             Arc::new(client),
             bucket,
             "us-west-1".to_string(),
-            "test-namespace/test-repo".to_string(),
+            "test-repo".to_string(),
             Some(format!("http://{addr}")),
         );
 
@@ -1242,7 +1242,7 @@ mod tests {
             Arc::clone(&client),
             "test-bucket".to_string(),
             "us-west-1".to_string(),
-            "ns/repo".to_string(),
+            "repo".to_string(),
             Some(format!("http://{addr}")),
         );
         // A sibling repo whose prefix extends this store's prefix must survive the destroy.
@@ -1250,7 +1250,7 @@ mod tests {
             client,
             "test-bucket".to_string(),
             "us-west-1".to_string(),
-            "ns/repo2".to_string(),
+            "repo2".to_string(),
             Some(format!("http://{addr}")),
         );
 
@@ -1330,10 +1330,7 @@ mod tests {
                 region,
                 endpoint_url,
             } => {
-                assert_eq!(
-                    url,
-                    format!("s3://{}/test-namespace/test-repo/{hash}/data", store.bucket)
-                );
+                assert_eq!(url, format!("s3://{}/test-repo/{hash}/data", store.bucket));
                 assert_eq!(region, "us-west-1");
                 let endpoint = endpoint_url.expect("test setup configures a loopback endpoint");
                 assert!(

--- a/crates/liboxen/src/storage/version_store.rs
+++ b/crates/liboxen/src/storage/version_store.rs
@@ -504,9 +504,9 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
 ///
 /// `server_s3_opts` is the server-wide S3 configuration (bucket name). It must be `Some`
 /// whenever `config.kind == StorageKind::S3`; CLI and test paths pass `None` because they never
-/// run with the S3 backend enabled. The S3 prefix is derived from the repo path's
-/// `<namespace>/<name>` tail at construction time and never written to per-repo config, so the
-/// server can rotate buckets without rewriting every repo.
+/// run with the S3 backend enabled. The S3 prefix is the repo directory's name, derived at
+/// construction time and never written to per-repo config, so the server can rotate buckets
+/// without rewriting every repo.
 pub fn create_version_store(
     repo_dir: &Path,
     config: &StorageConfig,
@@ -532,20 +532,14 @@ pub fn create_version_store(
         }
         StorageKind::S3 => {
             let opts = server_s3_opts.ok_or(OxenError::S3BackendMissingServerOpts)?;
-            // Server repo paths are always `<sync_dir>/<namespace>/<name>` (the only path that
-            // reaches the S3 branch), so the tail components should always be present. We still
-            // surface a structured error instead of panicking on a malformed caller.
-            let name = repo_dir
+            // The prefix is the repo directory's name alone, so an object's key is independent
+            // of the namespace the repo currently sits under.
+            let prefix = repo_dir
                 .file_name()
                 .and_then(|s| s.to_str())
                 .ok_or_else(|| OxenError::S3PrefixUnresolvable(repo_dir.into()))?;
-            let namespace = repo_dir
-                .parent()
-                .and_then(|p| p.file_name())
-                .and_then(|s| s.to_str())
-                .ok_or_else(|| OxenError::S3PrefixUnresolvable(repo_dir.into()))?;
-            let prefix = format!("{namespace}/{name}");
-            let store = S3VersionStore::new(opts.bucket.clone(), opts.region.clone(), prefix);
+            let store =
+                S3VersionStore::new(opts.bucket.clone(), opts.region.clone(), prefix.to_string());
             Ok(Arc::new(store))
         }
     }
@@ -586,6 +580,46 @@ mod tests {
         let store = create_version_store(&repo_dir, &s3_config(), Some(&opts))
             .expect("S3 store should construct when server opts are present");
         assert_eq!(store.storage_kind(), StorageKind::S3);
+    }
+
+    /// Object keys are scoped by the repo directory's name alone. The namespace directory above
+    /// it never appears in a key, so moving a repo to another namespace leaves its objects where
+    /// they are.
+    #[tokio::test]
+    async fn create_version_store_s3_prefix_excludes_namespace() {
+        let repo_dir = PathBuf::from("/srv/oxen/test-ns/test-repo");
+        let opts = S3Opts {
+            bucket: "my-bucket".to_string(),
+            region: "us-west-1".to_string(),
+        };
+        let store = create_version_store(&repo_dir, &s3_config(), Some(&opts))
+            .expect("S3 store should construct when server opts are present");
+
+        let hash = "abc123";
+        let location = store
+            .version_location(hash)
+            .await
+            .expect("S3 version_location resolves without contacting the bucket");
+        match location {
+            VersionLocation::S3 { url, .. } => {
+                assert_eq!(url, format!("s3://my-bucket/test-repo/{hash}/data"));
+            }
+            other => panic!("expected S3 variant, got {other:?}"),
+        }
+    }
+
+    /// A repo path with no final component has no name to scope object keys by.
+    #[test]
+    fn create_version_store_s3_without_a_repo_directory_name_errors() {
+        let opts = S3Opts {
+            bucket: "my-bucket".to_string(),
+            region: "us-west-1".to_string(),
+        };
+        let result = create_version_store(Path::new("/"), &s3_config(), Some(&opts));
+        assert!(
+            matches!(result, Err(OxenError::S3PrefixUnresolvable(_))),
+            "expected S3PrefixUnresolvable, got {result:?}",
+        );
     }
 }
 


### PR DESCRIPTION
Moving a repository to another namespace no longer implies re-keying every object it has stored in S3. The version store previously built each repo's object prefix from the `<namespace>/<name>` tail of its path, so a namespace transfer would have had to copy every blob to a new key; the prefix is now the repository's name alone, and a transfer leaves stored objects untouched.

S3 is pre-GA, so there is no stored data to migrate.

ENG-1171