### PR TITLE
Remove a sleep from remote test setup

### DIFF
--- a/crates/liboxen/src/test.rs
+++ b/crates/liboxen/src/test.rs
@@ -23,6 +23,7 @@ use crate::repositories;
 use crate::util;
 use crate::util::telemetry::TracingGuard;
 
+use http::StatusCode;
 use rand::Rng;
 use rand::distributions::Alphanumeric;
 use std::fs::File;
@@ -164,7 +165,13 @@ pub async fn create_or_clear_remote_repo(
     let host = repo_new.host();
     let url = api::endpoint::url_from_host(&host, &remote_name);
 
-    let _ = api::client::repositories::delete_from_url(url.clone()).await;
+    // A repo that was never there is the common case and not a failure; anything else means the
+    // delete itself went wrong, and saying so beats waiting out the poll below for a worse message.
+    match api::client::repositories::delete_from_url(url.clone()).await {
+        Ok(_) => {}
+        Err(OxenError::HttpStatusError { status, .. }) if status == StatusCode::NOT_FOUND => {}
+        Err(err) => return Err(err),
+    }
     wait_until_remote_repo_deleted(&url).await?;
     api::client::repositories::create_from_local(repo, repo_new).await
 }

--- a/crates/liboxen/src/test.rs
+++ b/crates/liboxen/src/test.rs
@@ -180,7 +180,7 @@ pub async fn create_or_clear_remote_repo(
 /// Errors if the repo is still there after 30s, or if the existence check itself fails.
 async fn wait_until_remote_repo_deleted(url: &str) -> Result<(), OxenError> {
     const TIMEOUT: Duration = Duration::from_secs(30);
-    const POLL_INTERVAL: Duration = Duration::from_millis(5);
+    const POLL_INTERVAL: Duration = Duration::from_millis(25);
 
     let poll = async {
         loop {

--- a/crates/liboxen/src/test.rs
+++ b/crates/liboxen/src/test.rs
@@ -33,7 +33,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Mutex;
-use tokio::time::sleep;
+use std::time::Duration;
+use tokio::time::{sleep, timeout};
 use tracing::level_filters::LevelFilter;
 
 pub const DEFAULT_TEST_HOST: &str = "localhost:3000";
@@ -163,9 +164,32 @@ pub async fn create_or_clear_remote_repo(
     let host = repo_new.host();
     let url = api::endpoint::url_from_host(&host, &remote_name);
 
-    let _ = api::client::repositories::delete_from_url(url).await;
-    sleep(std::time::Duration::from_millis(500)).await;
+    let _ = api::client::repositories::delete_from_url(url.clone()).await;
+    wait_until_remote_repo_deleted(&url).await?;
     api::client::repositories::create_from_local(repo, repo_new).await
+}
+
+/// Returns once the remote repo at `url` reports 404, so a recreate cannot race a slow delete.
+/// Errors if the repo is still there after 30s, or if the existence check itself fails.
+async fn wait_until_remote_repo_deleted(url: &str) -> Result<(), OxenError> {
+    const TIMEOUT: Duration = Duration::from_secs(30);
+    const POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+    let poll = async {
+        loop {
+            match api::client::repositories::get_by_url(url).await {
+                Err(OxenError::RemoteRepoNotFound(_)) => return Ok(()),
+                Err(err) => return Err(err),
+                Ok(_) => sleep(POLL_INTERVAL).await,
+            }
+        }
+    };
+
+    timeout(TIMEOUT, poll).await.unwrap_or_else(|_| {
+        Err(OxenError::internal_error(format!(
+            "remote repo {url} still exists {TIMEOUT:?} after delete"
+        )))
+    })
 }
 
 pub async fn add_n_files_m_dirs(


### PR DESCRIPTION
Remove a sleep from the remote test setup and poll for it to finish instead.

`create_or_clear_remote_repo` deleted a remote repo and then slept 500ms before recreating it. The sleep was a guess that the delete had landed: too long when it had, and — under concurrent load — potentially too short, in which case `create_from_local` races a repo that still exists. The helper is used by a large fraction of the benchmarks.

Setup now polls the repo's URL until it reports 404, and gives up loudly after 30 seconds. A non-404 failure from the existence check propagates rather than being slept through, so a broken test server surfaces as an error at the point it happens.

ENG-1257