### PR TITLE
Configure OTLP export through the standard OpenTelemetry variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -418,7 +418,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2270,7 +2270,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3097,7 +3097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3971,7 +3971,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4268,7 +4268,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5188,7 +5188,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5522,9 +5522,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -5536,22 +5536,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.5.0",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "flate2",
  "http 1.5.0",
@@ -5560,18 +5560,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -5582,15 +5582,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
@@ -5938,18 +5939,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6705,6 +6706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6937,7 +6947,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6975,7 +6985,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7339,6 +7349,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.15",
@@ -7578,7 +7589,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7675,7 +7686,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8408,7 +8419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8719,7 +8730,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9066,6 +9077,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9133,9 +9155,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-actix-web"
-version = "0.7.21"
+version = "0.7.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca6b15407f9bfcb35f82d0e79e603e1629ece4e91cc6d9e58f890c184dd20af"
+checksum = "36bb7a33ce7f0807d44124b5119ea3581fd59028db56477a7aa01741c869ca6a"
 dependencies = [
  "actix-web",
  "mutually_exclusive_features",
@@ -9202,9 +9224,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -9763,7 +9785,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,12 +104,23 @@ minus = { version = "5.4.0", features = ["static_output", "search"] }
 mockito = "1.1.0"
 mp4 = "0.14.0"
 num_cpus = "1.16.0"
-opentelemetry = "0.31"
+opentelemetry = "0.32"
 # The OTLP/HTTP encoding is chosen by this feature list, not at runtime. Binary protobuf comes
 # from the default "http-proto"; adding "http-json" back would make JSON the exporter's default
 # encoding, which is why the builder names its encoding instead of inheriting it.
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "gzip-http", "gzip-tonic", "tls-roots", "trace"] }
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
+#
+# "tls-roots" supplies the platform trust store that `ClientTlsConfig::with_native_roots()` reads,
+# and "tls-ring" supplies the crypto provider it runs on. Without a provider feature the gRPC
+# exporter refuses to build for an `https://` endpoint, which disables export.
+opentelemetry-otlp = { version = "0.32", features = [
+    "grpc-tonic",
+    "gzip-http",
+    "gzip-tonic",
+    "tls-ring",
+    "tls-roots",
+    "trace",
+] }
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
 os_path = "0.8.0"
 page_size = "0.6.0"
 par-stream = { version = "0.10.2", features = ["runtime-tokio"] }
@@ -159,7 +170,7 @@ tracing = "0.1"
 tracing-actix-web = { version = "0.7", default-features = false }
 tracing-appender = "0.2"
 tracing-log = "0.2"
-tracing-opentelemetry = "0.32"
+tracing-opentelemetry = "0.33"
 # "tracing-log" installs the log->tracing bridge, without which none of the `log::*` call sites
 # reach a subscriber layer. It is also a default feature; listed explicitly so turning defaults off
 # cannot silently unhook every error report.

--- a/README.md
+++ b/README.md
@@ -286,8 +286,8 @@ at runtime. See [Prometheus Metrics](crates/oxen-server/README.md#prometheus-met
 
 `oxen-server` can export tracing spans to any OTLP-compatible collector (Jaeger, Tempo, etc.),
 continuing a trace begun by whoever called it. The release image is built with the `otel` feature;
-a local build needs it named explicitly. Export stays off until `OXEN_OTEL_ENDPOINT` (or the
-standard `OTEL_EXPORTER_OTLP_ENDPOINT`) is set. The CLI and the Python bindings can export too.
+a local build needs it named explicitly. Export stays off until the standard
+`OTEL_EXPORTER_OTLP_ENDPOINT` is set. The CLI and the Python bindings can export too.
 See [OpenTelemetry Tracing](crates/oxen-server/README.md#opentelemetry-tracing) for the full env-var
 reference.
 

--- a/bin/otel-metrics-test
+++ b/bin/otel-metrics-test
@@ -203,9 +203,9 @@ MODIFIED_AUTH_CONFIG=true
 # that is what a deployment uses: it is the binary built with the otel feature, and hosted
 # collectors commonly accept OTLP/HTTP with binary protobuf and nothing else. The trace
 # assertions below read the server's spans, so a break in HTTP export shows up there as missing
-# or unparented spans rather than as an obvious export failure.
-OXEN_OTEL_ENDPOINT=http://localhost:4318 \
-OXEN_OTEL_PROTOCOL=http \
+# or unparented spans rather than as an obvious export failure. The server names no transport, so
+# this also covers the default resolving to HTTP.
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
 OXEN_METRICS_PORT="$OXEN_METRICS_PORT" \
 "$SERVER" start -p "$OXEN_SERVER_PORT" &
 SERVER_PID=$!
@@ -272,7 +272,8 @@ echo "modified in repo-b" >> test-file.txt
 
 # Repo A: pull (with client-side OTel too)
 cd "$REPO_A_DIR"
-OXEN_OTEL_ENDPOINT=http://localhost:4317 \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
 "$OXEN" pull
 
 # ── oxen-python OTel check ──
@@ -287,7 +288,8 @@ echo "another change for python test" >> test-file.txt
 
 # Pull from repo-a using Python with OTel enabled
 cd "$REPO_A_DIR"
-OXEN_OTEL_ENDPOINT=http://localhost:4317 \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
 "$REPO_ROOT/oxen-python/.venv/bin/python" -c "
 import oxen
 repo = oxen.Repo('.')

--- a/crates/liboxen/src/util/telemetry.rs
+++ b/crates/liboxen/src/util/telemetry.rs
@@ -22,10 +22,8 @@ pub enum TelemetryError {
     #[error("Failed to initialize tracing: {0}")]
     InitFail(#[from] TryInitError),
     #[cfg(feature = "otel")]
-    #[error(
-        "Unknown OTEL_EXPORTER_OTLP_PROTOCOL value: {0} (expected grpc, http, http/protobuf, or http/json)"
-    )]
-    UnknownProtocol(String),
+    #[error("Unknown {var} value: {value} (expected grpc, http, http/protobuf, or http/json)")]
+    UnknownProtocol { var: &'static str, value: String },
 }
 
 /// A caller-supplied tracing layer composed into the registry by
@@ -479,24 +477,37 @@ impl std::fmt::Display for Protocol {
 /// The transport OTLP export uses, from the traces-specific protocol variable or the general one.
 #[cfg(feature = "otel")]
 fn otel_protocol() -> Result<Protocol, TelemetryError> {
-    let configured = non_empty_env("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
-        .or_else(|| non_empty_env("OTEL_EXPORTER_OTLP_PROTOCOL"));
-    parse_otel_protocol(configured.as_deref())
+    let (var, configured) = [
+        "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_PROTOCOL",
+    ]
+    .into_iter()
+    .find_map(|var| non_empty_env(var).map(|value| (var, Some(value))))
+    .unwrap_or(("OTEL_EXPORTER_OTLP_PROTOCOL", None));
+    parse_otel_protocol(var, configured.as_deref())
 }
 
 /// Read a configured protocol as a transport, defaulting to HTTP where nothing is configured.
 ///
+/// An unaccepted value is reported against `var`, the variable it came from.
+///
 /// `http/protobuf` and `http/json` name an encoding as well as a transport, and both select HTTP.
 /// Spans are encoded as binary protobuf either way, which every OTLP/HTTP endpoint accepts.
 #[cfg(feature = "otel")]
-fn parse_otel_protocol(configured: Option<&str>) -> Result<Protocol, TelemetryError> {
+fn parse_otel_protocol(
+    var: &'static str,
+    configured: Option<&str>,
+) -> Result<Protocol, TelemetryError> {
     match configured
         .map(|value| value.trim().to_lowercase())
         .as_deref()
     {
         None | Some("http" | "http/protobuf" | "http/json") => Ok(Protocol::Http),
         Some("grpc") => Ok(Protocol::Grpc),
-        Some(unknown) => Err(TelemetryError::UnknownProtocol(unknown.to_string())),
+        Some(unknown) => Err(TelemetryError::UnknownProtocol {
+            var,
+            value: unknown.to_string(),
+        }),
     }
 }
 
@@ -763,7 +774,10 @@ mod tests {
         /// default across the OTLP ecosystem.
         #[test]
         fn no_configured_protocol_is_http() {
-            assert_eq!(parse_otel_protocol(None).unwrap(), Protocol::Http);
+            assert_eq!(
+                parse_otel_protocol("OTEL_EXPORTER_OTLP_PROTOCOL", None).unwrap(),
+                Protocol::Http
+            );
         }
 
         /// `OTEL_EXPORTER_OTLP_PROTOCOL` carries values naming an encoding along with the
@@ -771,7 +785,11 @@ mod tests {
         /// copying a stock OTLP snippet exports over the transport it asked for.
         #[test]
         fn standard_protocol_values_select_a_transport() {
-            assert_eq!(parse_otel_protocol(Some("grpc")).unwrap(), Protocol::Grpc);
+            let var = "OTEL_EXPORTER_OTLP_PROTOCOL";
+            assert_eq!(
+                parse_otel_protocol(var, Some("grpc")).unwrap(),
+                Protocol::Grpc
+            );
             // Case and surrounding whitespace are normalized before the match, so the HTTP
             // spellings cover both for every value.
             for value in [
@@ -782,21 +800,37 @@ mod tests {
                 " http ",
             ] {
                 assert_eq!(
-                    parse_otel_protocol(Some(value)).unwrap(),
+                    parse_otel_protocol(var, Some(value)).unwrap(),
                     Protocol::Http,
                     "{value} should select HTTP"
                 );
             }
         }
 
+        /// An unaccepted value names the variable it came from, so an operator who set the
+        /// traces-specific one is not sent looking at the general one.
         #[test]
         fn rejects_an_unknown_protocol() {
-            for value in ["https", "http/proto", "tcp"] {
-                let result = parse_otel_protocol(Some(value));
-                assert!(
-                    matches!(result, Err(TelemetryError::UnknownProtocol(_))),
-                    "{value} should be rejected, got {result:?}"
-                );
+            for var in [
+                "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+                "OTEL_EXPORTER_OTLP_PROTOCOL",
+            ] {
+                for value in ["https", "http/proto", "tcp"] {
+                    let result = parse_otel_protocol(var, Some(value));
+                    match result {
+                        Err(TelemetryError::UnknownProtocol {
+                            var: named,
+                            value: v,
+                        }) => {
+                            assert_eq!(
+                                named, var,
+                                "the rejected value should name its own variable"
+                            );
+                            assert_eq!(v, value);
+                        }
+                        other => panic!("{var}={value} should be rejected, got {other:?}"),
+                    }
+                }
             }
         }
 

--- a/crates/liboxen/src/util/telemetry.rs
+++ b/crates/liboxen/src/util/telemetry.rs
@@ -476,10 +476,12 @@ impl std::fmt::Display for Protocol {
     }
 }
 
-/// The transport OTLP export uses.
+/// The transport OTLP export uses, from the traces-specific protocol variable or the general one.
 #[cfg(feature = "otel")]
 fn otel_protocol() -> Result<Protocol, TelemetryError> {
-    parse_otel_protocol(non_empty_env("OTEL_EXPORTER_OTLP_PROTOCOL").as_deref())
+    let configured = non_empty_env("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
+        .or_else(|| non_empty_env("OTEL_EXPORTER_OTLP_PROTOCOL"));
+    parse_otel_protocol(configured.as_deref())
 }
 
 /// Read a configured protocol as a transport, defaulting to HTTP where nothing is configured.

--- a/crates/liboxen/src/util/telemetry.rs
+++ b/crates/liboxen/src/util/telemetry.rs
@@ -23,14 +23,9 @@ pub enum TelemetryError {
     InitFail(#[from] TryInitError),
     #[cfg(feature = "otel")]
     #[error(
-        "Unknown OXEN_OTEL_PROTOCOL / OTEL_EXPORTER_OTLP_PROTOCOL value: {0} (expected grpc, http, http/protobuf, or http/json)"
+        "Unknown OTEL_EXPORTER_OTLP_PROTOCOL value: {0} (expected grpc, http, http/protobuf, or http/json)"
     )]
     UnknownProtocol(String),
-    #[cfg(feature = "otel")]
-    #[error(
-        "OXEN_OTEL_ENDPOINT must be an http:// or https:// URL, or a bare host:port (got: {0})"
-    )]
-    InvalidEndpoint(String),
 }
 
 /// A caller-supplied tracing layer composed into the registry by
@@ -164,17 +159,16 @@ mod atexit_flush {
 /// values: `NEW`, `CLOSE`, `ENTER`, `EXIT`, `ACTIVE`, `FULL`, `NONE`,
 /// `1`/`true` (alias for `CLOSE`), or `|`-combined (e.g. `NEW|CLOSE`).
 ///
-/// **OpenTelemetry** (opt-in via `OXEN_OTEL_ENDPOINT`, requires `otel` feature):
-/// export spans to an OTLP-compatible collector. See env var documentation in
-/// the server README for configuration details. Also accepts the standard named
-/// env var `OTEL_EXPORTER_OTLP_ENDPOINT`, but checks `OXEN_OTEL_ENDPOINT` first.
+/// **OpenTelemetry** (opt-in via `OTEL_EXPORTER_OTLP_ENDPOINT`, requires the `otel` feature):
+/// export spans to an OTLP-compatible collector. That variable names the collector and takes
+/// `/v1/traces` under HTTP, while `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` names the traces signal
+/// directly and takes precedence. Both need an `http://` or `https://` scheme, since a schemeless
+/// value leaves the exporter on its own `http://localhost:4318` default. See env var documentation
+/// in the server README for configuration details.
 ///
-/// The `OXEN_OTEL_PROTOCOL` env var selects the transport OTLP exports use, and
-/// accepts `"grpc"`, `"http"`, `"http/protobuf"`, or `"http/json"`, the last
-/// three all meaning HTTP. If not set, the standard
-/// `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` and `OTEL_EXPORTER_OTLP_PROTOCOL` are
-/// read in that order, and absent all three it defaults to `"grpc"`. Spans are
-/// encoded as binary protobuf under either transport.
+/// The `OTEL_EXPORTER_OTLP_PROTOCOL` env var selects the transport, accepting `"grpc"`, `"http"`,
+/// `"http/protobuf"`, or `"http/json"`, where the last three all mean HTTP. Unset, it defaults to
+/// HTTP. Spans are encoded as binary protobuf under either transport.
 ///
 /// **Filtering** is per-layer, not global. `RUST_LOG` (falling back to `default`) gates the log
 /// destinations — stderr, the JSON file, and the caller-supplied layer. Span export is gated
@@ -260,19 +254,16 @@ pub fn init_tracing_with_layer(
     // `OpenTelemetryLayer<S, T>` must match the exact inner subscriber.
     #[cfg(feature = "otel")]
     let (m_otel_layer, m_tracer_provider, m_endpoint_p) = match otel_endpoint() {
-        Some(mut endpoint) => {
-            endpoint.url = normalize_otel_endpoint(&endpoint.url)?;
-
+        Some((var, endpoint)) => {
             let protocol = otel_protocol()?;
 
-            match build_otel_layer(app_name, &protocol, &endpoint) {
+            match build_otel_layer(app_name, &protocol) {
                 (Some(layer), Some(provider)) => {
                     atexit_flush::register(provider.clone());
-                    let url = &endpoint.url;
                     (
                         Some(layer),
                         Some(provider),
-                        Some(format!("{protocol} (protobuf) -> {url}")),
+                        Some(format!("{protocol} (protobuf) -> {var}={endpoint}")),
                     )
                 }
                 _ => (None, None, None),
@@ -303,12 +294,8 @@ pub fn init_tracing_with_layer(
     {
         registry.try_init()?;
 
-        if otel_env(
-            "OXEN_OTEL_ENDPOINT",
-            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-            "OTEL_EXPORTER_OTLP_ENDPOINT",
-        )
-        .is_some()
+        if non_empty_env("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT").is_some()
+            || non_empty_env("OTEL_EXPORTER_OTLP_ENDPOINT").is_some()
         {
             log::error!(
                 "An OTLP endpoint is configured but the otel feature is not enabled! (Ignoring)"
@@ -367,49 +354,20 @@ fn env_names_a_service(
         .any(|name| !name.trim().is_empty())
 }
 
-/// An OTLP endpoint as configured, and whether it names the collector or the traces signal.
+/// The endpoint variable that enables export, and its value, reported for the startup line.
+///
+/// Read only to decide whether to build an exporter at all: without one the exporter defaults to
+/// `http://localhost:4318` and every process would push spans there. The exporter reads these same
+/// variables itself and applies the OTLP precedence and signal-path rules, so the value is not
+/// passed along.
 #[cfg(feature = "otel")]
-struct OtlpEndpoint {
-    url: String,
-    /// Whether the OTLP signal path is this crate's to append. A base endpoint names the collector,
-    /// so `/v1/traces` is appended under HTTP. A signal-specific endpoint already names the signal
-    /// and is dialed exactly as configured, which is what the OpenTelemetry specification requires
-    /// of `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
-    is_base: bool,
-}
-
-/// The OTLP endpoint, from the first of the endpoint variables to name one.
-///
-/// Resolved here rather than through [`otel_env`] because the tier that matched decides whether the
-/// signal path is appended, and that distinction is lost once the value is just a string.
-#[cfg(feature = "otel")]
-fn otel_endpoint() -> Option<OtlpEndpoint> {
-    if let Some(url) = non_empty_env("OXEN_OTEL_ENDPOINT") {
-        return Some(OtlpEndpoint { url, is_base: true });
-    }
-    if let Some(url) = non_empty_env("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") {
-        return Some(OtlpEndpoint {
-            url,
-            is_base: false,
-        });
-    }
-    non_empty_env("OTEL_EXPORTER_OTLP_ENDPOINT").map(|url| OtlpEndpoint { url, is_base: true })
-}
-
-/// The first of three variables to name something: this project's own, then the traces-specific
-/// standard variable, then the general standard one.
-///
-/// That is the precedence the OpenTelemetry SDK applies to its own variables, but only to settings
-/// it reads for itself. The transport is handed to the exporter builder instead, which bypasses
-/// that lookup, so a value configured through a standard variable reaches the exporter only by
-/// being read here.
-///
-/// A blank value names nothing and falls through, so blanking a variable leaves the next one
-/// standing rather than shadowing it with an empty string.
-fn otel_env(oxen: &str, traces: &str, general: &str) -> Option<String> {
-    non_empty_env(oxen)
-        .or_else(|| non_empty_env(traces))
-        .or_else(|| non_empty_env(general))
+fn otel_endpoint() -> Option<(&'static str, String)> {
+    [
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+    ]
+    .into_iter()
+    .find_map(|var| non_empty_env(var).map(|value| (var, value)))
 }
 
 /// The value of `name`, or `None` when it is unset or blank.
@@ -518,108 +476,32 @@ impl std::fmt::Display for Protocol {
     }
 }
 
-/// The transport OTLP export uses, from the first of the protocol variables to name one.
+/// The transport OTLP export uses.
 #[cfg(feature = "otel")]
 fn otel_protocol() -> Result<Protocol, TelemetryError> {
-    let configured = otel_env(
-        "OXEN_OTEL_PROTOCOL",
-        "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
-        "OTEL_EXPORTER_OTLP_PROTOCOL",
-    );
-    parse_otel_protocol(configured.as_deref())
+    parse_otel_protocol(non_empty_env("OTEL_EXPORTER_OTLP_PROTOCOL").as_deref())
 }
 
-/// Read a configured protocol as a transport, defaulting to gRPC where nothing is configured.
+/// Read a configured protocol as a transport, defaulting to HTTP where nothing is configured.
 ///
-/// The standard variables' `http/protobuf` and `http/json` name an encoding as well as a transport,
-/// and both select HTTP. Spans are encoded as binary protobuf either way, which every OTLP/HTTP
-/// endpoint accepts.
+/// `http/protobuf` and `http/json` name an encoding as well as a transport, and both select HTTP.
+/// Spans are encoded as binary protobuf either way, which every OTLP/HTTP endpoint accepts.
 #[cfg(feature = "otel")]
 fn parse_otel_protocol(configured: Option<&str>) -> Result<Protocol, TelemetryError> {
     match configured
         .map(|value| value.trim().to_lowercase())
         .as_deref()
     {
-        None | Some("grpc") => Ok(Protocol::Grpc),
-        Some("http" | "http/protobuf" | "http/json") => Ok(Protocol::Http),
+        None | Some("http" | "http/protobuf" | "http/json") => Ok(Protocol::Http),
+        Some("grpc") => Ok(Protocol::Grpc),
         Some(unknown) => Err(TelemetryError::UnknownProtocol(unknown.to_string())),
     }
 }
 
-/// Turn a configured OTLP endpoint into an absolute URL the exporter can dial.
-///
-/// `http://` and `https://` URLs are taken as given — TLS is what every hosted collector speaks. A
-/// value with no scheme is a host with an optional port (`collector:4317`), the form the OTLP gRPC
-/// convention uses, and gets `http://`. Any other scheme names a transport this exporter cannot
-/// speak and is rejected rather than silently retried against a URL that will never connect. Either
-/// way the result has to name a host.
-#[cfg(feature = "otel")]
-fn normalize_otel_endpoint(endpoint: &str) -> Result<String, TelemetryError> {
-    let endpoint = endpoint.trim();
-    if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
-        require_host(endpoint, endpoint)?;
-        return Ok(endpoint.to_string());
-    }
-    if endpoint.is_empty() || endpoint.contains("://") || endpoint.starts_with('/') {
-        return Err(TelemetryError::InvalidEndpoint(endpoint.to_string()));
-    }
-    let with_scheme = format!("http://{endpoint}");
-    require_host(&with_scheme, endpoint)?;
-    Ok(with_scheme)
-}
-
-/// Reject a URL with no host. Reported against `configured`, the value the operator actually set.
-///
-/// The exporter builds happily from a hostless URL and only fails once it tries to send, so
-/// without this a typo like `http://:4317` looks like a working configuration that silently
-/// exports nothing.
-#[cfg(feature = "otel")]
-fn require_host(url: &str, configured: &str) -> Result<(), TelemetryError> {
-    let invalid = || TelemetryError::InvalidEndpoint(configured.to_string());
-    let parsed = url::Url::parse(url).map_err(|_| invalid())?;
-    match parsed.host_str() {
-        Some(host) if !host.is_empty() => Ok(()),
-        _ => Err(invalid()),
-    }
-}
-
-/// The path OTLP/HTTP posts spans to, relative to the configured base endpoint.
-#[cfg(feature = "otel")]
-const OTLP_HTTP_TRACES_PATH: &str = "/v1/traces";
-
-/// The URL the OTLP/HTTP exporter posts spans to, which only a base endpoint has the signal path
-/// appended to. See [`OtlpEndpoint::is_base`].
-#[cfg(feature = "otel")]
-fn http_endpoint_url(endpoint: &OtlpEndpoint) -> String {
-    if endpoint.is_base {
-        http_traces_endpoint(&endpoint.url)
-    } else {
-        endpoint.url.clone()
-    }
-}
-
-/// The URL OTLP/HTTP posts spans to for a configured base endpoint.
-///
-/// The exporter appends the signal path only to an endpoint it reads from the environment itself;
-/// one handed to the builder is used verbatim, so a base endpoint gets the path here. An endpoint
-/// that already names the path is left alone.
-///
-/// The path is set on the parsed URL rather than concatenated, so a query string an endpoint
-/// carries stays a query string instead of swallowing the path appended after it.
-#[cfg(feature = "otel")]
-fn http_traces_endpoint(endpoint: &str) -> String {
-    let Ok(mut url) = url::Url::parse(endpoint) else {
-        return endpoint.to_string();
-    };
-    let base_path = url.path().trim_end_matches('/');
-    if base_path.ends_with(OTLP_HTTP_TRACES_PATH) {
-        return endpoint.to_string();
-    }
-    url.set_path(&format!("{base_path}{OTLP_HTTP_TRACES_PATH}"));
-    url.to_string()
-}
-
 /// Build an OpenTelemetry tracing layer that exports spans via OTLP.
+///
+/// The exporter reads the endpoint from the environment, appending the OTLP signal path to a
+/// collector endpoint and dialing a traces endpoint as configured.
 ///
 /// Returns the layer (wrapped in `Option`) and the provider. When the
 /// exporter cannot be built, returns `(None, None)`.
@@ -627,7 +509,6 @@ fn http_traces_endpoint(endpoint: &str) -> String {
 fn build_otel_layer<S>(
     app_name: &str,
     protocol: &Protocol,
-    endpoint: &OtlpEndpoint,
 ) -> (
     Option<tracing_opentelemetry::OpenTelemetryLayer<S, opentelemetry_sdk::trace::SdkTracer>>,
     Option<opentelemetry_sdk::trace::SdkTracerProvider>,
@@ -654,7 +535,6 @@ where
             match opentelemetry_otlp::SpanExporter::builder()
                 .with_http()
                 .with_protocol(opentelemetry_otlp::Protocol::HttpBinary)
-                .with_endpoint(http_endpoint_url(endpoint))
                 .build()
             {
                 Ok(e) => e,
@@ -669,7 +549,6 @@ where
             // against. An `http://` endpoint ignores it.
             match opentelemetry_otlp::SpanExporter::builder()
                 .with_tonic()
-                .with_endpoint(&endpoint.url)
                 .with_tls_config(ClientTlsConfig::new().with_native_roots())
                 .build()
             {
@@ -874,22 +753,20 @@ mod tests {
     #[cfg(feature = "otel")]
     mod otel_tests {
         use super::super::{
-            OtlpEndpoint, Protocol, TelemetryError, env_names_a_service, http_endpoint_url,
-            http_traces_endpoint, normalize_otel_endpoint, otel_filter_directives,
+            Protocol, TelemetryError, env_names_a_service, otel_filter_directives,
             parse_otel_protocol,
         };
 
-        /// Nothing configured is gRPC, the transport a collector reached at a bare `host:port`
-        /// speaks.
+        /// Nothing configured is HTTP, the transport `OTEL_EXPORTER_OTLP_PROTOCOL` carries by
+        /// default across the OTLP ecosystem.
         #[test]
-        fn no_configured_protocol_is_grpc() {
-            assert_eq!(parse_otel_protocol(None).unwrap(), Protocol::Grpc);
+        fn no_configured_protocol_is_http() {
+            assert_eq!(parse_otel_protocol(None).unwrap(), Protocol::Http);
         }
 
-        /// The values the standard `OTEL_EXPORTER_OTLP_PROTOCOL` carries name an encoding along
-        /// with the transport. Both HTTP spellings select HTTP rather than being rejected, so a
-        /// deployment configured only through the standard variable exports over the transport it
-        /// asked for instead of silently falling back to gRPC.
+        /// `OTEL_EXPORTER_OTLP_PROTOCOL` carries values naming an encoding along with the
+        /// transport. Both HTTP spellings select HTTP rather than being rejected, so a deployment
+        /// copying a stock OTLP snippet exports over the transport it asked for.
         #[test]
         fn standard_protocol_values_select_a_transport() {
             assert_eq!(parse_otel_protocol(Some("grpc")).unwrap(), Protocol::Grpc);
@@ -954,132 +831,6 @@ mod tests {
                     "both blank at {blank:?} should not count as naming a service"
                 );
             }
-        }
-
-        #[test]
-        fn keeps_http_endpoint() {
-            assert_eq!(
-                normalize_otel_endpoint("http://localhost:4317").unwrap(),
-                "http://localhost:4317"
-            );
-        }
-
-        #[test]
-        fn keeps_https_endpoint() {
-            assert_eq!(
-                normalize_otel_endpoint("https://otlp.vendor.example:443").unwrap(),
-                "https://otlp.vendor.example:443"
-            );
-        }
-
-        #[test]
-        fn adds_scheme_to_bare_host_port() {
-            assert_eq!(
-                normalize_otel_endpoint("localhost:4317").unwrap(),
-                "http://localhost:4317"
-            );
-        }
-
-        #[test]
-        fn adds_scheme_to_bare_host() {
-            assert_eq!(
-                normalize_otel_endpoint("collector").unwrap(),
-                "http://collector"
-            );
-        }
-
-        #[test]
-        fn trims_surrounding_whitespace() {
-            assert_eq!(
-                normalize_otel_endpoint("  http://localhost:4317 ").unwrap(),
-                "http://localhost:4317"
-            );
-        }
-
-        #[test]
-        fn rejects_other_schemes() {
-            for endpoint in ["grpc://localhost:4317", "unix:///var/run/otel.sock"] {
-                let err = normalize_otel_endpoint(endpoint).unwrap_err();
-                assert!(matches!(err, TelemetryError::InvalidEndpoint(_)));
-            }
-        }
-
-        #[test]
-        fn rejects_empty_endpoint() {
-            let err = normalize_otel_endpoint("   ").unwrap_err();
-            assert!(matches!(err, TelemetryError::InvalidEndpoint(_)));
-        }
-
-        /// A hostless URL builds an exporter that only fails once it tries to send, so it has to be
-        /// rejected at startup rather than looking like a working configuration.
-        #[test]
-        fn rejects_endpoints_with_no_host() {
-            for endpoint in ["http://", "https://", "http://:4317", ":4317"] {
-                let result = normalize_otel_endpoint(endpoint);
-                assert!(
-                    matches!(result, Err(TelemetryError::InvalidEndpoint(_))),
-                    "{endpoint} should be rejected, got {result:?}"
-                );
-            }
-        }
-
-        #[test]
-        fn http_signal_path_is_appended_to_a_base_endpoint() {
-            assert_eq!(
-                http_traces_endpoint("http://localhost:4318"),
-                "http://localhost:4318/v1/traces"
-            );
-            assert_eq!(
-                http_traces_endpoint("http://localhost:4318/"),
-                "http://localhost:4318/v1/traces"
-            );
-            assert_eq!(
-                http_traces_endpoint("https://vendor.example/otlp"),
-                "https://vendor.example/otlp/v1/traces"
-            );
-        }
-
-        #[test]
-        fn http_signal_path_is_not_doubled() {
-            assert_eq!(
-                http_traces_endpoint("http://localhost:4318/v1/traces"),
-                "http://localhost:4318/v1/traces"
-            );
-        }
-
-        /// The signal path belongs on the path component. Concatenating it onto the whole URL puts
-        /// it after any query string, producing something the collector never matches.
-        #[test]
-        fn http_signal_path_keeps_a_query_string_intact() {
-            assert_eq!(
-                http_traces_endpoint("http://localhost:4318?token=abc"),
-                "http://localhost:4318/v1/traces?token=abc"
-            );
-            assert_eq!(
-                http_traces_endpoint("https://vendor.example/otlp?token=abc"),
-                "https://vendor.example/otlp/v1/traces?token=abc"
-            );
-        }
-
-        /// Only a base endpoint names the collector, so only a base endpoint gets the signal path.
-        /// A traces endpoint is posted to as configured even when it names no path of its own.
-        /// Appending one would send spans somewhere the operator never pointed us.
-        #[test]
-        fn only_a_base_endpoint_carries_the_signal_path() {
-            let url = "https://vendor.example/otlp";
-            let base = OtlpEndpoint {
-                url: url.to_string(),
-                is_base: true,
-            };
-            let traces = OtlpEndpoint {
-                url: url.to_string(),
-                is_base: false,
-            };
-            assert_eq!(
-                http_endpoint_url(&base),
-                "https://vendor.example/otlp/v1/traces"
-            );
-            assert_eq!(http_endpoint_url(&traces), url);
         }
 
         /// Span export must not be silenced by the stock log level: `#[tracing::instrument]` and

--- a/crates/oxen-cli/README.md
+++ b/crates/oxen-cli/README.md
@@ -64,7 +64,7 @@ OXEN_OTEL_FILTER=warn,liboxen=debug OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost
 |---|---|---|
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector URL, needing an `http://` or `https://` scheme, which under HTTP has `/v1/traces` appended to it. Absent = disabled, unless `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` names one. | *(none)* |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | The traces endpoint, taking precedence over the above and posted to exactly as configured under HTTP, so include `/v1/traces` in it. | *(none)* |
-| `OTEL_EXPORTER_OTLP_PROTOCOL` | Transport: `grpc`, or `http` / `http/protobuf` / `http/json` for HTTP (binary protobuf either way). | `http/protobuf` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Transport: `grpc`, or `http` / `http/protobuf` / `http/json` for HTTP (binary protobuf either way). `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` takes precedence over it. | `http/protobuf` |
 | `OXEN_OTEL_FILTER` | Which spans and events are exported. Same syntax as `RUST_LOG`, and independent of it. | `info` |
 | `RUST_LOG` | Log verbosity on stderr. Does not affect span export. | `off` |
 

--- a/crates/oxen-cli/README.md
+++ b/crates/oxen-cli/README.md
@@ -39,10 +39,10 @@ The `oxen` CLI can export tracing spans to any OTLP-compatible collector
 cargo build -p oxen-cli --features otel
 ```
 
-At runtime, set `OXEN_OTEL_ENDPOINT`:
+At runtime, set `OTEL_EXPORTER_OTLP_ENDPOINT`:
 
 ```bash
-OXEN_OTEL_ENDPOINT=http://localhost:4317 oxen pull
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 oxen pull
 ```
 
 ### Filtering: logs and spans are separate
@@ -57,13 +57,14 @@ session does not change what is exported.
 be narrowed or widened on its own:
 
 ```bash
-OXEN_OTEL_FILTER=warn,liboxen=debug OXEN_OTEL_ENDPOINT=http://localhost:4317 oxen pull
+OXEN_OTEL_FILTER=warn,liboxen=debug OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 oxen pull
 ```
 
 | Variable | Description | Default |
 |---|---|---|
-| `OXEN_OTEL_ENDPOINT` | Collector base URL, which under HTTP has `/v1/traces` appended to it. Falls back to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` (a full traces URL, posted to exactly as configured, so include `/v1/traces` in it), then to `OTEL_EXPORTER_OTLP_ENDPOINT`, a collector base URL appended to like the first. Absent from all three = disabled. | *(none)* |
-| `OXEN_OTEL_PROTOCOL` | Transport: `grpc`, or `http` / `http/protobuf` / `http/json` for HTTP (binary protobuf either way). Falls back to `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, then `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector URL, needing an `http://` or `https://` scheme, which under HTTP has `/v1/traces` appended to it. Absent = disabled, unless `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` names one. | *(none)* |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | The traces endpoint, taking precedence over the above and posted to exactly as configured under HTTP, so include `/v1/traces` in it. | *(none)* |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Transport: `grpc`, or `http` / `http/protobuf` / `http/json` for HTTP (binary protobuf either way). | `http/protobuf` |
 | `OXEN_OTEL_FILTER` | Which spans and events are exported. Same syntax as `RUST_LOG`, and independent of it. | `info` |
 | `RUST_LOG` | Log verbosity on stderr. Does not affect span export. | `off` |
 
@@ -80,7 +81,7 @@ docker run --rm --name jaeger \
   cr.jaegertracing.io/jaegertracing/jaeger:2.17.0
 
 # Run a pull with tracing enabled
-OXEN_OTEL_ENDPOINT=http://localhost:4317 cargo run --features otel -p oxen-cli pull
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 cargo run --features otel -p oxen-cli pull
 
 # View traces at http://localhost:16686 under service "oxen"
 ```

--- a/crates/oxen-server/Cargo.toml
+++ b/crates/oxen-server/Cargo.toml
@@ -26,13 +26,14 @@ path = "src/main.rs"
 [features]
 default = []
 metrics = ["liboxen/metrics", "dep:metrics", "dep:metrics-exporter-prometheus"]
-# `tracing-actix-web/opentelemetry_0_31` is what extracts an inbound `traceparent` and parents the
+# `tracing-actix-web/opentelemetry_0_32` is what extracts an inbound `traceparent` and parents the
 # HTTP root span to it. It must name the same `opentelemetry` minor the rest of the workspace
-# resolves — bump the two together.
+# resolves — bump the two together. A mismatch compiles and exports spans, but the propagator
+# registered by one minor is invisible to the other, so inbound traces stop being continued.
 otel = [
     "liboxen/otel",
     "dep:tracing-opentelemetry",
-    "tracing-actix-web/opentelemetry_0_31",
+    "tracing-actix-web/opentelemetry_0_32",
 ]
 production = ["metrics", "otel", "liboxen/production", "default"]
 

--- a/crates/oxen-server/README.md
+++ b/crates/oxen-server/README.md
@@ -219,49 +219,43 @@ rate(oxen_errors_total[5m])
 cargo build -p oxen-server --features otel
 ```
 
-At runtime, set `OXEN_OTEL_ENDPOINT` to enable export. Nothing is exported
-until you do, so a build with the feature compiled in and no endpoint
+At runtime, set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable export. Nothing is
+exported until you do, so a build with the feature compiled in and no endpoint
 configured behaves exactly like one without it.
 
-```bash
-# gRPC (default protocol) — a bare host:port gets http://
-OXEN_OTEL_ENDPOINT=localhost:4317 oxen-server start
+The endpoint must carry an `http://` or `https://` scheme. A schemeless value
+does not fail: the exporter cannot parse it and falls back to its own default of
+`http://localhost:4318`, so spans go somewhere nobody configured.
 
-# OTLP/HTTP
-OXEN_OTEL_ENDPOINT=localhost:4318 OXEN_OTEL_PROTOCOL=http oxen-server start
+```bash
+# OTLP/HTTP (default protocol)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 oxen-server start
+
+# gRPC
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 OTEL_EXPORTER_OTLP_PROTOCOL=grpc oxen-server start
 
 # A TLS-terminated vendor endpoint
-OXEN_OTEL_ENDPOINT=https://otlp.vendor.example:443 oxen-server start
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.vendor.example:443 oxen-server start
 ```
 
 | Variable | Description | Default |
 |---|---|---|
-| `OXEN_OTEL_ENDPOINT` | Collector endpoint: an `http://` or `https://` URL, or a bare `host:port` (which gets `http://`). Absent = export disabled, unless a standard endpoint variable below names one. | *(none)* |
-| `OXEN_OTEL_PROTOCOL` | Transport: `grpc`, or `http` / `http/protobuf` / `http/json` for HTTP. Under HTTP the OTLP signal path `/v1/traces` is appended to the endpoint unless it already names one, and the payload is binary protobuf whichever of the three spellings is used. | `grpc` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint, an `http://` or `https://` URL. It names the collector, not one signal, so `/v1/traces` is appended under HTTP. Absent = export disabled, unless `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` names one. | *(none)* |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | The traces signal endpoint, taking precedence over the collector endpoint above. It already names the signal, so it is posted to exactly as configured under HTTP and needs `/v1/traces` in it. | *(none)* |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Transport: `grpc`, or `http` / `http/protobuf` / `http/json` for HTTP. The payload is binary protobuf whichever of the three spellings is used. | `http/protobuf` |
 | `OXEN_OTEL_FILTER` | Which spans and events are exported. Same syntax as `RUST_LOG`, and independent of it. | `info` |
+
+A variable set to a blank value counts as unset.
+
+`OXEN_OTEL_FILTER` keeps a project-specific name because it selects spans by
+target and level, a `tracing` concept the OTLP specification has no equivalent
+for. Sampling, which the specification does define, is `OTEL_TRACES_SAMPLER`
+below and is a separate mechanism.
 
 An `https://` endpoint is verified against the platform's root certificate
 store under both transports, so a collector behind a publicly trusted
 certificate needs no further configuration. A private CA has to be installed in
 that store.
-
-The endpoint and the transport each fall back to their standard variables where
-the `OXEN_` one is not set, so a vendor's stock configuration snippet works as
-given. Each is resolved in the order `OXEN_OTEL_*`, then the traces-specific
-standard variable, then the general one:
-
-| Setting | Resolved in this order |
-|---|---|
-| Endpoint | `OXEN_OTEL_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_ENDPOINT` |
-| Transport | `OXEN_OTEL_PROTOCOL`, `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, `OTEL_EXPORTER_OTLP_PROTOCOL` |
-
-A variable set to a blank value names nothing and falls through to the next,
-rather than shadowing it.
-
-`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` names the traces signal rather than the
-collector, so under HTTP it is posted to exactly as configured. Include
-`/v1/traces` in it. The other two name the collector, and `/v1/traces` is
-appended to them.
 
 These standard `OTEL_*` variables are read by the SDK itself:
 
@@ -318,10 +312,10 @@ debugging does not change what is exported:
 
 ```bash
 # Full traces, warnings and errors only on stderr — the recommended setup.
-OXEN_OTEL_ENDPOINT=http://localhost:4317 oxen-server start
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 oxen-server start
 
 # Verbose stderr for a debugging session; the traces are unchanged.
-OXEN_OTEL_ENDPOINT=http://localhost:4317 RUST_LOG=warn,liboxen=debug oxen-server start
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 RUST_LOG=warn,liboxen=debug oxen-server start
 ```
 
 `OXEN_OTEL_FILTER` takes the same directive syntax, so span export can be
@@ -350,7 +344,7 @@ docker run --rm --name jaeger \
   cr.jaegertracing.io/jaegertracing/jaeger:2.17.0
 
 # Start oxen-server with OTel export
-OXEN_OTEL_ENDPOINT=http://localhost:4317 cargo run --features otel -p oxen-server start
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 cargo run --features otel -p oxen-server start
 
 # View traces at http://localhost:16686 under service "oxen-server"
 ```
@@ -394,7 +388,7 @@ output with span timing, JSON file logs, and OpenTelemetry export:
 ```bash
 OXEN_LOG_DIR='/var/log/oxen' \
 OXEN_FMT_SPAN='CLOSE' \
-OXEN_OTEL_ENDPOINT='http://localhost:4317' \
+OTEL_EXPORTER_OTLP_ENDPOINT='http://localhost:4318' \
 RUST_LOG='info' \
 oxen-server start
 ```

--- a/crates/oxen-server/README.md
+++ b/crates/oxen-server/README.md
@@ -243,6 +243,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.vendor.example:443 oxen-server start
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint, an `http://` or `https://` URL. It names the collector, not one signal, so `/v1/traces` is appended under HTTP. Absent = export disabled, unless `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` names one. | *(none)* |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | The traces signal endpoint, taking precedence over the collector endpoint above. It already names the signal, so it is posted to exactly as configured under HTTP and needs `/v1/traces` in it. | *(none)* |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | Transport: `grpc`, or `http` / `http/protobuf` / `http/json` for HTTP. The payload is binary protobuf whichever of the three spellings is used. | `http/protobuf` |
+| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | The same setting for span exports alone, and takes precedence over `OTEL_EXPORTER_OTLP_PROTOCOL` where both are set. | *(whatever `OTEL_EXPORTER_OTLP_PROTOCOL` resolves to)* |
 | `OXEN_OTEL_FILTER` | Which spans and events are exported. Same syntax as `RUST_LOG`, and independent of it. | `info` |
 
 A variable set to a blank value counts as unset.


### PR DESCRIPTION
A followup to #862 

Open telemetry [already defines a set of environment variables](https://opentelemetry.io/docs/specs/otel/protocol/exporter/) to use for configuration, and the the `opentelemetry*` crates already have the functionality to read them and configure them. So let's use the existing environment variables instead of defining our own with custom handling. This makes it so that we can configure these values for any Open Telemetry-supporting service/language/ecosystem in our infrastructure in the same way.

- `OXEN_OTEL_ENDPOINT` and `OXEN_OTEL_PROTOCOL` have been removed.
- The main items to configure now are `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL`.  See [the docs](https://opentelemetry.io/docs/specs/otel/protocol/exporter/) for way more configuration information than you ever wanted to know.
  - The endpoint now requires an `http://` or `https://` scheme.
  - Absent `OTEL_EXPORTER_OTLP_PROTOCOL` the transport is `HTTP`, matching what that variable means elsewhere.
- The transport, the binary protobuf encoding, and the gRPC trust roots stay in this crate's hands, since those guard the dependency graph and the certificate store rather than a configured value.
`OXEN_OTEL_FILTER` stays because it selects spans by target and level, a tracing concept the OTLP specification has no equivalent for.