### PR TITLE
Compile server with debuginfo so we can find causes of panics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,12 @@ COPY . .
 ARG CARGO_PROFILE_RELEASE_LTO=true
 ENV CARGO_PROFILE_RELEASE_LTO=${CARGO_PROFILE_RELEASE_LTO}
 
+# Keeps the symbol table in the server binary, so a panic reported to Sentry names its frames.
+# `debuginfo` drops DWARF, so a frame carries a function name but no file or line. Overrides the
+# `strip` setting in `[profile.release]`, which the CLI and the Python wheels still build under.
+ARG CARGO_PROFILE_RELEASE_STRIP=debuginfo
+ENV CARGO_PROFILE_RELEASE_STRIP=${CARGO_PROFILE_RELEASE_STRIP}
+
 # `oxen-server/otel` compiles the OTLP span exporter and inbound W3C trace-context extraction into
 # the binary; both stay dormant until an OTLP endpoint is configured at runtime. Named explicitly
 # rather than via the `production` feature, which additionally turns on `perf-logging`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,8 @@ ARG CARGO_PROFILE_RELEASE_LTO=true
 ENV CARGO_PROFILE_RELEASE_LTO=${CARGO_PROFILE_RELEASE_LTO}
 
 # Keeps the symbol table in the server binary, so a panic reported to Sentry names its frames.
-# `debuginfo` drops DWARF, so a frame carries a function name but no file or line. Overrides the
-# `strip` setting in `[profile.release]`, which the CLI and the Python wheels still build under.
+# `debuginfo` drops DWARF, so a frame carries a function name but no file or line. Scoped to this
+# image: every other build of the workspace uses the `strip` setting in `[profile.release]`.
 ARG CARGO_PROFILE_RELEASE_STRIP=debuginfo
 ENV CARGO_PROFILE_RELEASE_STRIP=${CARGO_PROFILE_RELEASE_STRIP}
 
@@ -78,6 +78,9 @@ ENV CARGO_PROFILE_RELEASE_STRIP=${CARGO_PROFILE_RELEASE_STRIP}
 # the binary; both stay dormant until an OTLP endpoint is configured at runtime. Named explicitly
 # rather than via the `production` feature, which additionally turns on `perf-logging`.
 RUN cargo build --workspace --exclude oxen-py --release --features liboxen/ffmpeg,oxen-server/otel
+
+# The CLI ships without a symbol table. Only oxen-server reports panics.
+RUN strip target/release/oxen
 
 # Minimal image to run the binary (without Rust toolchain)
 FROM debian:bookworm-slim AS runtime


### PR DESCRIPTION
Every panic oxen-server reports to Sentry arrives with twenty unresolved frames because the server image builds under a release profile that strips the symbol table. A panic can be seen but not located, so each one requires an open-ended hunt for the root cause.

The server image now keeps the symbol table, so a reported panic includes its frames. The CLI and the Python wheels build under the unchanged profile and still ship stripped.

ENG-1579
Sentry: OXEN-SERVER-18, OXEN-SERVER-19, OXEN-SERVER-1A, OXEN-SERVER-1D, OXEN-SERVER-20, OXEN-SERVER-21, OXEN-SERVER-22, OXEN-SERVER-1Y