### PR TITLE
Bump to Rust 1.98.0 and fix lints

### DIFF
--- a/crates/liboxen/benches/add.rs
+++ b/crates/liboxen/benches/add.rs
@@ -67,16 +67,15 @@ async fn setup_repo_for_add_benchmark(
             .collect();
         dirs.push(files_dir.clone());
 
-        let large_file_percentage: f64;
         let min_repo_size_for_scaling = 1000.0;
         let max_repo_size_for_scaling = 100000.0;
         let max_large_file_ratio = 0.5;
         let min_large_file_ratio = 0.01;
 
-        if (repo_size as f64) <= min_repo_size_for_scaling {
-            large_file_percentage = max_large_file_ratio;
+        let large_file_percentage: f64 = if (repo_size as f64) <= min_repo_size_for_scaling {
+            max_large_file_ratio
         } else if (repo_size as f64) >= max_repo_size_for_scaling {
-            large_file_percentage = min_large_file_ratio;
+            min_large_file_ratio
         } else {
             let log_repo_size = (repo_size as f64).log10();
             let log_min_repo_size = min_repo_size_for_scaling.log10();
@@ -85,9 +84,9 @@ async fn setup_repo_for_add_benchmark(
             let normalized_log_repo_size =
                 (log_repo_size - log_min_repo_size) / (log_max_repo_size - log_min_repo_size);
 
-            large_file_percentage = max_large_file_ratio
-                - (max_large_file_ratio - min_large_file_ratio) * normalized_log_repo_size;
-        }
+            max_large_file_ratio
+                - (max_large_file_ratio - min_large_file_ratio) * normalized_log_repo_size
+        };
 
         for i in 0..repo_size {
             let dir_idx = rng.gen_range(0..dirs.len());

--- a/crates/liboxen/benches/download.rs
+++ b/crates/liboxen/benches/download.rs
@@ -76,16 +76,15 @@ async fn setup_repo_for_download_benchmark(
             .collect();
         dirs.push(files_dir.clone());
 
-        let large_file_percentage: f64;
         let min_repo_size_for_scaling = 1000.0;
         let max_repo_size_for_scaling = 100000.0;
         let max_large_file_ratio = 0.5;
         let min_large_file_ratio = 0.01;
 
-        if (repo_size as f64) <= min_repo_size_for_scaling {
-            large_file_percentage = max_large_file_ratio;
+        let large_file_percentage: f64 = if (repo_size as f64) <= min_repo_size_for_scaling {
+            max_large_file_ratio
         } else if (repo_size as f64) >= max_repo_size_for_scaling {
-            large_file_percentage = min_large_file_ratio;
+            min_large_file_ratio
         } else {
             let log_repo_size = (repo_size as f64).log10();
             let log_min_repo_size = min_repo_size_for_scaling.log10();
@@ -94,9 +93,9 @@ async fn setup_repo_for_download_benchmark(
             let normalized_log_repo_size =
                 (log_repo_size - log_min_repo_size) / (log_max_repo_size - log_min_repo_size);
 
-            large_file_percentage = max_large_file_ratio
-                - (max_large_file_ratio - min_large_file_ratio) * normalized_log_repo_size;
-        }
+            max_large_file_ratio
+                - (max_large_file_ratio - min_large_file_ratio) * normalized_log_repo_size
+        };
 
         for i in repo_size..(repo_size + num_files_to_download_in_benchmark) {
             let dir_idx = rng.gen_range(0..dirs.len());

--- a/crates/liboxen/benches/fetch.rs
+++ b/crates/liboxen/benches/fetch.rs
@@ -75,16 +75,15 @@ async fn setup_repo_for_fetch_benchmark(
             .collect();
         dirs.push(files_dir.clone());
 
-        let large_file_percentage: f64;
         let min_repo_size_for_scaling = 1000.0;
         let max_repo_size_for_scaling = 100000.0;
         let max_large_file_ratio = 0.5;
         let min_large_file_ratio = 0.01;
 
-        if (repo_size as f64) <= min_repo_size_for_scaling {
-            large_file_percentage = max_large_file_ratio;
+        let large_file_percentage: f64 = if (repo_size as f64) <= min_repo_size_for_scaling {
+            max_large_file_ratio
         } else if (repo_size as f64) >= max_repo_size_for_scaling {
-            large_file_percentage = min_large_file_ratio;
+            min_large_file_ratio
         } else {
             let log_repo_size = (repo_size as f64).log10();
             let log_min_repo_size = min_repo_size_for_scaling.log10();
@@ -93,9 +92,9 @@ async fn setup_repo_for_fetch_benchmark(
             let normalized_log_repo_size =
                 (log_repo_size - log_min_repo_size) / (log_max_repo_size - log_min_repo_size);
 
-            large_file_percentage = max_large_file_ratio
-                - (max_large_file_ratio - min_large_file_ratio) * normalized_log_repo_size;
-        }
+            max_large_file_ratio
+                - (max_large_file_ratio - min_large_file_ratio) * normalized_log_repo_size
+        };
 
         for i in repo_size..(repo_size + num_files_to_fetch_in_benchmark) {
             let dir_idx = rng.gen_range(0..dirs.len());

--- a/crates/liboxen/benches/push.rs
+++ b/crates/liboxen/benches/push.rs
@@ -75,16 +75,15 @@ async fn setup_repo_for_push_benchmark(
             .collect();
         dirs.push(files_dir.clone());
 
-        let large_file_percentage: f64;
         let min_repo_size_for_scaling = 1000.0;
         let max_repo_size_for_scaling = 100000.0;
         let max_large_file_ratio = 0.5;
         let min_large_file_ratio = 0.01;
 
-        if (repo_size as f64) <= min_repo_size_for_scaling {
-            large_file_percentage = max_large_file_ratio;
+        let large_file_percentage: f64 = if (repo_size as f64) <= min_repo_size_for_scaling {
+            max_large_file_ratio
         } else if (repo_size as f64) >= max_repo_size_for_scaling {
-            large_file_percentage = min_large_file_ratio;
+            min_large_file_ratio
         } else {
             let log_repo_size = (repo_size as f64).log10();
             let log_min_repo_size = min_repo_size_for_scaling.log10();
@@ -93,9 +92,9 @@ async fn setup_repo_for_push_benchmark(
             let normalized_log_repo_size =
                 (log_repo_size - log_min_repo_size) / (log_max_repo_size - log_min_repo_size);
 
-            large_file_percentage = max_large_file_ratio
-                - (max_large_file_ratio - min_large_file_ratio) * normalized_log_repo_size;
-        }
+            max_large_file_ratio
+                - (max_large_file_ratio - min_large_file_ratio) * normalized_log_repo_size
+        };
 
         // Note: If we want to have the push benchmark actually push to remotes with the proper repo_size,
         //       We would need to do this every iteration, which would be slow

--- a/crates/liboxen/benches/workspace_add.rs
+++ b/crates/liboxen/benches/workspace_add.rs
@@ -83,16 +83,15 @@ async fn setup_repo_for_workspace_add_benchmark(
         .collect();
     base_dirs.push(base_dir.clone());
 
-    let large_file_percentage: f64;
     let min_repo_size_for_scaling = 1000.0;
     let max_repo_size_for_scaling = 100000.0;
     let max_large_file_ratio = 0.5;
     let min_large_file_ratio = 0.01;
 
-    if (repo_size as f64) <= min_repo_size_for_scaling {
-        large_file_percentage = max_large_file_ratio;
+    let large_file_percentage: f64 = if (repo_size as f64) <= min_repo_size_for_scaling {
+        max_large_file_ratio
     } else if (repo_size as f64) >= max_repo_size_for_scaling {
-        large_file_percentage = min_large_file_ratio;
+        min_large_file_ratio
     } else {
         let log_repo_size = (repo_size as f64).log10();
         let log_min_repo_size = min_repo_size_for_scaling.log10();
@@ -101,9 +100,9 @@ async fn setup_repo_for_workspace_add_benchmark(
         let normalized_log_repo_size =
             (log_repo_size - log_min_repo_size) / (log_max_repo_size - log_min_repo_size);
 
-        large_file_percentage = max_large_file_ratio
-            - (max_large_file_ratio - min_large_file_ratio) * normalized_log_repo_size;
-    }
+        max_large_file_ratio
+            - (max_large_file_ratio - min_large_file_ratio) * normalized_log_repo_size
+    };
 
     for i in 0..repo_size {
         let dir_idx = rng.gen_range(0..base_dirs.len());

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -649,10 +649,8 @@ impl error::ResponseError for OxenHttpError {
                         let error_json = json!({
                             "error": {
                                 "type": "schema_error",
-                                "title":
-                                    "Incompatible Schemas",
-                                "detail":
-                                    format!("{}", error)
+                                "title": "Incompatible Schemas",
+                                "detail": error.to_string(),
                             },
                             "status": STATUS_ERROR,
                             "status_message": MSG_BAD_REQUEST,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"


### PR DESCRIPTION
Bump to [Rust 1.98.0](https://blog.rust-lang.org/2026/08/20/Rust-1.98.0/). No changes that should make a big difference for us in this release.

Except for the snippet inside the `json!` macro, `cargo clippy` autofixed all these new lints without any intervention from me. Autofixing is getting pretty good!