### PR TITLE
Reject an unusable data frame range where the request arrives

### DIFF
--- a/crates/liboxen/src/api/client/data_frames.rs
+++ b/crates/liboxen/src/api/client/data_frames.rs
@@ -110,7 +110,7 @@ mod tests {
     use crate::constants::DEFAULT_BRANCH_NAME;
     use crate::constants::DEFAULT_REMOTE_NAME;
     use crate::error::OxenError;
-    use crate::opts::DFOpts;
+    use crate::opts::{DFOpts, SliceRange};
     use crate::repositories;
     use crate::test;
     use crate::util;
@@ -701,7 +701,7 @@ mod tests {
 
             // Get the df
             let mut opts = DFOpts::empty();
-            opts.slice = Some("330..333".to_string());
+            opts.slice = Some(SliceRange::new(330, 333)?);
             opts.columns = Some("id,title".to_string());
             let df = api::client::data_frames::get(
                 &remote_repo,

--- a/crates/liboxen/src/core/df/tabular.rs
+++ b/crates/liboxen/src/core/df/tabular.rs
@@ -18,7 +18,7 @@ use crate::model::DataFrameSize;
 use crate::model::LocalRepository;
 use crate::model::data_frame::schema::DataType;
 use crate::model::merkle_tree::node::MerkleTreeNode;
-use crate::opts::{CountLinesOpts, DFOpts, PaginateOpts};
+use crate::opts::{CountLinesOpts, DFOpts, PaginateOpts, SliceRange};
 use crate::repositories;
 use crate::storage::{VersionLocation, VersionStore};
 use crate::util::fs;
@@ -460,7 +460,7 @@ pub async fn transform_lazy(mut df: LazyFrame, opts: DFOpts) -> Result<LazyFrame
             .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     }
 
-    if let Some(col_vals) = opts.add_col_vals() {
+    if let Some(col_vals) = opts.add_col_vals()? {
         df = add_col_lazy(
             df,
             &col_vals.name,
@@ -554,7 +554,7 @@ pub async fn transform_lazy(mut df: LazyFrame, opts: DFOpts) -> Result<LazyFrame
     }
 
     // These ops should be the last ops since they depends on order
-    if let Some(indices) = opts.take_indices() {
+    if let Some(indices) = opts.take_indices()? {
         // `take` collects the frame, so run it off the async runtime: a cloud frame's collect
         // drives Polars `block_in_place`, which panics on the server's current-thread runtime.
         // Mirrors the spawn_blocking-wrapped collects in `add_col_lazy`/`add_row`.
@@ -578,7 +578,7 @@ pub fn transform_slice_lazy(mut df: LazyFrame, opts: &DFOpts) -> Result<LazyFram
     df = head(df, opts);
     df = tail(df, opts);
 
-    if let Some(item) = opts.column_at() {
+    if let Some(item) = opts.column_at()? {
         // `collect` is real S3 IO for a cloud-backed frame, and col/index come from user input;
         // propagate errors rather than panicking via `unwrap`.
         let full_df = df.collect()?;
@@ -630,7 +630,7 @@ fn tail(df: LazyFrame, opts: &DFOpts) -> LazyFrame {
 
 pub fn slice_df(df: DataFrame, start: usize, end: usize) -> Result<DataFrame, OxenError> {
     let mut opts = DFOpts::empty();
-    opts.slice = Some(format!("{start}..{end}"));
+    opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
     log::debug!("slice_df with opts: {opts:?}");
     let df = df.lazy();
     let df = slice(df, &opts);
@@ -640,29 +640,25 @@ pub fn slice_df(df: DataFrame, start: usize, end: usize) -> Result<DataFrame, Ox
 
 pub fn paginate_df(df: DataFrame, page_opts: &PaginateOpts) -> Result<DataFrame, OxenError> {
     let mut opts = DFOpts::empty();
-    opts.slice = Some(format!(
-        "{}..{}",
-        page_opts.page_size * (page_opts.page_num - 1),
-        page_opts.page_size * page_opts.page_num
-    ));
+    opts.slice = Some(SliceRange::new(
+        (page_opts.page_size * (page_opts.page_num - 1)) as i64,
+        (page_opts.page_size * page_opts.page_num) as i64,
+    )?);
     let df = df.lazy();
     let df = slice(df, &opts);
     df.collect()
         .map_err(|e| OxenError::basic_str(format!("{e:?}")))
 }
 
+// `SliceRange` enforces `0 <= start < end` at construction, so there is no unusable range to
+// reject.
 fn slice(df: LazyFrame, opts: &DFOpts) -> LazyFrame {
     log::debug!("SLICE {:?}", opts.slice);
-    if let Some((start, end)) = opts.slice_indices() {
-        log::debug!("SLICE with indices {start:?}..{end:?}");
-        if start >= end {
-            panic!("Slice error: Start must be greater than end.");
-        }
-        let len = end - start;
-        df.slice(start, len as u32)
-    } else {
-        df
-    }
+    let Some(range) = opts.slice_indices() else {
+        return df;
+    };
+    log::debug!("SLICE with indices {range}");
+    df.slice(range.start, range.row_count())
 }
 
 pub fn df_add_row_num(df: DataFrame) -> Result<DataFrame, OxenError> {
@@ -1603,7 +1599,7 @@ pub async fn show_path(input: impl AsRef<Path>, opts: DFOpts) -> Result<DataFram
     log::debug!("Got opts {opts:?}");
     let df = read_df(input, opts.clone()).await?;
     log::debug!("Transform finished");
-    if opts.column_at().is_some() {
+    if opts.column_at()?.is_some() {
         for val in df.get(0).unwrap() {
             match val {
                 polars::prelude::AnyValue::List(vals) => {
@@ -2050,7 +2046,7 @@ mod tests {
     #[tokio::test]
     async fn test_slice_parquet_lazy() -> Result<(), OxenError> {
         let mut opts = DFOpts::empty();
-        opts.slice = Some("329..333".to_string());
+        opts.slice = Some(SliceRange::new(329, 333)?);
         let df = tabular::scan_df_parquet(test::test_1k_parquet(), 333)?;
         let df = tabular::transform_lazy(df, opts.clone()).await?;
 
@@ -2085,7 +2081,7 @@ mod tests {
     #[tokio::test]
     async fn test_slice_parquet_full_read() -> Result<(), OxenError> {
         let mut opts = DFOpts::empty();
-        opts.slice = Some("329..333".to_string());
+        opts.slice = Some(SliceRange::new(329, 333)?);
         let mut df = tabular::read_df(test::test_1k_parquet(), opts).await?;
         println!("{df:?}");
 

--- a/crates/liboxen/src/core/df/tabular.rs
+++ b/crates/liboxen/src/core/df/tabular.rs
@@ -562,14 +562,8 @@ pub async fn transform_lazy(mut df: LazyFrame, opts: DFOpts) -> Result<LazyFrame
         // drives Polars `block_in_place`, which panics on the server's current-thread runtime.
         // Mirrors the spawn_blocking-wrapped collects in `add_col_lazy`/`add_row`.
         let df_to_take = df.clone();
-        match task::spawn_blocking(move || take(df_to_take, indices)).await? {
-            Ok(new_df) => {
-                df = new_df.lazy();
-            }
-            Err(err) => {
-                log::error!("error taking indices from df {err:?}")
-            }
-        }
+        let new_df = task::spawn_blocking(move || take(df_to_take, indices)).await??;
+        df = new_df.lazy();
     }
     Ok(df)
 }

--- a/crates/liboxen/src/core/df/tabular.rs
+++ b/crates/liboxen/src/core/df/tabular.rs
@@ -574,7 +574,7 @@ pub async fn transform_lazy(mut df: LazyFrame, opts: DFOpts) -> Result<LazyFrame
 // Separate out slice transform because it needs to be done after other transforms
 pub fn transform_slice_lazy(mut df: LazyFrame, opts: &DFOpts) -> Result<LazyFrame, OxenError> {
     // Maybe slice it up
-    df = slice(df, opts);
+    df = slice(df, opts)?;
     df = head(df, opts);
     df = tail(df, opts);
 
@@ -630,13 +630,13 @@ fn tail(df: LazyFrame, opts: &DFOpts) -> LazyFrame {
 
 // `SliceRange` enforces `0 <= start < end` at construction, so there is no unusable range to
 // reject.
-fn slice(df: LazyFrame, opts: &DFOpts) -> LazyFrame {
+fn slice(df: LazyFrame, opts: &DFOpts) -> Result<LazyFrame, OxenError> {
     log::debug!("SLICE {:?}", opts.slice);
-    let Some(range) = opts.slice_indices() else {
-        return df;
+    let Some(range) = opts.slice_indices()? else {
+        return Ok(df);
     };
     log::debug!("SLICE with indices {range}");
-    df.slice(range.start, range.row_count())
+    Ok(df.slice(range.start, range.row_count()))
 }
 
 pub fn df_add_row_num(df: DataFrame) -> Result<DataFrame, OxenError> {

--- a/crates/liboxen/src/core/df/tabular.rs
+++ b/crates/liboxen/src/core/df/tabular.rs
@@ -18,7 +18,7 @@ use crate::model::DataFrameSize;
 use crate::model::LocalRepository;
 use crate::model::data_frame::schema::DataType;
 use crate::model::merkle_tree::node::MerkleTreeNode;
-use crate::opts::{CountLinesOpts, DFOpts, PaginateOpts, SliceRange};
+use crate::opts::{CountLinesOpts, DFOpts};
 use crate::repositories;
 use crate::storage::{VersionLocation, VersionStore};
 use crate::util::fs;
@@ -626,28 +626,6 @@ fn tail(df: LazyFrame, opts: &DFOpts) -> LazyFrame {
     } else {
         df
     }
-}
-
-pub fn slice_df(df: DataFrame, start: usize, end: usize) -> Result<DataFrame, OxenError> {
-    let mut opts = DFOpts::empty();
-    opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
-    log::debug!("slice_df with opts: {opts:?}");
-    let df = df.lazy();
-    let df = slice(df, &opts);
-    df.collect()
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))
-}
-
-pub fn paginate_df(df: DataFrame, page_opts: &PaginateOpts) -> Result<DataFrame, OxenError> {
-    let mut opts = DFOpts::empty();
-    opts.slice = Some(SliceRange::new(
-        (page_opts.page_size * (page_opts.page_num - 1)) as i64,
-        (page_opts.page_size * page_opts.page_num) as i64,
-    )?);
-    let df = df.lazy();
-    let df = slice(df, &opts);
-    df.collect()
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))
 }
 
 // `SliceRange` enforces `0 <= start < end` at construction, so there is no unusable range to
@@ -1768,7 +1746,10 @@ mod tests {
     use crate::core::df::{filter, tabular};
     use crate::test::{self, TEST_DATA_DIR};
     use crate::view::JsonDataFrameView;
-    use crate::{error::OxenError, opts::DFOpts};
+    use crate::{
+        error::OxenError,
+        opts::{DFOpts, SliceRange},
+    };
     use itertools::Itertools;
     use tokio::task;
 

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -175,6 +175,15 @@ pub enum OxenError {
     #[error("If provided, the quote character must be non-empty")]
     InvalidQuoteChar,
 
+    /// A data frame parameter could not be parsed, or names a range that cannot be read. Carries
+    /// the parameter and the value the caller sent, which is what identifies the bad request.
+    #[error("Invalid {param} parameter {value:?}: {reason}")]
+    InvalidDataFrameParam {
+        param: &'static str,
+        value: String,
+        reason: &'static str,
+    },
+
     //
     // Workspaces
     //
@@ -876,6 +885,9 @@ impl OxenError {
             TabularFileMissingMetadata(_) => {
                 "Commit a new version of this file with at least one row to make it readable as a data frame."
             }
+            InvalidDataFrameParam { .. } => {
+                "Check the parameter's format, for example `--slice 0..10`, `--take 1,2,3`, or `--item col:0`."
+            }
             _ => return None,
         }
         .to_string();
@@ -966,6 +978,7 @@ impl OxenError {
             OxenError::VersionStoreBlobMissing { .. } => true,
             OxenError::UnknownRemoteResponseStatus(_) => true,
             OxenError::TabularFileMissingMetadata(_) => true,
+            OxenError::InvalidDataFrameParam { .. } => true,
             OxenError::InvalidFileType(_) => true,
             // A malformed file or an unsatisfiable query reads the same way every time. Only the
             // IO case can resolve on its own.

--- a/crates/liboxen/src/model/diff/diff_entry.rs
+++ b/crates/liboxen/src/model/diff/diff_entry.rs
@@ -215,7 +215,7 @@ impl DiffEntry {
         {
             log::debug!("doing full diff for tabular");
             let diff =
-                TabularDiffView::from_file_nodes(repo, &base_entry, &head_entry, df_opts).await;
+                TabularDiffView::from_file_nodes(repo, &base_entry, &head_entry, df_opts).await?;
             return Ok(DiffEntry {
                 status: status.to_string(),
                 data_type: data_type.clone(),

--- a/crates/liboxen/src/opts.rs
+++ b/crates/liboxen/src/opts.rs
@@ -25,6 +25,7 @@ pub use crate::opts::clean_opts::CleanOpts;
 pub use crate::opts::clone_opts::CloneOpts;
 pub use crate::opts::count_lines_opts::CountLinesOpts;
 pub use crate::opts::df_opts::DFOpts;
+pub use crate::opts::df_opts::SliceRange;
 pub use crate::opts::diff_opts::DiffOpts;
 pub use crate::opts::embedding_query_opts::EmbeddingQueryOpts;
 pub use crate::opts::fetch_opts::FetchOpts;

--- a/crates/liboxen/src/opts/df_opts.rs
+++ b/crates/liboxen/src/opts/df_opts.rs
@@ -289,14 +289,14 @@ impl DFOpts {
 
     /// The rows the options select, from either an explicit `slice` or a single `row`. `None`
     /// means every row.
-    pub fn slice_indices(&self) -> Option<SliceRange> {
+    pub fn slice_indices(&self) -> Result<Option<SliceRange>, OxenError> {
         if let Some(range) = self.slice {
-            return Some(range);
+            return Ok(Some(range));
         }
         if let Some(row) = self.row {
-            return SliceRange::for_row(row).ok();
+            return Ok(Some(SliceRange::for_row(row)?));
         }
-        None
+        Ok(None)
     }
 
     pub fn take_indices(&self) -> Result<Option<Vec<u32>>, OxenError> {
@@ -610,11 +610,12 @@ mod tests {
     fn test_a_row_selects_only_that_row() -> Result<(), OxenError> {
         let mut opts = DFOpts::empty();
         opts.row = Some(7);
-        assert_eq!(opts.slice_indices(), Some(SliceRange::new(7, 8)?));
+        assert_eq!(opts.slice_indices()?, Some(SliceRange::new(7, 8)?));
 
-        // A row index too large to name a range selects everything rather than a bad range.
+        // A row index too large to name a range used to read as no selection at all, which
+        // answered a request for one row with every row.
         opts.row = Some(usize::MAX);
-        assert_eq!(opts.slice_indices(), None);
+        assert!(opts.slice_indices().is_err());
         Ok(())
     }
 
@@ -633,7 +634,7 @@ mod tests {
         let mut opts = DFOpts::empty();
         opts.row = Some(7);
         opts.slice = Some(SliceRange::new(0, 3)?);
-        assert_eq!(opts.slice_indices(), Some(SliceRange::new(0, 3)?));
+        assert_eq!(opts.slice_indices()?, Some(SliceRange::new(0, 3)?));
         Ok(())
     }
 

--- a/crates/liboxen/src/opts/df_opts.rs
+++ b/crates/liboxen/src/opts/df_opts.rs
@@ -82,11 +82,11 @@ impl SliceRange {
         Self::new(start, start.checked_add(1).ok_or_else(too_large)?)
     }
 
-    /// The number of rows the range covers.
+    /// The number of rows the range covers, at most `u32::MAX`.
     pub fn row_count(&self) -> u32 {
-        // `0 <= start < end` holds by construction, so the difference is positive and cannot
-        // overflow.
-        (self.end - self.start) as u32
+        // `0 <= start < end` holds by construction, so the difference is positive. A range wider
+        // than a `u32` asks for more rows than a data frame can hold, so it reads as all of them.
+        (self.end - self.start).min(u32::MAX as i64) as u32
     }
 }
 
@@ -574,6 +574,32 @@ mod tests {
         assert_eq!(SliceRange::for_page(1, 0), SliceRange::new(0, 1)?);
         assert_eq!(SliceRange::for_page(0, 0), SliceRange::new(0, 1)?);
         Ok(())
+    }
+
+    #[test]
+    fn test_a_page_wider_than_a_row_count_asks_for_every_row() {
+        // Truncating this width to a `u32` reads as zero rows, so a request for a very large page
+        // answers with nothing at all rather than with everything.
+        let range = SliceRange::for_page(1, 1usize << 32);
+        assert_eq!(range.row_count(), u32::MAX);
+        assert_eq!(SliceRange::for_page(1, 100).row_count(), 100);
+    }
+
+    #[test]
+    fn test_a_page_offset_never_goes_backwards() {
+        // These two multiply to exactly 2^64, which wraps to 0..4294967296. That range is
+        // well formed, so validating it catches nothing and a page far past the end of a data
+        // frame quietly serves the first rows instead. Offsets only ever grow with the page
+        // number, so a later page starting before an earlier one is the tell.
+        let page_size = 1usize << 32;
+        let prev = SliceRange::for_page(page_size, page_size);
+        let far = SliceRange::for_page(page_size + 1, page_size);
+        assert!(
+            far.start >= prev.start,
+            "page {} starts at {far}, before page {} at {prev}",
+            page_size + 1,
+            page_size
+        );
     }
 
     #[test]

--- a/crates/liboxen/src/opts/df_opts.rs
+++ b/crates/liboxen/src/opts/df_opts.rs
@@ -71,6 +71,17 @@ impl SliceRange {
         }
     }
 
+    /// The range covering a single row.
+    pub fn for_row(row: usize) -> Result<Self, OxenError> {
+        let too_large = || OxenError::InvalidDataFrameParam {
+            param: "row",
+            value: row.to_string(),
+            reason: "is past the largest row a range can name",
+        };
+        let start = i64::try_from(row).map_err(|_| too_large())?;
+        Self::new(start, start.checked_add(1).ok_or_else(too_large)?)
+    }
+
     /// The number of rows the range covers.
     pub fn row_count(&self) -> u32 {
         // `0 <= start < end` holds by construction, so the difference is positive and cannot
@@ -283,9 +294,7 @@ impl DFOpts {
             return Some(range);
         }
         if let Some(row) = self.row {
-            // A row index selects the single row `row..row + 1`.
-            let start = i64::try_from(row).ok()?;
-            return SliceRange::new(start, start.checked_add(1)?).ok();
+            return SliceRange::for_row(row).ok();
         }
         None
     }
@@ -565,7 +574,7 @@ mod tests {
     fn test_a_degenerate_page_reads_as_the_first_page() -> Result<(), OxenError> {
         // A page or page size of zero would otherwise underflow the `page - 1` subtraction and
         // derive a range that selects nothing.
-        assert_eq!(SliceRange::for_page(0, 10), SliceRange::new(1, 10)?);
+        assert_eq!(SliceRange::for_page(0, 10), SliceRange::new(0, 10)?);
         assert_eq!(SliceRange::for_page(1, 0), SliceRange::new(0, 1)?);
         assert_eq!(SliceRange::for_page(0, 0), SliceRange::new(0, 1)?);
         Ok(())
@@ -610,6 +619,16 @@ mod tests {
         // A row index too large to name a range selects everything rather than a bad range.
         opts.row = Some(usize::MAX);
         assert_eq!(opts.slice_indices(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_a_row_past_what_a_range_can_name_is_an_error() -> Result<(), OxenError> {
+        assert_eq!(SliceRange::for_row(7)?, SliceRange::new(7, 8)?);
+
+        // Both of these used to overflow while computing the exclusive end.
+        assert!(SliceRange::for_row(usize::MAX).is_err());
+        assert!(SliceRange::for_row(i64::MAX as usize).is_err());
         Ok(())
     }
 

--- a/crates/liboxen/src/opts/df_opts.rs
+++ b/crates/liboxen/src/opts/df_opts.rs
@@ -384,23 +384,19 @@ impl DFOpts {
 
     pub fn column_at(&self) -> Result<Option<IndexedItem>, OxenError> {
         if let Some(value) = self.item.clone() {
-            // col:index
-            // ie: file:2
-            let delimiter = ":";
-            if value.contains(delimiter) {
-                let malformed = || OxenError::InvalidDataFrameParam {
-                    param: "item",
-                    value: value.clone(),
-                    reason: "expected a column name and a whole number, as 'col:index'",
-                };
-                let mut split = value.split(delimiter);
-                let col = split.next().ok_or_else(malformed)?;
-                let index = split.next().ok_or_else(malformed)?;
-                return Ok(Some(IndexedItem {
-                    col: String::from(col),
-                    index: index.parse::<usize>().map_err(|_| malformed())?,
-                }));
+            let malformed = || OxenError::InvalidDataFrameParam {
+                param: "item",
+                value: value.clone(),
+                reason: "expected a column name and a whole number, as 'col:index'",
+            };
+            let (col, index) = value.split_once(':').ok_or_else(malformed)?;
+            if col.is_empty() {
+                return Err(malformed());
             }
+            return Ok(Some(IndexedItem {
+                col: String::from(col),
+                index: index.parse::<usize>().map_err(|_| malformed())?,
+            }));
         }
         Ok(None)
     }
@@ -638,6 +634,26 @@ mod tests {
         opts.row = Some(7);
         opts.slice = Some(SliceRange::new(0, 3)?);
         assert_eq!(opts.slice_indices(), Some(SliceRange::new(0, 3)?));
+        Ok(())
+    }
+
+    #[test]
+    fn test_an_item_that_is_not_a_column_and_index_is_an_error() -> Result<(), OxenError> {
+        let mut opts = DFOpts::empty();
+        opts.item = Some("file:2".to_string());
+        let item = opts.column_at()?.expect("item should parse");
+        assert_eq!(item.col, "file");
+        assert_eq!(item.index, 2);
+
+        // A value with no delimiter used to be ignored, returning the whole frame, and one with
+        // extra segments used to drop everything past the second.
+        for value in ["file", "", "file:2:3", "file:", ":2", "file:abc"] {
+            opts.item = Some(value.to_string());
+            assert!(
+                opts.column_at().is_err(),
+                "expected {value:?} to be rejected"
+            );
+        }
         Ok(())
     }
 

--- a/crates/liboxen/src/opts/df_opts.rs
+++ b/crates/liboxen/src/opts/df_opts.rs
@@ -57,6 +57,20 @@ impl SliceRange {
         Ok(Self { start, end })
     }
 
+    /// The rows on a 1-based page. A page or page size below one reads as the first page, and a
+    /// page past what the arithmetic can express reads as the last page it can.
+    pub fn for_page(page: usize, page_size: usize) -> Self {
+        let page_size = i64::try_from(page_size).unwrap_or(i64::MAX).max(1);
+        let page = i64::try_from(page).unwrap_or(i64::MAX).max(1);
+        // Holding the start below `i64::MAX - page_size` keeps `start + page_size` from
+        // overflowing, so `0 <= start < end` holds for every page.
+        let start = page_size.saturating_mul(page - 1).min(i64::MAX - page_size);
+        Self {
+            start,
+            end: start + page_size,
+        }
+    }
+
     /// The number of rows the range covers.
     pub fn row_count(&self) -> u32 {
         // `0 <= start < end` holds by construction, so the difference is positive and cannot
@@ -251,6 +265,15 @@ impl DFOpts {
             || self.unique.is_some()
             || self.unique_count.is_some()
             || self.vstack.is_some()
+    }
+
+    /// The 1-based page and page size the options request, clamped to the domain the reader can
+    /// serve. A page or page size below one reads as the first page.
+    pub fn page_bounds(&self) -> (usize, usize) {
+        (
+            self.page.unwrap_or(DEFAULT_PAGE_NUM).max(1),
+            self.page_size.unwrap_or(DEFAULT_PAGE_SIZE).max(1),
+        )
     }
 
     /// The rows the options select, from either an explicit `slice` or a single `row`. `None`
@@ -529,6 +552,53 @@ mod tests {
                 "expected {value:?} to be rejected"
             );
         }
+    }
+
+    #[test]
+    fn test_a_page_covers_the_rows_it_names() -> Result<(), OxenError> {
+        assert_eq!(SliceRange::for_page(1, 10), SliceRange::new(0, 10)?);
+        assert_eq!(SliceRange::for_page(3, 10), SliceRange::new(20, 30)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_a_degenerate_page_reads_as_the_first_page() -> Result<(), OxenError> {
+        // A page or page size of zero would otherwise underflow the `page - 1` subtraction and
+        // derive a range that selects nothing.
+        assert_eq!(SliceRange::for_page(0, 10), SliceRange::new(1, 10)?);
+        assert_eq!(SliceRange::for_page(1, 0), SliceRange::new(0, 1)?);
+        assert_eq!(SliceRange::for_page(0, 0), SliceRange::new(0, 1)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_an_absurd_page_still_names_a_usable_range() {
+        // The multiplication cannot overflow into a range the reader rejects, however large the
+        // caller's page number is.
+        for (page, page_size) in [
+            (usize::MAX, usize::MAX),
+            (usize::MAX, 100),
+            (100, usize::MAX),
+            (1 << 40, 1 << 40),
+        ] {
+            let range = SliceRange::for_page(page, page_size);
+            assert!(
+                range.start >= 0 && range.start < range.end,
+                "for_page({page}, {page_size}) gave {range}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_page_bounds_clamps_to_the_servable_domain() {
+        let mut opts = DFOpts::empty();
+        opts.page = Some(0);
+        opts.page_size = Some(0);
+        assert_eq!(opts.page_bounds(), (1, 1));
+
+        opts.page = Some(4);
+        opts.page_size = Some(25);
+        assert_eq!(opts.page_bounds(), (4, 25));
     }
 
     #[test]

--- a/crates/liboxen/src/opts/df_opts.rs
+++ b/crates/liboxen/src/opts/df_opts.rs
@@ -1,4 +1,6 @@
+use std::fmt;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
@@ -26,6 +28,64 @@ pub struct AddColVals {
 pub struct IndexedItem {
     pub col: String,
     pub index: usize,
+}
+
+/// A half-open row range, `start..end`. Constructing one enforces `0 <= start < end`, so a range
+/// that selects nothing, or that counts backwards from the end of the frame, cannot reach the read
+/// path. Parses from and displays as `"0..10"`, the form the `slice` query parameter travels in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SliceRange {
+    pub start: i64,
+    pub end: i64,
+}
+
+impl SliceRange {
+    pub fn new(start: i64, end: i64) -> Result<Self, OxenError> {
+        let invalid = |reason| {
+            Err(OxenError::InvalidDataFrameParam {
+                param: "slice",
+                value: format!("{start}..{end}"),
+                reason,
+            })
+        };
+        if start < 0 {
+            return invalid("start must not be negative");
+        }
+        if start >= end {
+            return invalid("start must be less than end");
+        }
+        Ok(Self { start, end })
+    }
+
+    /// The number of rows the range covers.
+    pub fn row_count(&self) -> u32 {
+        // `0 <= start < end` holds by construction, so the difference is positive and cannot
+        // overflow.
+        (self.end - self.start) as u32
+    }
+}
+
+impl FromStr for SliceRange {
+    type Err = OxenError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let malformed = || OxenError::InvalidDataFrameParam {
+            param: "slice",
+            value: value.to_string(),
+            reason: "expected two whole numbers separated by '..', as '0..10'",
+        };
+        let (start, end) = value.split_once("..").ok_or_else(malformed)?;
+        Self::new(
+            start.parse().map_err(|_| malformed())?,
+            end.parse().map_err(|_| malformed())?,
+        )
+    }
+}
+
+impl fmt::Display for SliceRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}..{}", self.start, self.end)
+    }
 }
 
 #[derive(Clone, Debug, ToSchema)]
@@ -57,7 +117,8 @@ pub struct DFOpts {
     pub should_randomize: bool,
     pub should_reverse: bool,
     pub should_page: bool,
-    pub slice: Option<String>,
+    #[schema(value_type = Option<String>)]
+    pub slice: Option<SliceRange>,
     pub sort_by: Option<String>,
     pub sort_by_similarity_to: Option<String>,
     pub sql: Option<String>,
@@ -192,37 +253,36 @@ impl DFOpts {
             || self.vstack.is_some()
     }
 
-    pub fn slice_indices(&self) -> Option<(i64, i64)> {
-        if let Some(slice) = self.slice.clone() {
-            let split = slice.split("..").collect::<Vec<&str>>();
-            if split.len() == 2 {
-                let start = split[0]
-                    .parse::<i64>()
-                    .expect("Start must be a valid integer.");
-                let end = split[1]
-                    .parse::<i64>()
-                    .expect("End must be a valid integer.");
-                return Some((start, end));
-            } else {
-                return None;
-            }
+    /// The rows the options select, from either an explicit `slice` or a single `row`. `None`
+    /// means every row.
+    pub fn slice_indices(&self) -> Option<SliceRange> {
+        if let Some(range) = self.slice {
+            return Some(range);
         }
         if let Some(row) = self.row {
-            let next_row = row + 1;
-            return Some((row as i64, next_row as i64));
+            // A row index selects the single row `row..row + 1`.
+            let start = i64::try_from(row).ok()?;
+            return SliceRange::new(start, start.checked_add(1)?).ok();
         }
         None
     }
 
-    pub fn take_indices(&self) -> Option<Vec<u32>> {
+    pub fn take_indices(&self) -> Result<Option<Vec<u32>>, OxenError> {
         if let Some(take) = self.take.clone() {
             let split = take
                 .split(',')
-                .map(|v| v.parse::<u32>().expect("Values must be a valid u32."))
-                .collect::<Vec<u32>>();
-            return Some(split);
+                .map(|v| {
+                    v.parse::<u32>()
+                        .map_err(|_| OxenError::InvalidDataFrameParam {
+                            param: "take",
+                            value: take.clone(),
+                            reason: "expected whole numbers separated by ','",
+                        })
+                })
+                .collect::<Result<Vec<u32>, OxenError>>()?;
+            return Ok(Some(split));
         }
-        None
+        Ok(None)
     }
 
     pub fn columns_names(&self) -> Option<Vec<String>> {
@@ -290,43 +350,50 @@ impl DFOpts {
         }
     }
 
-    pub fn column_at(&self) -> Option<IndexedItem> {
+    pub fn column_at(&self) -> Result<Option<IndexedItem>, OxenError> {
         if let Some(value) = self.item.clone() {
             // col:index
             // ie: file:2
             let delimiter = ":";
             if value.contains(delimiter) {
+                let malformed = || OxenError::InvalidDataFrameParam {
+                    param: "item",
+                    value: value.clone(),
+                    reason: "expected a column name and a whole number, as 'col:index'",
+                };
                 let mut split = value.split(delimiter);
-                return Some(IndexedItem {
-                    col: String::from(split.next().unwrap()),
-                    index: split
-                        .next()
-                        .unwrap()
-                        .parse::<usize>()
-                        .expect("Index must be usize"),
-                });
+                let col = split.next().ok_or_else(malformed)?;
+                let index = split.next().ok_or_else(malformed)?;
+                return Ok(Some(IndexedItem {
+                    col: String::from(col),
+                    index: index.parse::<usize>().map_err(|_| malformed())?,
+                }));
             }
         }
-        None
+        Ok(None)
     }
 
-    pub fn add_col_vals(&self) -> Option<AddColVals> {
+    pub fn add_col_vals(&self) -> Result<Option<AddColVals>, OxenError> {
         if let Some(add_col) = self.add_col.clone() {
             let split = add_col
                 .split(':')
                 .map(String::from)
                 .collect::<Vec<String>>();
             if split.len() != 3 {
-                panic!("Invalid input for col vals. Format: 'name:val:dtype'");
+                return Err(OxenError::InvalidDataFrameParam {
+                    param: "add-col",
+                    value: add_col,
+                    reason: "expected three parts, as 'name:value:dtype'",
+                });
             }
 
-            return Some(AddColVals {
+            return Ok(Some(AddColVals {
                 name: split[0].to_owned(),
                 value: split[1].to_owned(),
                 dtype: split[2].to_owned(),
-            });
+            }));
         }
-        None
+        Ok(None)
     }
 
     pub fn to_http_query_params(&self) -> String {
@@ -351,7 +418,7 @@ impl DFOpts {
             ("randomize", randomize),
             ("reverse", should_reverse),
             ("filter", self.filter.clone()),
-            ("slice", self.slice.clone()),
+            ("slice", self.slice.map(|s| s.to_string())),
             ("sort_by", self.sort_by.clone()),
             ("sql", self.sql.clone()),
             ("take", self.take.clone()),
@@ -411,12 +478,92 @@ impl DFOptsView {
                 &Some(serde_json::to_value(opts.should_reverse).unwrap()),
             ),
             DFOptView::from_opt("take", &opts.take),
-            DFOptView::from_opt("slice", &opts.slice),
+            DFOptView::from_opt("slice", &opts.slice.map(|s| s.to_string())),
             DFOptView::from_opt("head", &opts.head),
             DFOptView::from_opt("tail", &opts.tail),
         ]
         .to_vec();
 
         DFOptsView { opts: ordered_opts }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DFOpts, SliceRange};
+    use crate::error::OxenError;
+
+    #[test]
+    fn test_slice_range_rejects_a_range_that_selects_nothing() {
+        // A range whose start is not below its end reaches polars as a zero or negative length,
+        // which panics the worker thread rather than answering the caller.
+        assert!(SliceRange::new(0, 0).is_err());
+        assert!(SliceRange::new(10, 3).is_err());
+        assert!(SliceRange::new(3, 10).is_ok());
+    }
+
+    #[test]
+    fn test_slice_range_rejects_a_negative_start() {
+        // Polars reads a negative offset as counting back from the end of the frame, which is a
+        // different operation than the one `start..end` names.
+        assert!(SliceRange::new(-5, 3).is_err());
+        assert!(SliceRange::new(i64::MIN, i64::MAX).is_err());
+    }
+
+    #[test]
+    fn test_slice_range_round_trips_through_its_wire_form() -> Result<(), OxenError> {
+        let range: SliceRange = "330..333".parse()?;
+        assert_eq!(range, SliceRange::new(330, 333)?);
+        assert_eq!(range.to_string(), "330..333");
+        assert_eq!(range.row_count(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_a_slice_that_is_not_a_range_is_an_error() {
+        // Each of these used to be silently ignored, which answered a request for a few rows with
+        // the whole data frame.
+        for value in ["5", "1..2..3", "a..b", "", "..", "0..", "..10"] {
+            assert!(
+                value.parse::<SliceRange>().is_err(),
+                "expected {value:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_a_row_selects_only_that_row() -> Result<(), OxenError> {
+        let mut opts = DFOpts::empty();
+        opts.row = Some(7);
+        assert_eq!(opts.slice_indices(), Some(SliceRange::new(7, 8)?));
+
+        // A row index too large to name a range selects everything rather than a bad range.
+        opts.row = Some(usize::MAX);
+        assert_eq!(opts.slice_indices(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_a_slice_wins_over_a_row() -> Result<(), OxenError> {
+        let mut opts = DFOpts::empty();
+        opts.row = Some(7);
+        opts.slice = Some(SliceRange::new(0, 3)?);
+        assert_eq!(opts.slice_indices(), Some(SliceRange::new(0, 3)?));
+        Ok(())
+    }
+
+    #[test]
+    fn test_a_take_that_is_not_a_list_of_indices_is_an_error() {
+        let mut opts = DFOpts::empty();
+        opts.take = Some("1,2,3".to_string());
+        assert_eq!(opts.take_indices().unwrap(), Some(vec![1, 2, 3]));
+
+        for value in ["abc", "1,,2", "1,-2", ""] {
+            opts.take = Some(value.to_string());
+            assert!(
+                opts.take_indices().is_err(),
+                "expected {value:?} to be rejected"
+            );
+        }
     }
 }

--- a/crates/liboxen/src/view/json_data_frame.rs
+++ b/crates/liboxen/src/view/json_data_frame.rs
@@ -9,6 +9,7 @@ use std::io::Cursor;
 use utoipa::ToSchema;
 
 use crate::core::df::tabular;
+use crate::error::OxenError;
 use crate::model::DataFrameSize;
 use crate::{model::Schema, opts::DFOpts};
 
@@ -38,15 +39,15 @@ impl JsonDataFrame {
         }
     }
 
-    pub async fn from_df_opts(df: DataFrame, opts: DFOpts) -> JsonDataFrame {
+    pub async fn from_df_opts(df: DataFrame, opts: DFOpts) -> Result<JsonDataFrame, OxenError> {
         let full_height = df.height();
         let full_width = df.width();
 
         let schema = Schema::from_polars(df.schema());
-        let mut view_df = tabular::transform(df, opts).await.unwrap();
+        let mut view_df = tabular::transform(df, opts).await?;
         let view_schema = Schema::from_polars(view_df.schema());
 
-        JsonDataFrame {
+        Ok(JsonDataFrame {
             schema,
             view_schema,
             view_size: DataFrameSize {
@@ -58,7 +59,7 @@ impl JsonDataFrame {
                 width: full_width,
             },
             data: JsonDataFrame::json_data(&mut view_df),
-        }
+        })
     }
 
     pub async fn to_df(&self) -> DataFrame {

--- a/crates/liboxen/src/view/json_data_frame_view.rs
+++ b/crates/liboxen/src/view/json_data_frame_view.rs
@@ -290,6 +290,9 @@ impl JsonDataFrameView {
         opts: &DFOpts,
     ) -> JsonDataFrameView {
         let mut default_df = DataFrame::empty();
+        // An empty frame still answers with the page the caller asked for, so a reader gets the
+        // same pagination shape whether or not there were rows to return.
+        let (page_number, page_size) = opts.page_bounds();
         JsonDataFrameView {
             schema: schema.to_owned(),
             size: DataFrameSize {
@@ -298,8 +301,8 @@ impl JsonDataFrameView {
             },
             data: JsonDataFrameView::json_from_df(&mut default_df),
             pagination: Pagination {
-                page_number: 0,
-                page_size: 0,
+                page_number,
+                page_size,
                 total_pages: 0,
                 total_entries,
             },

--- a/crates/liboxen/src/view/json_data_frame_view.rs
+++ b/crates/liboxen/src/view/json_data_frame_view.rs
@@ -9,7 +9,6 @@ use std::io::Cursor;
 use utoipa::ToSchema;
 
 use super::StatusMessage;
-use crate::constants;
 use crate::core::df::tabular;
 use crate::error::OxenError;
 use crate::model::Commit;
@@ -137,17 +136,7 @@ impl JsonDataFrameView {
         let full_width = df.width();
         let full_height = df.height();
 
-        // Pages are 1-based and a page of zero rows names no rows, so clamp both to the valid
-        // domain: a degenerate request reads as the first page rather than an empty slice, a
-        // division by zero in the total, or an error.
-        let page_size = opts
-            .page_size
-            .unwrap_or(constants::DEFAULT_PAGE_SIZE)
-            .max(1);
-        let page = opts.page.unwrap_or(constants::DEFAULT_PAGE_NUM).max(1);
-
-        let start = page_size * (page - 1);
-        let end = page_size * page;
+        let (page, page_size) = opts.page_bounds();
 
         let total_pages = (full_height as f64 / page_size as f64).ceil() as usize;
 
@@ -161,7 +150,7 @@ impl JsonDataFrameView {
             ));
         };
 
-        opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
+        opts.slice = Some(SliceRange::for_page(page, page_size));
         let opts_view = DFOptsView::from_df_opts(&opts);
         let mut sliced_df = tabular::transform(df, opts).await?;
 
@@ -216,8 +205,7 @@ impl JsonDataFrameView {
         slice_schema.update_metadata_from_schema(&og_schema);
         log::debug!("Slice schema {slice_schema:?}");
 
-        let page_size = opts.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
-        let page_number = opts.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
+        let (page_number, page_size) = opts.page_bounds();
 
         let total_pages = (og_height as f64 / page_size as f64).ceil() as usize;
 

--- a/crates/liboxen/src/view/json_data_frame_view.rs
+++ b/crates/liboxen/src/view/json_data_frame_view.rs
@@ -15,6 +15,7 @@ use crate::error::OxenError;
 use crate::model::Commit;
 use crate::model::DataFrameSize;
 use crate::model::data_frame::DataFrameSchemaSize;
+use crate::opts::SliceRange;
 use crate::opts::df_opts::DFOptsView;
 
 use crate::view::Pagination;
@@ -108,20 +109,20 @@ pub struct DerivedDFResource {
 }
 
 impl WorkspaceJsonDataFrameViewResponse {
-    pub async fn empty() -> WorkspaceJsonDataFrameViewResponse {
-        WorkspaceJsonDataFrameViewResponse {
+    pub async fn empty() -> Result<WorkspaceJsonDataFrameViewResponse, OxenError> {
+        Ok(WorkspaceJsonDataFrameViewResponse {
             status: StatusMessage::resource_found(),
-            data_frame: Some(JsonDataFrameViews::empty().await),
+            data_frame: Some(JsonDataFrameViews::empty().await?),
             commit: None,
             resource: None,
             derived_resource: None,
             is_indexed: false,
-        }
+        })
     }
 }
 
 impl JsonDataFrameViews {
-    pub async fn empty() -> JsonDataFrameViews {
+    pub async fn empty() -> Result<JsonDataFrameViews, OxenError> {
         JsonDataFrameViews::from_df_and_opts(DataFrame::empty(), Schema::empty(), &DFOpts::empty())
             .await
     }
@@ -132,14 +133,20 @@ impl JsonDataFrameView {
         df: DataFrame,
         og_schema: Schema,
         opts: &DFOpts,
-    ) -> JsonDataFrameView {
+    ) -> Result<JsonDataFrameView, OxenError> {
         let full_width = df.width();
         let full_height = df.height();
 
-        let page_size = opts.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
-        let page = opts.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
+        // Pages are 1-based and a page of zero rows names no rows, so clamp both to the valid
+        // domain: a degenerate request reads as the first page rather than an empty slice, a
+        // division by zero in the total, or an error.
+        let page_size = opts
+            .page_size
+            .unwrap_or(constants::DEFAULT_PAGE_SIZE)
+            .max(1);
+        let page = opts.page.unwrap_or(constants::DEFAULT_PAGE_NUM).max(1);
 
-        let start = if page == 0 { 0 } else { page_size * (page - 1) };
+        let start = page_size * (page - 1);
         let end = page_size * page;
 
         let total_pages = (full_height as f64 / page_size as f64).ceil() as usize;
@@ -147,18 +154,22 @@ impl JsonDataFrameView {
         let mut opts = opts.clone();
 
         if df.height() == 0 {
-            return JsonDataFrameView::empty_with_schema(&og_schema, full_height, &opts);
+            return Ok(JsonDataFrameView::empty_with_schema(
+                &og_schema,
+                full_height,
+                &opts,
+            ));
         };
 
-        opts.slice = Some(format!("{start}..{end}"));
+        opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
         let opts_view = DFOptsView::from_df_opts(&opts);
-        let mut sliced_df = tabular::transform(df, opts).await.unwrap();
+        let mut sliced_df = tabular::transform(df, opts).await?;
 
         // Merge the metadata from the original schema
         let mut slice_schema = Schema::from_polars(sliced_df.schema());
         slice_schema.update_metadata_from_schema(&og_schema);
 
-        JsonDataFrameView {
+        Ok(JsonDataFrameView {
             schema: slice_schema,
             size: DataFrameSize {
                 height: full_height,
@@ -172,7 +183,7 @@ impl JsonDataFrameView {
                 total_entries: full_height,
             },
             opts: opts_view,
-        }
+        })
     }
 
     pub async fn from_df_opts_unpaginated(
@@ -180,7 +191,7 @@ impl JsonDataFrameView {
         og_schema: Schema,
         og_height: usize,
         opts: &DFOpts,
-    ) -> JsonDataFrameView {
+    ) -> Result<JsonDataFrameView, OxenError> {
         let full_width = df.width();
         let view_height = df.height();
 
@@ -196,7 +207,7 @@ impl JsonDataFrameView {
         let opts_view = DFOptsView::from_df_opts(&opts);
         let mut transform_opts = opts.clone();
         transform_opts.sort_by = None;
-        let mut sliced_df = tabular::transform(df, transform_opts).await.unwrap();
+        let mut sliced_df = tabular::transform(df, transform_opts).await?;
 
         // Merge the metadata from the original schema
         let mut slice_schema = Schema::from_polars(sliced_df.schema());
@@ -210,7 +221,7 @@ impl JsonDataFrameView {
 
         let total_pages = (og_height as f64 / page_size as f64).ceil() as usize;
 
-        JsonDataFrameView {
+        Ok(JsonDataFrameView {
             schema: slice_schema,
             size: DataFrameSize {
                 height: view_height,
@@ -224,7 +235,7 @@ impl JsonDataFrameView {
                 total_entries: og_height,
             },
             opts: opts_view,
-        }
+        })
     }
 
     pub async fn to_df(&self) -> DataFrame {
@@ -314,10 +325,10 @@ impl JsonDataFrameViews {
         df: DataFrame,
         og_schema: Schema,
         opts: &DFOpts,
-    ) -> JsonDataFrameViews {
+    ) -> Result<JsonDataFrameViews, OxenError> {
         let source = DataFrameSchemaSize::from_df(&df, &og_schema);
-        let view = JsonDataFrameView::from_df_opts(df, og_schema, opts).await;
-        JsonDataFrameViews { source, view }
+        let view = JsonDataFrameView::from_df_opts(df, og_schema, opts).await?;
+        Ok(JsonDataFrameViews { source, view })
     }
 
     // To avoid duplicate pagination when the pagination has already been applied
@@ -327,11 +338,11 @@ impl JsonDataFrameViews {
         og_schema: Schema,
         og_height: usize,
         opts: &DFOpts,
-    ) -> JsonDataFrameViews {
+    ) -> Result<JsonDataFrameViews, OxenError> {
         let source = DataFrameSchemaSize::from_df(&df, &og_schema);
         let view =
-            JsonDataFrameView::from_df_opts_unpaginated(df, og_schema, og_height, opts).await;
-        JsonDataFrameViews { source, view }
+            JsonDataFrameView::from_df_opts_unpaginated(df, og_schema, og_height, opts).await?;
+        Ok(JsonDataFrameViews { source, view })
     }
 }
 

--- a/crates/liboxen/src/view/tabular_diff_view.rs
+++ b/crates/liboxen/src/view/tabular_diff_view.rs
@@ -3,6 +3,7 @@ use polars::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use crate::error::OxenError;
 use crate::model::merkle_tree::node::FileNode;
 use crate::model::{LocalRepository, Schema};
 use crate::opts::DFOpts;
@@ -41,7 +42,7 @@ impl TabularDiffView {
         base_entry: &Option<FileNode>,
         head_entry: &Option<FileNode>,
         df_opts: DFOpts,
-    ) -> TabularDiffView {
+    ) -> Result<TabularDiffView, OxenError> {
         let base_df = TabularDiffWrapper::maybe_get_df_from_file_node(repo, base_entry).await;
         let head_df = TabularDiffWrapper::maybe_get_df_from_file_node(repo, head_entry).await;
 
@@ -52,7 +53,7 @@ impl TabularDiffView {
         base_df: Option<DataFrame>,
         head_df: Option<DataFrame>,
         df_opts: DFOpts,
-    ) -> TabularDiffView {
+    ) -> Result<TabularDiffView, OxenError> {
         let schema_has_changed = TabularDiffWrapper::schema_has_changed(&base_df, &head_df);
 
         let base_schema = TabularDiffView::maybe_get_schema(&base_df);
@@ -76,12 +77,12 @@ impl TabularDiffView {
                 .unwrap();
 
                 let added_cols = match df_diff.added_cols {
-                    Some(df) => Some(JsonDataFrame::from_df_opts(df, df_opts.clone()).await),
+                    Some(df) => Some(JsonDataFrame::from_df_opts(df, df_opts.clone()).await?),
                     None => None,
                 };
 
                 let removed_cols = match df_diff.removed_cols {
-                    Some(df) => Some(JsonDataFrame::from_df_opts(df, df_opts.clone()).await),
+                    Some(df) => Some(JsonDataFrame::from_df_opts(df, df_opts.clone()).await?),
                     None => None,
                 };
 
@@ -93,7 +94,7 @@ impl TabularDiffView {
                                 head_schema.clone(),
                                 &df_opts,
                             )
-                            .await,
+                            .await?,
                         ),
                         df.full_size.width,
                     ),
@@ -108,7 +109,7 @@ impl TabularDiffView {
                                 head_schema.clone(),
                                 &df_opts,
                             )
-                            .await,
+                            .await?,
                         ),
                         df.full_size.width,
                     ),
@@ -171,11 +172,11 @@ impl TabularDiffView {
                 };
 
                 let added_rows = match added_rows_view {
-                    Some(df) => Some(df.await),
+                    Some(df) => Some(df.await?),
                     None => None,
                 };
                 let removed_rows = match removed_rows_view {
-                    Some(df) => Some(df.await),
+                    Some(df) => Some(df.await?),
                     None => None,
                 };
 
@@ -201,7 +202,7 @@ impl TabularDiffView {
 
                 log::debug!("summary: {summary:?}");
 
-                return TabularDiffView {
+                return Ok(TabularDiffView {
                     tabular: TabularDiffViewImpl {
                         summary,
                         base_schema: Some(base_schema),
@@ -215,7 +216,7 @@ impl TabularDiffView {
                         removed_cols,
                         removed_cols_view,
                     },
-                };
+                });
             } else {
                 // schema has not changed
                 // compute new rows
@@ -225,7 +226,7 @@ impl TabularDiffView {
                         .unwrap();
 
                 let added_rows = match df_diff.added_rows {
-                    Some(df) => Some(JsonDataFrame::from_df_opts(df, df_opts.clone()).await),
+                    Some(df) => Some(JsonDataFrame::from_df_opts(df, df_opts.clone()).await?),
                     None => None,
                 };
 
@@ -236,13 +237,13 @@ impl TabularDiffView {
                             base_schema.clone(),
                             &df_opts,
                         )
-                        .await,
+                        .await?,
                     ),
                     None => None,
                 };
 
                 let removed_rows = match df_diff.removed_rows {
-                    Some(df) => Some(JsonDataFrame::from_df_opts(df, df_opts.clone()).await),
+                    Some(df) => Some(JsonDataFrame::from_df_opts(df, df_opts.clone()).await?),
                     None => None,
                 };
 
@@ -253,7 +254,7 @@ impl TabularDiffView {
                             base_schema.clone(),
                             &df_opts,
                         )
-                        .await,
+                        .await?,
                     ),
                     None => None,
                 };
@@ -280,7 +281,7 @@ impl TabularDiffView {
                     },
                 };
 
-                return TabularDiffView {
+                return Ok(TabularDiffView {
                     tabular: TabularDiffViewImpl {
                         summary,
                         base_schema: Some(base_schema),
@@ -294,7 +295,7 @@ impl TabularDiffView {
                         removed_cols: None,
                         removed_cols_view: None,
                     },
-                };
+                });
             }
         }
 
@@ -303,9 +304,10 @@ impl TabularDiffView {
             let head_schema = head_schema.clone().unwrap();
             let head_df = head_df.unwrap();
             let added_df =
-                Some(JsonDataFrame::from_df_opts(head_df.clone(), df_opts.clone()).await);
-            let added_df_view =
-                Some(JsonDataFrameView::from_df_opts(head_df, head_schema.clone(), &df_opts).await);
+                Some(JsonDataFrame::from_df_opts(head_df.clone(), df_opts.clone()).await?);
+            let added_df_view = Some(
+                JsonDataFrameView::from_df_opts(head_df, head_schema.clone(), &df_opts).await?,
+            );
 
             let added_df = match added_df {
                 Some(df) => df,
@@ -324,7 +326,7 @@ impl TabularDiffView {
                 },
             };
 
-            return TabularDiffView {
+            return Ok(TabularDiffView {
                 tabular: TabularDiffViewImpl {
                     summary,
                     base_schema: None,
@@ -338,7 +340,7 @@ impl TabularDiffView {
                     removed_cols: None,
                     removed_cols_view: None,
                 },
-            };
+            });
         }
 
         if base_schema.is_some() && head_schema.is_none() {
@@ -346,9 +348,10 @@ impl TabularDiffView {
             let base_schema = base_schema.clone().unwrap();
             let base_df = base_df.unwrap();
             let removed_df =
-                Some(JsonDataFrame::from_df_opts(base_df.clone(), df_opts.clone()).await);
-            let removed_df_view =
-                Some(JsonDataFrameView::from_df_opts(base_df, base_schema.clone(), &df_opts).await);
+                Some(JsonDataFrame::from_df_opts(base_df.clone(), df_opts.clone()).await?);
+            let removed_df_view = Some(
+                JsonDataFrameView::from_df_opts(base_df, base_schema.clone(), &df_opts).await?,
+            );
 
             let removed_df = match removed_df {
                 Some(df) => df,
@@ -365,7 +368,7 @@ impl TabularDiffView {
                 },
             };
 
-            return TabularDiffView {
+            return Ok(TabularDiffView {
                 tabular: TabularDiffViewImpl {
                     summary,
                     base_schema: Some(base_schema),
@@ -379,7 +382,7 @@ impl TabularDiffView {
                     removed_cols: None,
                     removed_cols_view: None,
                 },
-            };
+            });
         }
 
         // schema has not changed
@@ -392,7 +395,7 @@ impl TabularDiffView {
                 schema_has_changed,
             },
         };
-        TabularDiffView {
+        Ok(TabularDiffView {
             tabular: TabularDiffViewImpl {
                 summary,
                 base_schema,
@@ -406,7 +409,7 @@ impl TabularDiffView {
                 removed_cols: None,
                 removed_cols_view: None,
             },
-        }
+        })
     }
 
     pub fn maybe_get_schema(df: &Option<DataFrame>) -> Option<Schema> {

--- a/crates/oxen-cli/src/cmd/df.rs
+++ b/crates/oxen-cli/src/cmd/df.rs
@@ -324,7 +324,10 @@ impl DFCmd {
             should_page: args.get_flag("full") || page_specified,
             should_randomize: args.get_flag("randomize"),
             should_reverse: args.get_flag("reverse"),
-            slice: args.get_one::<String>("slice").map(String::from),
+            slice: args
+                .get_one::<String>("slice")
+                .map(|s| s.parse())
+                .transpose()?,
             sort_by: args.get_one::<String>("sort").map(String::from),
             sort_by_similarity_to: args
                 .get_one::<String>("sort-by-similarity-to")

--- a/crates/oxen-py/src/py_remote_data_frame.rs
+++ b/crates/oxen-py/src/py_remote_data_frame.rs
@@ -1,6 +1,6 @@
 use liboxen::api;
 use liboxen::error::OxenError;
-use liboxen::opts::DFOpts;
+use liboxen::opts::{DFOpts, SliceRange};
 use pyo3::prelude::*;
 use std::path::PathBuf;
 
@@ -31,7 +31,7 @@ impl PyRemoteDataFrame {
 
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             let mut opts = DFOpts::empty();
-            opts.slice = Some("0..1".to_string());
+            opts.slice = Some(SliceRange::new(0, 1)?);
 
             let response = api::client::data_frames::get(
                 self.repo.repo()?,
@@ -55,7 +55,7 @@ impl PyRemoteDataFrame {
 
         let data = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             let mut opts = DFOpts::empty();
-            opts.slice = Some(format!("{}..{}", row, row + 1));
+            opts.slice = Some(SliceRange::new(row as i64, row as i64 + 1)?);
 
             let response =
                 api::client::data_frames::get(self.repo.repo()?, revision, &self.path, opts)
@@ -84,7 +84,7 @@ impl PyRemoteDataFrame {
 
         let data = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             let mut opts = DFOpts::empty();
-            opts.slice = Some(format!("{start}..{end}"));
+            opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
 
             if !columns.is_empty() {
                 // turn columns into comma separated list

--- a/crates/oxen-py/src/py_remote_data_frame.rs
+++ b/crates/oxen-py/src/py_remote_data_frame.rs
@@ -55,7 +55,7 @@ impl PyRemoteDataFrame {
 
         let data = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             let mut opts = DFOpts::empty();
-            opts.slice = Some(SliceRange::new(row as i64, row as i64 + 1)?);
+            opts.slice = Some(SliceRange::for_row(row)?);
 
             let response =
                 api::client::data_frames::get(self.repo.repo()?, revision, &self.path, opts)

--- a/crates/oxen-server/src/controllers/data_frames.rs
+++ b/crates/oxen-server/src/controllers/data_frames.rs
@@ -66,15 +66,12 @@ pub async fn get(
     if let Some(range) = opts.slice_indices()? {
         log::debug!("controllers::data_frames Got slice params {range}");
     } else {
-        let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
-        let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
+        let (page, page_size) = opts.page_bounds();
 
         page_opts.page_num = page;
         page_opts.page_size = page_size;
 
-        let start = if page == 0 { 0 } else { page_size * (page - 1) };
-        let end = page_size * page;
-        opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
+        opts.slice = Some(SliceRange::for_page(page, page_size));
     }
 
     let resource_version = ResourceVersion {

--- a/crates/oxen-server/src/controllers/data_frames.rs
+++ b/crates/oxen-server/src/controllers/data_frames.rs
@@ -63,7 +63,7 @@ pub async fn get(
         page_size: constants::DEFAULT_PAGE_SIZE,
     };
 
-    if let Some(range) = opts.slice_indices() {
+    if let Some(range) = opts.slice_indices()? {
         log::debug!("controllers::data_frames Got slice params {range}");
     } else {
         let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);

--- a/crates/oxen-server/src/controllers/data_frames.rs
+++ b/crates/oxen-server/src/controllers/data_frames.rs
@@ -14,7 +14,7 @@ use liboxen::view::data_frames::FromDirectoryRequest;
 use liboxen::view::entries::ResourceVersion;
 
 use actix_web::{HttpRequest, HttpResponse, web};
-use liboxen::opts::{DFOpts, PaginateOpts};
+use liboxen::opts::{DFOpts, PaginateOpts, SliceRange};
 use liboxen::view::{
     CommitResponse, JsonDataFrameView, JsonDataFrameViewResponse, JsonDataFrameViews, Pagination,
     StatusMessage,
@@ -56,15 +56,15 @@ pub async fn get(
     };
 
     let mut opts = DFOpts::empty();
-    opts = df_opts_query::parse_opts(&query, &mut opts);
+    opts = df_opts_query::parse_opts(&query, &mut opts)?;
 
     let mut page_opts = PaginateOpts {
         page_num: constants::DEFAULT_PAGE_NUM,
         page_size: constants::DEFAULT_PAGE_SIZE,
     };
 
-    if let Some((start, end)) = opts.slice_indices() {
-        log::debug!("controllers::data_frames Got slice params {start}..{end}");
+    if let Some(range) = opts.slice_indices() {
+        log::debug!("controllers::data_frames Got slice params {range}");
     } else {
         let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
         let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
@@ -74,7 +74,7 @@ pub async fn get(
 
         let start = if page == 0 { 0 } else { page_size * (page - 1) };
         let end = page_size * page;
-        opts.slice = Some(format!("{start}..{end}"));
+        opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
     }
 
     let resource_version = ResourceVersion {

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -403,8 +403,12 @@ pub async fn file(
     let mut opts = DFOpts::empty();
     opts = df_opts_query::parse_opts(&query, &mut opts)?;
 
-    let (page, page_size) = opts.page_bounds();
-    opts.slice = Some(SliceRange::for_page(page, page_size));
+    // A slice or row the caller named is the range they asked for, so only derive one from the
+    // page when they named none.
+    if opts.slice_indices()?.is_none() {
+        let (page, page_size) = opts.page_bounds();
+        opts.slice = Some(SliceRange::for_page(page, page_size));
+    }
 
     let diff = repositories::diffs::diff_entries(
         &repository,
@@ -805,6 +809,9 @@ pub async fn get_derived_df(
     log::debug!("get_derived_df got opts: {opts:?}");
 
     let (page, page_size) = opts.page_bounds();
+    // A slice or row the caller named is applied by the transform below, so paginating its
+    // result would slice the same frame a second time.
+    let paginate_by_page = opts.slice_indices()?.is_none();
 
     // Clear these for the first transform
     opts.page = None;
@@ -824,9 +831,13 @@ pub async fn get_derived_df(
             let view_height = view_df.height();
 
             // Paginate after transform
-            let mut paginate_opts = DFOpts::empty();
-            paginate_opts.slice = Some(SliceRange::for_page(page, page_size));
-            let mut paginated_df = tabular::transform(view_df, paginate_opts).await?;
+            let mut paginated_df = if paginate_by_page {
+                let mut paginate_opts = DFOpts::empty();
+                paginate_opts.slice = Some(SliceRange::for_page(page, page_size));
+                tabular::transform(view_df, paginate_opts).await?
+            } else {
+                view_df
+            };
 
             let total_pages = (view_height as f64 / page_size as f64).ceil() as usize;
             let source_size = DataFrameSize {

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -906,10 +906,7 @@ pub async fn get_derived_df(
             log::warn!("Error parsing SQL: {sql}");
             Err(OxenHttpError::SQLParseError(sql))
         }
-        Err(e) => {
-            log::error!("Error transforming df: {e}");
-            Err(OxenHttpError::InternalServerError)
-        }
+        Err(err) => Err(err.into()),
     }
 }
 

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -14,8 +14,8 @@ use liboxen::model::diff::diff_entry_status::DiffEntryStatus;
 use liboxen::model::diff::dir_diff_summary::{DirDiffSummary, DirDiffSummaryImpl};
 use liboxen::model::diff::generic_diff_summary::GenericDiffSummary;
 use liboxen::model::{Commit, CommitEntry, DataFrameSize, LocalRepository, Schema};
-use liboxen::opts::DFOpts;
 use liboxen::opts::df_opts::DFOptsView;
+use liboxen::opts::{DFOpts, SliceRange};
 use liboxen::view::compare::{
     CommitSide, CompareCommit, CompareCommits, CompareCommitsResponse, CompareDupes,
     CompareEntries, CompareEntryResponse, CompareTabular, CompareTabularResponse,
@@ -401,14 +401,14 @@ pub async fn file(
     };
 
     let mut opts = DFOpts::empty();
-    opts = df_opts_query::parse_opts(&query, &mut opts);
+    opts = df_opts_query::parse_opts(&query, &mut opts)?;
 
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
 
     let start = if page == 0 { 0 } else { page_size * (page - 1) };
     let end = page_size * page;
-    opts.slice = Some(format!("{start}..{end}"));
+    opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
 
     let diff = repositories::diffs::diff_entries(
         &repository,
@@ -805,7 +805,7 @@ pub async fn get_derived_df(
     let og_schema = Schema::from_polars(df.schema());
 
     let mut opts = DFOpts::empty();
-    opts = df_opts_query::parse_opts(&query, &mut opts);
+    opts = df_opts_query::parse_opts(&query, &mut opts)?;
     log::debug!("get_derived_df got opts: {opts:?}");
 
     // Clear these for the first transform
@@ -832,7 +832,7 @@ pub async fn get_derived_df(
 
             // Paginate after transform
             let mut paginate_opts = DFOpts::empty();
-            paginate_opts.slice = Some(format!("{start}..{end}"));
+            paginate_opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
             let mut paginated_df = tabular::transform(view_df, paginate_opts).await?;
 
             let total_pages = (view_height as f64 / page_size as f64).ceil() as usize;

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -403,12 +403,8 @@ pub async fn file(
     let mut opts = DFOpts::empty();
     opts = df_opts_query::parse_opts(&query, &mut opts)?;
 
-    let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
-    let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
-
-    let start = if page == 0 { 0 } else { page_size * (page - 1) };
-    let end = page_size * page;
-    opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
+    let (page, page_size) = opts.page_bounds();
+    opts.slice = Some(SliceRange::for_page(page, page_size));
 
     let diff = repositories::diffs::diff_entries(
         &repository,
@@ -808,6 +804,8 @@ pub async fn get_derived_df(
     opts = df_opts_query::parse_opts(&query, &mut opts)?;
     log::debug!("get_derived_df got opts: {opts:?}");
 
+    let (page, page_size) = opts.page_bounds();
+
     // Clear these for the first transform
     opts.page = None;
     opts.page_size = None;
@@ -815,11 +813,6 @@ pub async fn get_derived_df(
     let full_height = df.height();
     let full_width = df.width();
 
-    let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
-    let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
-
-    let start = if page == 0 { 0 } else { page_size * (page - 1) };
-    let end = page_size * page;
     let opts_view = DFOptsView::from_df_opts(&opts);
 
     // We have to run the query param transforms, then paginate separately
@@ -832,7 +825,7 @@ pub async fn get_derived_df(
 
             // Paginate after transform
             let mut paginate_opts = DFOpts::empty();
-            paginate_opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
+            paginate_opts.slice = Some(SliceRange::for_page(page, page_size));
             let mut paginated_df = tabular::transform(view_df, paginate_opts).await?;
 
             let total_pages = (view_height as f64 / page_size as f64).ceil() as usize;

--- a/crates/oxen-server/src/controllers/workspaces/data_frames.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames.rs
@@ -134,7 +134,7 @@ pub async fn get(
         // The read path paginates only via opts.slice, not page/page_size, so convert the requested
         // page into a slice before reading (as controllers::data_frames::get does). Without it the
         // read returns the whole frame regardless of the page. Skip if slice/row is set.
-        if opts.slice_indices().is_none() {
+        if opts.slice_indices()?.is_none() {
             let (page, page_size) = opts.page_bounds();
             opts.slice = Some(SliceRange::for_page(page, page_size));
         }

--- a/crates/oxen-server/src/controllers/workspaces/data_frames.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames.rs
@@ -135,16 +135,8 @@ pub async fn get(
         // page into a slice before reading (as controllers::data_frames::get does). Without it the
         // read returns the whole frame regardless of the page. Skip if slice/row is set.
         if opts.slice_indices().is_none() {
-            let page = opts.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
-            let page_size = opts.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
-            // page/page_size are clamped to >= 1 when read. Cap start so end = start + page_size
-            // can't overflow and stays strictly greater, preserving slice()'s start < end invariant
-            // even for an absurd page number (which then just yields an empty page).
-            let start = page_size
-                .saturating_mul(page - 1)
-                .min(usize::MAX - page_size);
-            let end = start + page_size;
-            opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
+            let (page, page_size) = opts.page_bounds();
+            opts.slice = Some(SliceRange::for_page(page, page_size));
         }
 
         let data_frame_slice =

--- a/crates/oxen-server/src/controllers/workspaces/data_frames.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames.rs
@@ -12,7 +12,7 @@ use liboxen::core::db::data_frames::workspace_df_db::schema_without_oxen_cols;
 use liboxen::core::repo_locks;
 use liboxen::error::OxenError;
 use liboxen::model::{ParsedResource, Schema, Workspace};
-use liboxen::opts::DFOpts;
+use liboxen::opts::{DFOpts, SliceRange};
 use liboxen::repositories;
 use liboxen::repositories::data_frames::schemas::get_staged_schema_with_staged_db_manager;
 use liboxen::util::paginate;
@@ -104,7 +104,7 @@ pub async fn get(
     let file_path = PathBuf::from(path_param(&req, "path")?);
 
     let mut opts = DFOpts::empty();
-    opts = df_opts_query::parse_opts(&query, &mut opts);
+    opts = df_opts_query::parse_opts(&query, &mut opts)?;
     opts.path = Some(file_path.clone());
 
     // Clamp pagination to the valid 1-based domain once, when read: downstream a 0 page derives an
@@ -144,7 +144,7 @@ pub async fn get(
                 .saturating_mul(page - 1)
                 .min(usize::MAX - page_size);
             let end = start + page_size;
-            opts.slice = Some(format!("{start}..{end}"));
+            opts.slice = Some(SliceRange::new(start as i64, end as i64)?);
         }
 
         let data_frame_slice =
@@ -167,7 +167,7 @@ pub async fn get(
         };
 
         let mut df_views =
-            JsonDataFrameViews::from_df_and_opts_unpaginated(df, df_schema, count, &opts).await;
+            JsonDataFrameViews::from_df_and_opts_unpaginated(df, df_schema, count, &opts).await?;
 
         // Metadata can be staged before the frame is ever indexed; surface it.
         let staged_schema =
@@ -222,7 +222,7 @@ pub async fn get(
     df_schema.update_metadata_from_schema(&og_schema);
 
     let mut df_views =
-        JsonDataFrameViews::from_df_and_opts_unpaginated(df, df_schema, count, &opts).await;
+        JsonDataFrameViews::from_df_and_opts_unpaginated(df, df_schema, count, &opts).await?;
 
     let new_schema = repositories::data_frames::schemas::get_staged_schema_with_staged_db_manager(
         &workspace.workspace_repo,
@@ -399,7 +399,7 @@ pub async fn download(
         ));
     };
 
-    let opts = df_opts_from_query(&query, file_path.clone());
+    let opts = df_opts_from_query(&query, file_path.clone())?;
 
     let is_indexed = repositories::workspaces::data_frames::is_indexed(&workspace, &file_path)?;
 
@@ -459,14 +459,17 @@ pub async fn download(
         .body(contents))
 }
 
-fn df_opts_from_query(query: &web::Query<DFOptsQuery>, file_path: PathBuf) -> DFOpts {
+fn df_opts_from_query(
+    query: &web::Query<DFOptsQuery>,
+    file_path: PathBuf,
+) -> Result<DFOpts, OxenError> {
     let mut opts = DFOpts::empty();
-    opts = df_opts_query::parse_opts(query, &mut opts);
+    opts = df_opts_query::parse_opts(query, &mut opts)?;
     opts.path = Some(file_path);
 
     opts.page = Some(query.page.unwrap_or(constants::DEFAULT_PAGE_NUM));
     opts.page_size = Some(query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE));
-    opts
+    Ok(opts)
 }
 
 /// Check if the file exists in the repository or the workspace.
@@ -528,7 +531,7 @@ pub async fn download_streaming(
         ));
     };
 
-    let opts = df_opts_from_query(&query, file_path.clone());
+    let opts = df_opts_from_query(&query, file_path.clone())?;
 
     let is_indexed = repositories::workspaces::data_frames::is_indexed(&workspace, &file_path)?;
 

--- a/crates/oxen-server/src/controllers/workspaces/data_frames/columns.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames/columns.rs
@@ -73,7 +73,7 @@ pub async fn create(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let opts = DFOpts::empty();
     let column_schema = Schema::from_polars(column_df.schema());
     let column_df_source = DataFrameSchemaSize::from_df(&column_df, &column_schema);
-    let column_df_view = JsonDataFrameView::from_df_opts(column_df, column_schema, &opts).await;
+    let column_df_view = JsonDataFrameView::from_df_opts(column_df, column_schema, &opts).await?;
     let df_views = JsonDataFrameViews {
         source: column_df_source,
         view: column_df_view,
@@ -140,7 +140,7 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let opts = DFOpts::empty();
     let column_schema = Schema::from_polars(column_df.schema());
     let column_df_source = DataFrameSchemaSize::from_df(&column_df, &column_schema);
-    let column_df_view = JsonDataFrameView::from_df_opts(column_df, column_schema, &opts).await;
+    let column_df_view = JsonDataFrameView::from_df_opts(column_df, column_schema, &opts).await?;
 
     let df_views = JsonDataFrameViews {
         source: column_df_source,
@@ -240,7 +240,7 @@ pub async fn update(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let opts = DFOpts::empty();
     let column_schema = Schema::from_polars(column_df.schema());
     let column_df_source = DataFrameSchemaSize::from_df(&column_df, &column_schema);
-    let column_df_view = JsonDataFrameView::from_df_opts(column_df, column_schema, &opts).await;
+    let column_df_view = JsonDataFrameView::from_df_opts(column_df, column_schema, &opts).await?;
 
     let mut df_views = JsonDataFrameViews {
         source: column_df_source,

--- a/crates/oxen-server/src/controllers/workspaces/data_frames/embeddings.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames/embeddings.rs
@@ -118,7 +118,7 @@ pub async fn neighbors(req: HttpRequest, body: String) -> Result<HttpResponse, O
     df_schema.update_metadata_from_schema(&og_schema);
 
     let mut df_views =
-        JsonDataFrameViews::from_df_and_opts_unpaginated(df, df_schema, count, &opts).await;
+        JsonDataFrameViews::from_df_and_opts_unpaginated(df, df_schema, count, &opts).await?;
 
     let new_schema = repositories::data_frames::schemas::get_staged_schema_with_staged_db_manager(
         &workspace.workspace_repo,

--- a/crates/oxen-server/src/controllers/workspaces/data_frames/rows.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames/rows.rs
@@ -64,7 +64,7 @@ pub async fn create(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, Oxen
     let opts = DFOpts::empty();
     let row_schema = Schema::from_polars(row_df.schema());
     let row_df_source = DataFrameSchemaSize::from_df(&row_df, &row_schema);
-    let row_df_view = JsonDataFrameView::from_df_opts(row_df, row_schema, &opts).await;
+    let row_df_view = JsonDataFrameView::from_df_opts(row_df, row_schema, &opts).await?;
 
     let response = JsonDataFrameRowResponse {
         data_frame: JsonDataFrameViews {
@@ -110,7 +110,7 @@ pub async fn get(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let opts = DFOpts::empty();
     let row_schema = Schema::from_polars(row_df.schema());
     let row_df_source = DataFrameSchemaSize::from_df(&row_df, &row_schema);
-    let row_df_view = JsonDataFrameView::from_df_opts(row_df, row_schema, &opts).await;
+    let row_df_view = JsonDataFrameView::from_df_opts(row_df, row_schema, &opts).await?;
 
     let response = JsonDataFrameRowResponse {
         data_frame: JsonDataFrameViews {
@@ -182,7 +182,7 @@ pub async fn update(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, Oxen
     Ok(HttpResponse::Ok().json(JsonDataFrameRowResponse {
         data_frame: JsonDataFrameViews {
             source: DataFrameSchemaSize::from_df(&modified_row, &schema),
-            view: JsonDataFrameView::from_df_opts(modified_row, schema, &DFOpts::empty()).await,
+            view: JsonDataFrameView::from_df_opts(modified_row, schema, &DFOpts::empty()).await?,
         },
         commit: None,
         derived_resource: None,
@@ -224,7 +224,7 @@ pub async fn delete(req: HttpRequest, _bytes: Bytes) -> Result<HttpResponse, Oxe
     Ok(HttpResponse::Ok().json(JsonDataFrameRowResponse {
         data_frame: JsonDataFrameViews {
             source: DataFrameSchemaSize::from_df(&df, &schema),
-            view: JsonDataFrameView::from_df_opts(df, schema, &DFOpts::empty()).await,
+            view: JsonDataFrameView::from_df_opts(df, schema, &DFOpts::empty()).await?,
         },
         commit: None,
         derived_resource: None,

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -444,6 +444,23 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::BadRequest().json(error_json)
                     }
+                    OxenError::InvalidDataFrameParam {
+                        param,
+                        value,
+                        reason,
+                    } => {
+                        log::warn!("Invalid {param} parameter {value:?}: {reason}");
+                        let error_json = json!({
+                            "error": {
+                                "type": "invalid_data_frame_param",
+                                "title": "Invalid query parameter",
+                                "detail": format!("The {param} parameter {value:?} is not usable: {reason}."),
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_BAD_REQUEST,
+                        });
+                        HttpResponse::BadRequest().json(error_json)
+                    }
                     OxenError::NoChanges => {
                         log::warn!("Commit refused, nothing staged differs from the parent commit");
                         let error_json = json!({
@@ -1188,6 +1205,22 @@ mod tests {
         let error = OxenHttpError::from(OxenError::InvalidFileType(
             "photo.png is a image file, which cannot be read as a data frame".into(),
         ));
+        let response = error.error_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(!response.status().is_server_error());
+        assert_eq!(status_message_of(response).await, MSG_BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn test_an_unusable_data_frame_parameter_is_a_client_error() {
+        // These reach the server straight off the query string, so a panic or a 5xx here hands a
+        // caller the power to fault a request worker with a malformed page or slice.
+        let error = OxenHttpError::from(OxenError::InvalidDataFrameParam {
+            param: "slice",
+            value: "0..0".to_string(),
+            reason: "start must be less than end",
+        });
         let response = error.error_response();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);

--- a/crates/oxen-server/src/params/df_opts_query.rs
+++ b/crates/oxen-server/src/params/df_opts_query.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use actix_web::web;
+use liboxen::error::OxenError;
 use liboxen::opts::DFOpts;
 use serde::Deserialize;
 use utoipa::{IntoParams, ToSchema};
@@ -26,16 +27,20 @@ pub struct DFOptsQuery {
 }
 
 /// Provide some default vals for opts
-pub fn parse_opts(query: &web::Query<DFOptsQuery>, filter_ops: &mut DFOpts) -> DFOpts {
+pub fn parse_opts(
+    query: &web::Query<DFOptsQuery>,
+    filter_ops: &mut DFOpts,
+) -> Result<DFOpts, OxenError> {
     // Default to 0..10 unless they ask for "all"
     log::debug!("Parsing opts {query:?}");
     if let Some(slice) = query.slice.clone() {
-        if slice == "all" {
-            // Return everything...probably don't want to do this unless explicitly asked for
+        // "all" asks for every row, and an empty parameter carries no request at all, so it reads
+        // the same as one the caller left off.
+        if slice == "all" || slice.is_empty() {
             filter_ops.slice = None;
         } else {
-            // Return what they asked for
-            filter_ops.slice = Some(slice);
+            // Reject a range the reader cannot use here, where the request is still in hand.
+            filter_ops.slice = Some(slice.parse()?);
         }
     }
 
@@ -63,7 +68,11 @@ pub fn parse_opts(query: &web::Query<DFOptsQuery>, filter_ops: &mut DFOpts) -> D
         .sort_by_similarity_to
         .clone_from(&query.sort_by_similarity_to);
     filter_ops.sql.clone_from(&query.sql);
-    filter_ops.take.clone_from(&query.take);
+    // An empty parameter carries no request, so it reads the same as one the caller left off.
+    filter_ops.take = query.take.clone().filter(|take| !take.is_empty());
+    // Reject a malformed list here, where the request is still in hand. Deeper in the read path
+    // the same error has callers that cannot answer with a 400.
+    filter_ops.take_indices()?;
 
-    filter_ops.clone()
+    Ok(filter_ops.clone())
 }


### PR DESCRIPTION
Fix some panics we're seeing in production.

A bad slice, take, item, or add-col value panicked the worker thread rather than returning an error, so a caller could fault a request worker with nothing more than a query string. Two were reachable straight from the slice and take query parameters, and a third from an ordinary page parameter.

Slice ranges are now parsed into a type that cannot hold an unusable range, at the two places untrusted input arrives. Callers that build a range from page arithmetic construct that type directly instead of formatting integers into a string for something deeper to parse again. A `page` or `page_size` of zero reads as the first page, matching what the workspace data frame endpoint already did.

A slice that was not shaped like a range, such as "5" or "1..2..3", was previously ignored and the whole frame returned. It is now rejected like any other malformed value. A negative start is rejected too: polars reads it as counting back from the end of the frame, which is not the range the caller named.

The view layer turned these errors straight back into panics by unwrapping the data frame transform, so the diff endpoints kept crashing on a malformed take even once the parse returned cleanly. Those constructors now report the failure to their caller, which answers with a 400.

ENG-1329
Sentry: OXEN-SERVER-28, OXEN-SERVER-29