### PR TITLE
Cache the dependency build in the registry with cargo-chef

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -40,6 +40,10 @@ env:
   AWS_ROLE: ${{ vars.EC2_GITHUB_RUNNER_ROLE }}
   # Lowercase: registry paths are case-sensitive and the owner name is not.
   REGISTRY_IMAGE: ghcr.io/oxen-ai/oxen-server
+  # Its own package: prune_server_images.yml keeps the newest 20 versions of
+  # oxen-server, and a cache manifest per build would spend that budget on entries no
+  # deployment can roll back to.
+  CACHE_IMAGE: ghcr.io/oxen-ai/oxen-server-buildcache
 
 # Each job below states what it needs; a job's own block replaces this one rather
 # than adding to it, so nothing inherits a write it has no use for.
@@ -113,14 +117,49 @@ jobs:
           echo "COMMIT=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "BUILD_DATE_UTC=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
+      # Ahead of the build because the cache below reads and writes the registry.
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The runner is destroyed after the job, so the cache has to live in the
+      # registry. The default docker driver refuses --cache-to type=registry.
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
       # Thin LTO in place of the release profile's fat LTO, a serial link-time pass
       # that reruns whenever this repository's own crates change, so no layer cache
       # can avoid it. `release_docker.yml` passes no override, so released binaries
       # keep fat LTO. `codegen-units` stays at 1 — raising it trades binary size for
       # less time than this saves.
       - name: Build oxen-server Docker Image (${{ inputs.ARCHITECTURE }})
+        env:
+          # Per architecture: a shared ref would have each build overwrite the other.
+          CACHE_REF: ${{ env.CACHE_IMAGE }}:${{ inputs.ARCHITECTURE }}
+          # Branches read the cache, only main writes it, so a branch cannot replace
+          # what main and the release builds read. `github.ref` alone would not do it:
+          # a manual run takes that from the workflow-selection dropdown, not from the
+          # `branch` input it actually builds.
+          WRITE_CACHE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
-          docker build \
+          cache_to=()
+          if [[ "$WRITE_CACHE" == "true" ]]; then
+            # mode=max: the dependency build is not in the final stage, and the
+            # default records only the final stage.
+            cache_to=(--cache-to "type=registry,ref=$CACHE_REF,mode=max")
+          fi
+
+          # --load: a docker-container builder does not populate the daemon, which the
+          # save, tag, and push steps below read from.
+          docker buildx build \
+            --load \
+            --cache-from "type=registry,ref=$CACHE_REF" \
+            "${cache_to[@]}" \
             --build-arg CARGO_PROFILE_RELEASE_LTO=thin \
             --label "org.opencontainers.image.revision=${{ steps.metadata.outputs.COMMIT }}" \
             --label "org.opencontainers.image.version=${{ steps.metadata.outputs.VERSION }}" \
@@ -139,13 +178,6 @@ jobs:
           name: oxen-server-docker-${{ inputs.ARCHITECTURE }}-${{ env.RELEASE_VERSION }}.tar
           path: oxen-server-docker-${{ inputs.ARCHITECTURE }}-${{ env.RELEASE_VERSION }}.tar
           retention-days: 1
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Published so a deployment can consume the image by digest rather than by
       # unpacking a workflow artifact, which expires and can only be fetched

--- a/.github/workflows/prune_server_images.yml
+++ b/.github/workflows/prune_server_images.yml
@@ -33,3 +33,13 @@ jobs:
           package-name: oxen-server
           package-type: container
           min-versions-to-keep: 20
+
+      # Each cache write leaves the manifest it replaced untagged, so this package
+      # grows faster than the image one. Only the newest is read. The rest are headroom
+      # for a build already pulling from one this would otherwise delete.
+      - name: Delete all but the newest build caches
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: oxen-server-buildcache
+          package-type: container
+          min-versions-to-keep: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,21 @@ RUN FFMPEG_ARCH="$TARGETARCH" TOOL_VERSIONS_FILE=/tmp/tool-versions.env \
     && rm -f /tmp/install-ffmpeg
 ENV PKG_CONFIG_PATH="/opt/ffmpeg/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 
+WORKDIR /usr/src/oxen-server
+
+# rustup reads rust-toolchain.toml from the working directory, and the base image's
+# toolchain is not the pinned one. A stage that compiles without it uses a different
+# rustc, so cargo reuses none of that stage's work. Nothing fails, the build just
+# recompiles every dependency, so anything that decides how a crate compiles belongs
+# here ahead of every compile step.
+COPY rust-toolchain.toml ./
+COPY .cargo/config.toml .cargo/config.toml
+RUN rustup toolchain install --no-self-update
+
 # cargo-chef keys the dependency build on the manifests instead of the source tree.
 # Version pinned in tool-versions.env, as with the FFmpeg install above.
 RUN . /tmp/tool-versions.env \
     && cargo install cargo-chef --locked --version "$CARGO_CHEF_VERSION"
-
-WORKDIR /usr/src/oxen-server
 
 # recipe.json describes the dependency graph from the manifests alone. A source edit
 # that leaves them untouched produces an identical recipe, so the cook layer survives.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:1.94-bookworm AS builder
+# Toolchain and system dependencies, shared by every stage that compiles anything.
+FROM rust:1.94-bookworm AS chef
 
 USER root
 RUN apt-get update
@@ -8,15 +9,6 @@ RUN apt-get install -y --no-install-recommends clang openssl libssl-dev pkg-conf
 RUN apt-get update \
     && apt-get -y install --no-install-recommends curl ca-certificates xz-utils build-essential clang cmake pkg-config libjpeg-turbo-progs libpng-dev \
     && rm -rfv /var/lib/apt/lists/*
-
-# FFmpeg 8 for the `ffmpeg` video-thumbnail feature, installed via the shared helper. Pins live in
-# tool-versions.env, the single source of truth shared with Linux dev (bin/install-prereqs) and CI.
-ARG TARGETARCH
-COPY bin/install-ffmpeg tool-versions.env /tmp/ffmpeg-install/
-RUN FFMPEG_ARCH="$TARGETARCH" TOOL_VERSIONS_FILE=/tmp/ffmpeg-install/tool-versions.env \
-    bash /tmp/ffmpeg-install/install-ffmpeg \
-    && rm -rf /tmp/ffmpeg-install
-ENV PKG_CONFIG_PATH="/opt/ffmpeg/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 
 # ENV MAGICK_VERSION 7.1
 
@@ -37,43 +29,59 @@ ENV PKG_CONFIG_PATH="/opt/ffmpeg/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 #     && cmake --build . -j $(nproc) \
 #     && cmake --install .
 
-### This is breaking because cargo-build-deps forces an update to dependencies
-### Commenting out and using a simpler approach until we find an alternative
-###
-# RUN cargo install cargo-build-deps
+# FFmpeg 8 for the `ffmpeg` video-thumbnail feature, installed via the shared helper. Pins live in
+# tool-versions.env, the single source of truth shared with Linux dev (bin/install-prereqs) and CI.
+# That file stays for the cargo-chef install below; only the helper script is cleaned up.
+ARG TARGETARCH
+COPY bin/install-ffmpeg tool-versions.env /tmp/
+RUN FFMPEG_ARCH="$TARGETARCH" TOOL_VERSIONS_FILE=/tmp/tool-versions.env \
+    bash /tmp/install-ffmpeg \
+    && rm -f /tmp/install-ffmpeg
+ENV PKG_CONFIG_PATH="/opt/ffmpeg/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 
-# # create an empty project to install dependencies
-# RUN cd /usr/src && cargo new --bin oxen-server
-# WORKDIR /usr/src/oxen-server
-# COPY Cargo.toml Cargo.lock ./
-# COPY crates/liboxen/Cargo.toml crates/liboxen/Cargo.toml
-# COPY crates/oxen-cli/Cargo.toml crates/oxen-cli/Cargo.toml
-# COPY crates/oxen-server/Cargo.toml crates/oxen-server/Cargo.toml
-# # build just the deps for caching
-# RUN cargo build-deps --release
-
-# # copy the rest of the source and build the server and cli
-# COPY src src
-# RUN cargo build --release
-### end commented section
+# cargo-chef keys the dependency build on the manifests instead of the source tree.
+# Version pinned in tool-versions.env, as with the FFmpeg install above.
+RUN . /tmp/tool-versions.env \
+    && cargo install cargo-chef --locked --version "$CARGO_CHEF_VERSION"
 
 WORKDIR /usr/src/oxen-server
+
+# recipe.json describes the dependency graph from the manifests alone. A source edit
+# that leaves them untouched produces an identical recipe, so the cook layer survives.
+FROM chef AS planner
 COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
 
 # Defaults to what `[profile.release]` in Cargo.toml already sets, so a build passing
 # no override compiles exactly what a plain release build compiles. Cargo reads this
 # as a profile override, the same mechanism release_windows.yml uses to select thin
 # LTO. It is re-declared as `ENV` because an `ARG` alone is not reliably present in
 # the `RUN` process environment.
+#
+# Must precede cook: the profile a dependency compiled under is part of its cached
+# artifact, so cooking and building under different profiles discards cook's work.
 ARG CARGO_PROFILE_RELEASE_LTO=true
 ENV CARGO_PROFILE_RELEASE_LTO=${CARGO_PROFILE_RELEASE_LTO}
 
 # Keeps the symbol table in the server binary, so a panic reported to Sentry names its frames.
 # `debuginfo` drops DWARF, so a frame carries a function name but no file or line. Scoped to this
 # image: every other build of the workspace uses the `strip` setting in `[profile.release]`.
+# Also a profile setting, so it precedes cook for the reason the LTO override above gives.
 ARG CARGO_PROFILE_RELEASE_STRIP=debuginfo
 ENV CARGO_PROFILE_RELEASE_STRIP=${CARGO_PROFILE_RELEASE_STRIP}
 
+# cook compiles dependencies only. Its flags must match the build below, features
+# included, or feature unification differs and the dependencies compile again instead
+# of being reused. `-p` stands in for `--workspace --exclude oxen-py`, which cook
+# cannot express: oxen-py needs a Python toolchain this image lacks, and oxen-cli plus
+# oxen-server reach the same dependencies.
+COPY --from=planner /usr/src/oxen-server/recipe.json recipe.json
+RUN cargo chef cook --release --features liboxen/ffmpeg,oxen-server/otel \
+    -p oxen-cli -p oxen-server --recipe-path recipe.json
+
+COPY . .
 # `oxen-server/otel` compiles the OTLP span exporter and inbound W3C trace-context extraction into
 # the binary; both stay dormant until an OTLP endpoint is configured at runtime. Named explicitly
 # rather than via the `production` feature, which additionally turns on `perf-logging`.

--- a/tool-versions.env
+++ b/tool-versions.env
@@ -1,16 +1,11 @@
 # Pinned tool versions for Oxen development.
 #
-# This file is the single source of truth read by:
-#   - bin/install-prereqs
-#   - bin/install-ffmpeg
-#   - .github/workflows that install uv (setup-uv and Windows choco)
-#   - .pre-commit-config.yaml (local hooks)
-#
 # Format: KEY=VALUE (no spaces around '=', no quoting needed).
 # Lines starting with '#' are comments.
 
 # Cargo-installable tools
 BACON_VERSION=3.22.0
+CARGO_CHEF_VERSION=0.1.77
 CARGO_MACHETE_VERSION=0.9.2
 CARGO_LLVM_COV_VERSION=0.8.7
 CARGO_SORT_VERSION=2.1.4


### PR DESCRIPTION
# Proposal - don't merge yet

Cuts the dev image build from about 8m50s to **6m07s** on an ordinary merge, a 31% saving.

`COPY . .` puts the whole tree in one layer, so any source change invalidates it and the build recompiles all 700 dependencies. cargo-chef splits that: a planner stage reduces the tree to `recipe.json`, the builder cooks dependencies from it, and source is copied afterwards. The runner is destroyed after each job, so the cache lives in the registry, which needs the docker-container buildx driver. Only `main` writes it.

## Measurements

arm64, `m7g.4xlarge`, `docker build` step only.

| | `main` today | cold | ordinary merge |
|---|---|---|---|
| `cargo chef cook` | n/a | 700 crates, 264.2s | 49.6s restored, 0 compiled |
| `cargo build` | n/a | 3 crates, 218.6s | 3 crates, 224.4s |
| cache export | n/a | 109.8s | 17.6s |
| build step | ~8m50s | 11m00s | **6m07s** |

Runs 31546916895, 31547808017 and 31728339790. The last one changed the build context without touching a manifest, which is the shape of a normal merge.

The cold column is what a build pays whenever `recipe.json` changes: the first merge after this lands, and every later dependency edit. A slow build there is expected rather than a regression. A release version bump does not invalidate it, because cargo-chef normalizes member versions in the skeleton.

## Why the toolchain moves into the base stage

The first attempt succeeded while being slower than what it replaced, at 17m11s. `cook` ran in a stage holding only `recipe.json`, so `rust-toolchain.toml` was absent and cook compiled against the image's 1.94 rather than the pinned 1.97.1. rustc's version is a global fingerprint input, so the build reused none of that work. `rust-toolchain.toml` and `.cargo/config.toml` now land in the `chef` stage ahead of anything that compiles.

That failure mode is the thing worth checking in review. Any global compilation input added outside the `chef` stage silently stops the cache working, and the only symptom is a slower build.

## For

- 2m43s off every merge to `main`, at roughly five merges a day.
- The dependency phase is gated by the `libduckdb-sys` and `librocksdb-sys` C/C++ build scripts, which no Rust-side tuning reaches.
- The apt and FFmpeg layers start being reused as well.
- Branches read the cache but cannot write it, so a branch cannot replace what `main` and the release builds read.

## Against

- Three build stages, a buildx driver switch, a registry cache, and a second GHCR package with its own pruning.
- The silent failure described above, guarded only by a comment.
- Roughly 100s of the theoretical 4m22s saving goes on restoring the cooked layer and copying source into two stages, so the payoff falls well short of the ceiling.
- `release_docker.yml` is untouched, so releases get none of this.
