### PR TITLE
Fix NFS CI by closing LMDB envs before cleaning up repository directories

### DIFF
--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -336,7 +336,12 @@ pub async fn create(
     Ok(local_repo)
 }
 
-pub async fn delete(repo: &LocalRepository) -> Result<&LocalRepository, OxenError> {
+/// Removes a repository: its version blobs, then its directory.
+///
+/// Consumes `repo` so the Merkle node store it owns closes before the directory is removed. A
+/// directory removed around an open LMDB env keeps the mapped `data.mdb` and `lock.mdb`, which
+/// fails the removal on Windows and on NFS.
+pub async fn delete(repo: LocalRepository) -> Result<(), OxenError> {
     if !repo.path.exists() {
         let err = format!("Repository does not exist {:?}", repo.path);
         return Err(OxenError::basic_str(err));
@@ -346,8 +351,9 @@ pub async fn delete(repo: &LocalRepository) -> Result<&LocalRepository, OxenErro
     // custom versions_path) they live outside the repo directory.
     repo.version_store().destroy().await?;
 
-    delete_dir(&repo.path).await?;
-    Ok(repo)
+    let path = repo.path.clone();
+    drop(repo);
+    delete_dir(&path).await
 }
 
 /// Removes a repository's directory.
@@ -423,7 +429,7 @@ mod tests {
             assert!(store.version_exists(&hash).await?);
             assert!(custom_root.exists());
 
-            repositories::delete(&repo).await?;
+            repositories::delete(repo).await?;
 
             assert!(
                 !custom_root.exists(),

--- a/crates/liboxen/src/test.rs
+++ b/crates/liboxen/src/test.rs
@@ -11,6 +11,7 @@ use crate::core;
 use crate::core::db::merkle_node::MerkleNodeBackend;
 use crate::core::df::duckdb_setup;
 use crate::error::OxenError;
+use crate::lmdb;
 use crate::model::Schema;
 use crate::model::User;
 use crate::model::data_frame::schema::Field;
@@ -35,6 +36,7 @@ use std::sync::LazyLock;
 use std::sync::Mutex;
 use tokio::time::sleep;
 use tracing::level_filters::LevelFilter;
+use walkdir::WalkDir;
 
 pub const DEFAULT_TEST_HOST: &str = "localhost:3000";
 
@@ -976,7 +978,9 @@ where
         }
     };
 
-    // Cleanup Local
+    // Cleanup Local. The repo owns its LMDB env, which must be closed before the directory
+    // holding it is removed (see `assert_no_live_lmdb_envs`).
+    drop(local_repo);
     maybe_cleanup_repo(&path)?;
 
     // Assert everything okay after we cleanup the repo dir
@@ -1078,7 +1082,9 @@ where
         }
     };
 
-    // Cleanup Local
+    // Cleanup Local. The repo owns its LMDB env, which must be closed before the directory
+    // holding it is removed (see `assert_no_live_lmdb_envs`).
+    drop(local_repo);
     maybe_cleanup_repo(&path)?;
 
     // Assert everything okay after we cleanup the repo dir
@@ -1429,6 +1435,24 @@ fn should_cleanup() -> bool {
         .unwrap_or(false)
 }
 
+/// Panics when any LMDB env under `dir` is still open, naming each one. Removing a directory that
+/// holds an open env leaves its memory-mapped `data.mdb` and `lock.mdb` behind (an outright removal
+/// failure on Windows, a hidden `.nfsXXXX` entry on NFS that fails the `rmdir` with `ENOTEMPTY`),
+/// so every `LocalRepository` under `dir` must be dropped before this call.
+pub fn assert_no_live_lmdb_envs(dir: &Path) {
+    let live: Vec<PathBuf> = WalkDir::new(dir)
+        .into_iter()
+        .flatten()
+        .map(|entry| entry.path().to_path_buf())
+        .filter(|path| path.ends_with(constants::NODES_LMDB_DIR) && lmdb::shared_env_is_live(path))
+        .collect();
+    assert!(
+        live.is_empty(),
+        "LMDB envs still open while removing {dir:?}: {live:?}. \
+         Drop every LocalRepository under it first."
+    );
+}
+
 pub fn maybe_cleanup_repo(repo_dir: &Path) -> Result<(), OxenError> {
     // Always remove caches
     merkle_tree_node_cache::remove_from_cache(repo_dir)?;
@@ -1439,6 +1463,7 @@ pub fn maybe_cleanup_repo(repo_dir: &Path) -> Result<(), OxenError> {
     core::workspaces::workspace_name_index::remove_from_cache_with_children(repo_dir);
 
     if should_cleanup() {
+        assert_no_live_lmdb_envs(repo_dir);
         log::debug!("maybe_cleanup_repo: cleaning up repo: {repo_dir:?}");
         util::fs::remove_dir_all(repo_dir)?;
     } else {

--- a/crates/oxen-server/src/controllers/repositories.rs
+++ b/crates/oxen-server/src/controllers/repositories.rs
@@ -541,8 +541,8 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     // Delete in a background task because it could take awhile; the blocking directory
     // removal runs inside delete's own spawn_blocking.
     tokio::spawn(async move {
-        let result = match &repository {
-            Some(repository) => repositories::delete(repository).await.map(|_| ()),
+        let result = match repository {
+            Some(repository) => repositories::delete(repository).await,
             None => repositories::delete_dir(&repo_dir).await,
         };
 

--- a/crates/oxen-server/src/controllers/versions.rs
+++ b/crates/oxen-server/src/controllers/versions.rs
@@ -984,7 +984,7 @@ mod tests {
             assert_eq!(stored, content.as_bytes());
         }
 
-        test::cleanup_sync_dir(&sync_dir)?;
+        test::cleanup_repo_and_sync_dir(repo, &sync_dir)?;
         Ok(())
     }
 }

--- a/crates/oxen-server/src/test.rs
+++ b/crates/oxen-server/src/test.rs
@@ -29,14 +29,16 @@ pub fn cleanup_sync_dir(sync_dir: &Path) -> Result<(), OxenError> {
     df_db::remove_df_db_from_cache_with_children(sync_dir)?;
     dir_hashes_db::remove_from_cache_with_children(sync_dir)?;
     workspace_name_index::remove_from_cache_with_children(sync_dir);
+    liboxen::test::assert_no_live_lmdb_envs(sync_dir);
     std::fs::remove_dir_all(sync_dir)?;
     Ok(())
 }
 
 /// Drop `repo` before removing `sync_dir`, then clean up. Under the LMDB Merkle-node backend a
 /// `LocalRepository` holds its env's `data.mdb`/`lock.mdb` memory-mapped for its whole lifetime;
-/// on Windows those mapped files cannot be deleted, so the owner must be dropped before the
-/// directory is removed. Consuming `repo` makes that ordering compiler-enforced.
+/// removing the directory around a mapped file fails outright on Windows and leaves a hidden
+/// `.nfsXXXX` entry on NFS that fails the `rmdir` with `ENOTEMPTY`, so the owner must be dropped
+/// before the directory is removed. Consuming `repo` makes that ordering compiler-enforced.
 pub fn cleanup_repo_and_sync_dir(repo: LocalRepository, sync_dir: &Path) -> Result<(), OxenError> {
     drop(repo);
     cleanup_sync_dir(sync_dir)


### PR DESCRIPTION
Fix the nightly NFS Test Suite by closing each repo's LMDB env before the directory holding it is removed.

`repositories::delete` also consumes its repository now, so the LMDB env closes before the directory gets deleted.
