### PR TITLE
Streamline Tests (15): Report per-test durations with `--timings`

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -55,12 +55,14 @@ Use the `bin/test-rust` script to run the tests — it is the standard, supporte
 ```bash
 bin/test-rust                         # Build and run all Rust tests
 bin/test-rust test_function_name      # Run only Rust tests matching test_function_name
+bin/test-rust --timings test_name     # Report each matching test's duration
 bin/test-rust -p                      # Run the Python test suite (via pytest + maturin)
 bin/test-rust -p -k test_init         # Run Python tests matching test_init
 ```
 - The script starts `oxen-server` itself, so you do not need to start it separately.
 - It does not install prerequisites by default. If a dependency is missing, run `bin/install-prereqs` (or re-run with `bin/test-rust --install-deps`).
 - If the ramdisk cannot be mounted, pass `--no-ramdisk` to run against the regular filesystem.
+- `--timings` prints each test's duration next to its result; plain `cargo test` reports only a per-binary total. Doctests are skipped. When comparing numbers, discard the first run after a build (a cold run reads two to three times high) and keep both sides on the same base commit (main moves fast enough that an older base is a different suite).
 - Arguments after the script's own flags are forwarded after `--` to the libtest binaries (or `pytest` under `-p`).
 - Output the terminal doesn't show goes to two log files, both overwritten per run: `./data/test/oxen-server.log` (server subprocess stdout+stderr) and `./data/test/cargo-test.log` (cargo test's stderr — indicatif progress bars, and any `tracing` output emitted from tokio worker or `spawn_blocking` threads that don't inherit libtest's per-thread capture). Check these first when the terminal report doesn't explain a failure.
 

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -2,7 +2,7 @@
 #
 # Build, configure, and run the Oxen test suite.
 #
-# Usage: test-rust [--ffmpeg] [--keep] [--install-deps] [--no-ramdisk] [-p|--python] [extra args...]
+# Usage: test-rust [--ffmpeg] [--keep] [--install-deps] [--no-ramdisk] [--timings] [-p|--python] [extra args...]
 #
 #   --ffmpeg        Enable the "ffmpeg" cargo feature for build and test commands.
 #   --keep          Do not remove test data (in data/ox and data/test/runs) on cleanup — useful for
@@ -10,6 +10,8 @@
 #   --install-deps  Check and install prerequisites (install-prereqs) before running tests.
 #                   By default, prereqs are not checked.
 #   --no-ramdisk    Skip ramdisk setup and run tests against the regular filesystem.
+#   --timings       Print each test's duration next to its result. Rust runs only; doctests are
+#                   skipped.
 #   -p|--python     Run the oxen-python test suite (via pytest) instead of the Rust test suite.
 #                   Builds the native extension with maturin.
 #   All remaining arguments are forwarded after `--` to the libtest binaries (or `pytest` under -p).
@@ -17,6 +19,7 @@
 # Examples:
 #   test-rust                       # Run all Rust tests
 #   test-rust test_name             # Run Rust tests matching test_name
+#   test-rust --timings test_name   # Report each matching test's duration
 #   test-rust -p                    # Run all Python tests
 #   test-rust -p -k test_init      # Run Python tests matching test_init
 #
@@ -31,12 +34,14 @@ KEEP_DATA=false
 INSTALL_DEPS=false
 RUN_PYTHON=false
 USE_RAMDISK=true
+TIMINGS=false
 while true; do
     case "${1:-}" in
         --ffmpeg)        FEATURE_ARGS="-F ffmpeg"; shift ;;
         --keep)          KEEP_DATA=true; shift ;;
         --install-deps)  INSTALL_DEPS=true; shift ;;
         --no-ramdisk)    USE_RAMDISK=false; shift ;;
+        --timings)       TIMINGS=true; shift ;;
         -p|--python)     RUN_PYTHON=true; shift ;;
         *) break ;;
     esac
@@ -261,9 +266,18 @@ else
     # written to the log at all. Tail the log to debug what would have shown on stderr.
     CARGO_TEST_LOG="./data/test/cargo-test.log"
     mkdir -p "$(dirname "$CARGO_TEST_LOG")"
-    echo "==> Running tests with 'cargo test --workspace --no-fail-fast $FEATURE_ARGS -- $*' (stderr at ${CARGO_TEST_LOG}) ..."
+    TARGET_ARGS=""
+    if [ "$TIMINGS" = true ]; then
+        # --report-time needs RUSTC_BOOTSTRAP; the runner sets it for the test binaries only,
+        # leaving the build untouched. Doctests reject the flag, so they are left out.
+        HOST_TRIPLE=$(rustc -vV | awk '/^host:/{print $2}')
+        export "CARGO_TARGET_$(echo "$HOST_TRIPLE" | tr 'a-z-' 'A-Z_')_RUNNER=env RUSTC_BOOTSTRAP=1"
+        TARGET_ARGS="--lib --bins --tests"
+        set -- "$@" -Z unstable-options --report-time
+    fi
+    echo "==> Running tests with 'cargo test --workspace --no-fail-fast $FEATURE_ARGS $TARGET_ARGS -- $*' (stderr at ${CARGO_TEST_LOG}) ..."
     # shellcheck disable=SC2086
-    cargo test --workspace --no-fail-fast $FEATURE_ARGS -- "$@" 2>"$CARGO_TEST_LOG"
+    cargo test --workspace --no-fail-fast $FEATURE_ARGS $TARGET_ARGS -- "$@" 2>"$CARGO_TEST_LOG"
 fi
 
 # cleanup handled via the trapped cleanup function

--- a/crates/liboxen/README.md
+++ b/crates/liboxen/README.md
@@ -279,6 +279,12 @@ To run with all debug output and run a specific test
 env RUST_LOG=warn,liboxen=debug,integration_test=debug bin/test-rust --no-capture test_command_push_clone_pull_push
 ```
 
+To see how long each test takes, pass `--timings`. Plain `cargo test` reports only one total per test binary. Doctests are skipped.
+
+```bash
+bin/test-rust --timings repositories::rm
+```
+
 To explicitly set the port for the `oxen-server` used in tests, set `OXEN_PORT`:
 
 ```bash


### PR DESCRIPTION
Add `bin/test-rust --timings`, which prints how long each test took next to its result, so it is possible again to see which tests are slow and whether a change made any individual test faster.

When we switched from `cargo nextest` to `cargo test` we lost the individual test times and this gets them back for us. Super helpful when you're looking for slow tests to speed up.

ENG-1658