### PR TITLE
Add "oxen verify" for a more complete repo scan

### DIFF
--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -51,6 +51,7 @@ pub mod size;
 pub mod stats;
 pub mod status;
 pub mod tree;
+pub mod verify;
 pub mod workspaces;
 
 pub use add::add;

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -1714,22 +1714,18 @@ pub fn print_tree_depth(
     Ok(())
 }
 
-/// A file an added subtree introduces, as the tree records it.
-#[derive(Debug, Clone)]
-pub struct AddedFile {
-    /// The size the file node declares for its content.
-    pub num_bytes: u64,
-    /// The path of one file node referencing the blob. Deduplicated content can give it several.
-    pub path: PathBuf,
-}
+/// The sizes file nodes declare for one version blob, each mapped to a path declaring it. More
+/// than one entry means nodes disagree about the size of the same content, of which at most one
+/// can match the stored blob.
+pub type DeclaredSizes = HashMap<u64, PathBuf>;
 
 /// The merkle nodes and version blobs a commit's tree introduces relative to a base.
 #[derive(Debug, Default)]
 pub struct AddedObjects {
     /// Merkle tree node hashes (dirs and vnodes) reachable from the added subtrees.
     pub nodes: HashSet<MerkleHash>,
-    /// The files the added subtrees introduce, keyed by the content hash each references.
-    pub versions: HashMap<String, AddedFile>,
+    /// The version blobs the added files reference, keyed by content hash.
+    pub versions: HashMap<String, DeclaredSizes>,
 }
 
 /// The merkle nodes and version blobs that `head`'s tree introduces relative to `base`. Returns
@@ -1864,10 +1860,12 @@ fn collect_added_from_dir(
             EntryKind::File { version, num_bytes } => {
                 // A file node lives inline in its parent vnode's DB (which we just read), not as a
                 // standalone node, so its presence is already covered. Verify its content blob.
-                added.versions.entry(version).or_insert_with(|| AddedFile {
-                    num_bytes,
-                    path: head_dir_path.join(&name),
-                });
+                added
+                    .versions
+                    .entry(version)
+                    .or_default()
+                    .entry(num_bytes)
+                    .or_insert_with(|| head_dir_path.join(&name));
             }
             EntryKind::Dir => {
                 let base_sub = base_entries

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -1714,13 +1714,22 @@ pub fn print_tree_depth(
     Ok(())
 }
 
-/// The merkle node hashes and version-blob hashes a commit's tree introduces relative to a base.
+/// A file an added subtree introduces, as the tree records it.
+#[derive(Debug, Clone)]
+pub struct AddedFile {
+    /// The size the file node declares for its content.
+    pub num_bytes: u64,
+    /// The path of one file node referencing the blob. Deduplicated content can give it several.
+    pub path: PathBuf,
+}
+
+/// The merkle nodes and version blobs a commit's tree introduces relative to a base.
 #[derive(Debug, Default)]
 pub struct AddedObjects {
     /// Merkle tree node hashes (dirs and vnodes) reachable from the added subtrees.
     pub nodes: HashSet<MerkleHash>,
-    /// Content hashes of the version blobs the added files reference.
-    pub versions: HashSet<String>,
+    /// The files the added subtrees introduce, keyed by the content hash each references.
+    pub versions: HashMap<String, AddedFile>,
 }
 
 /// The merkle nodes and version blobs that `head`'s tree introduces relative to `base`. Returns
@@ -1748,13 +1757,7 @@ pub fn added_objects(
     }
 
     let mut added = AddedObjects::default();
-    collect_added_from_dir(
-        repo,
-        base_root,
-        head_root,
-        &mut added.nodes,
-        &mut added.versions,
-    )?;
+    collect_added_from_dir(repo, base_root, head_root, Path::new(""), &mut added)?;
     Ok(Some(added))
 }
 
@@ -1803,7 +1806,7 @@ pub async fn find_missing_added_objects(
                 }
             }
 
-            Ok((missing_nodes, added.versions.into_iter().collect()))
+            Ok((missing_nodes, added.versions.into_keys().collect()))
         })
         .await??;
 
@@ -1835,13 +1838,13 @@ fn collect_added_from_dir(
     repo: &LocalRepository,
     base_dir: Option<MerkleHash>,
     head_dir: MerkleHash,
-    added_nodes: &mut HashSet<MerkleHash>,
-    added_versions: &mut HashSet<String>,
+    head_dir_path: &Path,
+    added: &mut AddedObjects,
 ) -> Result<(), OxenError> {
-    added_nodes.insert(head_dir);
+    added.nodes.insert(head_dir);
 
     let (head_entries, head_vnodes) = dir_entries(repo, &head_dir)?;
-    added_nodes.extend(head_vnodes);
+    added.nodes.extend(head_vnodes);
 
     let base_entries = match base_dir {
         Some(base_dir) => dir_entries(repo, &base_dir)?.0,
@@ -1858,17 +1861,26 @@ fn collect_added_from_dir(
         }
 
         match entry.kind {
-            EntryKind::File { version } => {
+            EntryKind::File { version, num_bytes } => {
                 // A file node lives inline in its parent vnode's DB (which we just read), not as a
                 // standalone node, so its presence is already covered. Verify its content blob.
-                added_versions.insert(version);
+                added.versions.entry(version).or_insert_with(|| AddedFile {
+                    num_bytes,
+                    path: head_dir_path.join(&name),
+                });
             }
             EntryKind::Dir => {
                 let base_sub = base_entries
                     .get(&name)
                     .filter(|base_entry| matches!(base_entry.kind, EntryKind::Dir))
                     .map(|base_entry| base_entry.hash);
-                collect_added_from_dir(repo, base_sub, entry.hash, added_nodes, added_versions)?;
+                collect_added_from_dir(
+                    repo,
+                    base_sub,
+                    entry.hash,
+                    &head_dir_path.join(&name),
+                    added,
+                )?;
             }
         }
     }
@@ -1877,9 +1889,10 @@ fn collect_added_from_dir(
 }
 
 enum EntryKind {
-    /// A file entry, carrying its content (version-store) hash.
+    /// A file entry, carrying its content (version-store) hash and the size it declares.
     File {
         version: String,
+        num_bytes: u64,
     },
     Dir,
 }
@@ -1925,6 +1938,7 @@ fn insert_entry(entries: &mut HashMap<String, DirEntry>, hash: MerkleHash, node:
                     hash,
                     kind: EntryKind::File {
                         version: file_node.hash().to_string(),
+                        num_bytes: file_node.num_bytes(),
                     },
                 },
             );

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -1850,27 +1850,28 @@ fn collect_added_from_dir(
 ) -> Result<(), OxenError> {
     added.nodes.insert(head_dir);
 
-    let (head_entries, head_vnodes) = match dir_entries(repo, &head_dir) {
-        Ok(entries) => entries,
+    let head = match dir_entries(repo, &head_dir) {
+        Ok(contents) => contents,
         Err(err) => {
-            // A node that will not parse hides everything beneath it, so it is recorded and the
-            // walk stops descending here instead of abandoning the rest of the tree.
+            // A directory node that will not parse hides everything beneath it, so it is recorded
+            // and the walk stops descending here instead of abandoning the rest of the tree.
             added.unreadable.insert(head_dir, err.to_string());
             return Ok(());
         }
     };
-    added.nodes.extend(head_vnodes);
+    added.nodes.extend(head.vnodes);
+    added.unreadable.extend(head.unreadable);
 
-    // An unreadable base prunes nothing, so every entry in head counts as added. The base commit
-    // reports its own damage when it is walked as a head in its own right.
+    // Damage on the base side prunes nothing: an entry it could not read is absent from
+    // `base_entries`, so the head entry of that name counts as added.
     let base_entries = match base_dir {
         Some(base_dir) => dir_entries(repo, &base_dir)
-            .map(|(entries, _)| entries)
+            .map(|contents| contents.entries)
             .unwrap_or_default(),
         None => HashMap::new(),
     };
 
-    for (name, entry) in head_entries {
+    for (name, entry) in head.entries {
         if base_entries
             .get(&name)
             .is_some_and(|base_entry| base_entry.hash == entry.hash)
@@ -1923,31 +1924,49 @@ struct DirEntry {
     kind: EntryKind,
 }
 
-/// The immediate file/dir entries of a directory node (flattening its vnode layer), keyed by name,
-/// plus the hashes of the vnodes traversed. Returns empty when the directory node is absent.
-fn dir_entries(
-    repo: &LocalRepository,
-    dir_hash: &MerkleHash,
-) -> Result<(HashMap<String, DirEntry>, Vec<MerkleHash>), OxenError> {
-    let mut entries = HashMap::new();
-    let mut vnode_hashes = Vec::new();
+/// What one directory node holds, gathered across its vnodes.
+struct DirContents {
+    entries: HashMap<String, DirEntry>,
+    vnodes: Vec<MerkleHash>,
+    /// VNodes the store holds but could not read, mapped to the failure. The entries each one
+    /// holds are absent from `entries`.
+    unreadable: HashMap<MerkleHash, String>,
+}
+
+/// Read the entries a directory node holds, descending through its vnodes.
+///
+/// A node the store does not hold reads as empty: an absent directory or vnode yields no entries
+/// and no failure. A node it holds but cannot parse does fail, the directory as an `Err` and a
+/// vnode as an entry in `unreadable` whose contents are then absent from `entries`.
+fn dir_entries(repo: &LocalRepository, dir_hash: &MerkleHash) -> Result<DirContents, OxenError> {
+    let mut contents = DirContents {
+        entries: HashMap::new(),
+        vnodes: Vec::new(),
+        unreadable: HashMap::new(),
+    };
 
     for (child_hash, child) in MerkleTreeNode::read_children_from_hash(repo, dir_hash)? {
         match &child.node {
             EMerkleTreeNode::VNode(_) => {
-                vnode_hashes.push(child_hash);
-                for (entry_hash, entry) in
-                    MerkleTreeNode::read_children_from_hash(repo, &child_hash)?
-                {
-                    insert_entry(&mut entries, entry_hash, &entry);
+                contents.vnodes.push(child_hash);
+                match MerkleTreeNode::read_children_from_hash(repo, &child_hash) {
+                    Ok(children) => {
+                        for (entry_hash, entry) in children {
+                            insert_entry(&mut contents.entries, entry_hash, &entry);
+                        }
+                    }
+                    // A vnode hides only the entries it holds, so its siblings are still read.
+                    Err(err) => {
+                        contents.unreadable.insert(child_hash, err.to_string());
+                    }
                 }
             }
             // Some trees may attach files/dirs directly under a directory node.
-            _ => insert_entry(&mut entries, child_hash, &child),
+            _ => insert_entry(&mut contents.entries, child_hash, &child),
         }
     }
 
-    Ok((entries, vnode_hashes))
+    Ok(contents)
 }
 
 fn insert_entry(entries: &mut HashMap<String, DirEntry>, hash: MerkleHash, node: &MerkleTreeNode) {

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -1726,6 +1726,9 @@ pub struct AddedObjects {
     pub nodes: HashSet<MerkleHash>,
     /// The version blobs the added files reference, keyed by content hash.
     pub versions: HashMap<String, DeclaredSizes>,
+    /// Nodes the store holds but could not read, mapped to the failure. Whatever each one contains
+    /// is absent from `nodes` and `versions`.
+    pub unreadable: HashMap<MerkleHash, String>,
 }
 
 /// The merkle nodes and version blobs that `head`'s tree introduces relative to `base`. Returns
@@ -1794,6 +1797,14 @@ pub async fn find_missing_added_objects(
                 return Ok((vec![head.hash()?.to_string()], vec![]));
             };
 
+            // A ref must never advance onto a tree whose contents could not be read: unreadable is
+            // not the same answer as present, and only this caller can say which it needs.
+            if let Some((hash, err)) = added.unreadable.iter().next() {
+                return Err(OxenError::InternalError(
+                    format!("merkle node {hash} could not be read: {err}").into(),
+                ));
+            }
+
             let store = walk_repo.merkle_node_store();
             let mut missing_nodes = Vec::new();
             for hash in &added.nodes {
@@ -1839,11 +1850,23 @@ fn collect_added_from_dir(
 ) -> Result<(), OxenError> {
     added.nodes.insert(head_dir);
 
-    let (head_entries, head_vnodes) = dir_entries(repo, &head_dir)?;
+    let (head_entries, head_vnodes) = match dir_entries(repo, &head_dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            // A node that will not parse hides everything beneath it, so it is recorded and the
+            // walk stops descending here instead of abandoning the rest of the tree.
+            added.unreadable.insert(head_dir, err.to_string());
+            return Ok(());
+        }
+    };
     added.nodes.extend(head_vnodes);
 
+    // An unreadable base prunes nothing, so every entry in head counts as added. The base commit
+    // reports its own damage when it is walked as a head in its own right.
     let base_entries = match base_dir {
-        Some(base_dir) => dir_entries(repo, &base_dir)?.0,
+        Some(base_dir) => dir_entries(repo, &base_dir)
+            .map(|(entries, _)| entries)
+            .unwrap_or_default(),
         None => HashMap::new(),
     };
 
@@ -1974,6 +1997,36 @@ mod tests {
     // The incremental check must flag a blob the head commit *adds* when it's missing,
     // and must NOT re-check blobs inherited unchanged from the base (that's the whole point of
     // scoping to the changed set rather than walking the full tree).
+    #[tokio::test]
+    async fn test_find_missing_added_objects_refuses_an_unreadable_node() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let nested = repo.path.join("nested");
+            util::fs::create_dir_all(&nested)?;
+            test::write_txt_file_to_path(nested.join("a.txt"), "alpha")?;
+            repositories::add(&repo, &repo.path).await?;
+            let head = repositories::commit(&repo, "add nested/a.txt")?;
+
+            let dir = get_dir_with_children(&repo, &head, "nested", None)?
+                .expect("the nested directory has a node");
+            repo.merkle_node_store().write_node(
+                &dir.hash,
+                Bytes::from_static(b"not a node"),
+                Bytes::from_static(b"not children"),
+            )?;
+
+            // Advancing a ref onto a tree that cannot be read must fail rather than report the
+            // parts that happened to be reachable, unlike `oxen verify`, which reports and goes on.
+            let result = find_missing_added_objects(&repo, None, &head).await;
+            assert!(
+                result.is_err(),
+                "the gate accepted a tree it could not read: {result:?}"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
     #[tokio::test]
     async fn test_find_missing_added_objects_scopes_to_the_added_set() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async move {

--- a/crates/liboxen/src/repositories/verify.rs
+++ b/crates/liboxen/src/repositories/verify.rs
@@ -92,7 +92,11 @@ pub struct UncheckedVersion {
 }
 
 /// What a [`verify_repo`] pass found.
+///
+/// Travels over the wire, so a class absent from the JSON reads as empty: that means the sender
+/// did not report it, not that it looked and found nothing.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct VerifyReport {
     pub branches_checked: usize,
     pub commits_checked: usize,
@@ -408,6 +412,37 @@ mod tests {
             findings.sample,
             (0..SAMPLE_LIMIT).collect::<Vec<_>>(),
             "the sample is the first findings seen"
+        );
+    }
+
+    #[test]
+    fn test_a_report_survives_skew_with_a_server_of_another_version() {
+        let mut report = VerifyReport {
+            versions_checked: 7,
+            ..Default::default()
+        };
+        report.missing_versions.record("abc123".to_string());
+
+        let mut json = serde_json::to_value(&report).expect("a report serializes");
+        let fields = json.as_object_mut().expect("a report is a JSON object");
+        // A server older than this client omits a class it never had.
+        fields
+            .remove("unchecked_versions")
+            .expect("the class was there to remove");
+        // A server newer than this client sends a class this client has never heard of.
+        fields.insert(
+            "findings_from_a_later_version".to_string(),
+            serde_json::json!({ "count": 1, "sample": [] }),
+        );
+
+        let parsed: VerifyReport =
+            serde_json::from_value(json).expect("a report from either side still parses");
+
+        assert_eq!(parsed.versions_checked, 7, "known counters survive");
+        assert_eq!(parsed.missing_versions.count, 1, "known findings survive");
+        assert!(
+            parsed.unchecked_versions.is_empty(),
+            "an omitted class reads as unreported"
         );
     }
 

--- a/crates/liboxen/src/repositories/verify.rs
+++ b/crates/liboxen/src/repositories/verify.rs
@@ -1,0 +1,512 @@
+//! # oxen verify
+//!
+//! Read-only integrity checks for a repository.
+//!
+//! Answers one question: does everything this repository's branches reference actually exist, and
+//! does it look like what the tree says it is. Nothing here mutates a repository.
+//!
+//! Findings are reported as counts plus a bounded sample.
+
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use crate::error::OxenError;
+use crate::model::{Commit, CommitEntry, LocalRepository, MerkleHash, NewCommit};
+use crate::repositories;
+use crate::repositories::commits::commit_writer::compute_commit_id;
+
+/// Examples of each finding a report carries alongside the count.
+const SAMPLE_LIMIT: usize = 10;
+
+/// Concurrent size probes against the version store.
+const MAX_CONCURRENT_SIZE_PROBES: usize = 16;
+
+/// One class of finding: how many there are, and a bounded sample for triage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Findings<T> {
+    pub count: usize,
+    pub sample: Vec<T>,
+}
+
+// Hand-written so an empty `Findings` needs nothing of `T`, which a derive would demand.
+impl<T> Default for Findings<T> {
+    fn default() -> Self {
+        Self {
+            count: 0,
+            sample: Vec::new(),
+        }
+    }
+}
+
+impl<T> Findings<T> {
+    fn record(&mut self, item: T) {
+        self.count += 1;
+        if self.sample.len() < SAMPLE_LIMIT {
+            self.sample.push(item);
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+}
+
+/// A branch whose head names a commit the repository does not have.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DanglingBranch {
+    pub branch: String,
+    pub commit_id: String,
+}
+
+/// A commit naming a parent the repository does not have.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DanglingParent {
+    pub commit_id: String,
+    pub parent_id: String,
+}
+
+/// A commit whose recorded id is not the hash of the fields it stores.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MisaddressedCommit {
+    pub recorded_id: String,
+    pub computed_id: String,
+}
+
+/// A version blob whose stored size disagrees with the size its file node declares.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SizeMismatch {
+    pub hash: String,
+    pub path: PathBuf,
+    pub declared_bytes: u64,
+    pub stored_bytes: u64,
+}
+
+/// What a [`verify_repo`] pass found.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct VerifyReport {
+    pub branches_checked: usize,
+    pub commits_checked: usize,
+    pub entries_checked: usize,
+    pub dangling_branches: Findings<DanglingBranch>,
+    pub dangling_parents: Findings<DanglingParent>,
+    pub misaddressed_commits: Findings<MisaddressedCommit>,
+    pub missing_nodes: Findings<String>,
+    pub missing_versions: Findings<String>,
+    pub size_mismatches: Findings<SizeMismatch>,
+}
+
+impl VerifyReport {
+    /// Whether the pass found nothing wrong.
+    pub fn is_healthy(&self) -> bool {
+        self.dangling_branches.is_empty()
+            && self.dangling_parents.is_empty()
+            && self.misaddressed_commits.is_empty()
+            && self.missing_nodes.is_empty()
+            && self.missing_versions.is_empty()
+            && self.size_mismatches.is_empty()
+    }
+
+    /// Findings across every class.
+    pub fn total_findings(&self) -> usize {
+        self.dangling_branches.count
+            + self.dangling_parents.count
+            + self.misaddressed_commits.count
+            + self.missing_nodes.count
+            + self.missing_versions.count
+            + self.size_mismatches.count
+    }
+}
+
+/// Check that everything the repository's branches reference is present and the right size.
+///
+/// Reads only. Cost scales with the number of reachable entries: one version-store metadata probe
+/// per distinct content hash, and no blob contents are read.
+pub async fn verify_repo(repo: &LocalRepository) -> Result<VerifyReport, OxenError> {
+    let mut report = VerifyReport::default();
+
+    let heads = resolve_branch_heads(repo, &mut report).await?;
+    check_commits(repo, &mut report).await?;
+    check_reachable_objects(repo, &heads, &mut report).await?;
+    check_entry_sizes(repo, &heads, &mut report).await?;
+
+    Ok(report)
+}
+
+/// The commit each branch points at, recording the branches whose head does not resolve.
+async fn resolve_branch_heads(
+    repo: &LocalRepository,
+    report: &mut VerifyReport,
+) -> Result<Vec<Commit>, OxenError> {
+    let branches = repositories::branches::list(repo).await?;
+    report.branches_checked = branches.len();
+
+    let walk_repo = repo.clone();
+    let (heads, dangling) = tokio::task::spawn_blocking(
+        move || -> Result<(Vec<Commit>, Vec<DanglingBranch>), OxenError> {
+            let mut heads = Vec::new();
+            let mut dangling = Vec::new();
+            for branch in branches {
+                match repositories::commits::get_by_id(&walk_repo, &branch.commit_id)? {
+                    Some(commit) => heads.push(commit),
+                    None => dangling.push(DanglingBranch {
+                        branch: branch.name,
+                        commit_id: branch.commit_id,
+                    }),
+                }
+            }
+            Ok((heads, dangling))
+        },
+    )
+    .await??;
+
+    for branch in dangling {
+        report.dangling_branches.record(branch);
+    }
+    Ok(heads)
+}
+
+/// Every reachable commit hashes to the id it is filed under, and every parent it names resolves.
+async fn check_commits(repo: &LocalRepository, report: &mut VerifyReport) -> Result<(), OxenError> {
+    type CommitFindings = (usize, Vec<DanglingParent>, Vec<MisaddressedCommit>);
+
+    let walk_repo = repo.clone();
+    let (commits_checked, dangling, misaddressed) =
+        tokio::task::spawn_blocking(move || -> Result<CommitFindings, OxenError> {
+            let commits = repositories::commits::list_all(&walk_repo)?;
+            let mut dangling = Vec::new();
+            let mut misaddressed = Vec::new();
+
+            for commit in &commits {
+                if let Some(finding) = misaddressed_commit(commit)? {
+                    misaddressed.push(finding);
+                }
+                for parent_id in &commit.parent_ids {
+                    let resolves = match parent_id.parse::<MerkleHash>() {
+                        Ok(hash) => {
+                            repositories::commits::get_by_hash(&walk_repo, &hash)?.is_some()
+                        }
+                        Err(_) => false,
+                    };
+                    if !resolves {
+                        dangling.push(DanglingParent {
+                            commit_id: commit.id.clone(),
+                            parent_id: parent_id.clone(),
+                        });
+                    }
+                }
+            }
+            Ok((commits.len(), dangling, misaddressed))
+        })
+        .await??;
+
+    report.commits_checked = commits_checked;
+    for parent in dangling {
+        report.dangling_parents.record(parent);
+    }
+    for commit in misaddressed {
+        report.misaddressed_commits.record(commit);
+    }
+    Ok(())
+}
+
+/// A commit's own fields, re-hashed, against the id it is filed under.
+///
+/// Calls the function the commit writer uses, so the check cannot drift from the rule it enforces.
+fn misaddressed_commit(commit: &Commit) -> Result<Option<MisaddressedCommit>, OxenError> {
+    let computed = compute_commit_id(&NewCommit {
+        parent_ids: commit.parent_ids.clone(),
+        message: commit.message.clone(),
+        author: commit.author.clone(),
+        email: commit.email.clone(),
+        timestamp: commit.timestamp,
+    })?;
+
+    if computed.to_string() == commit.id {
+        return Ok(None);
+    }
+    Ok(Some(MisaddressedCommit {
+        recorded_id: commit.id.clone(),
+        computed_id: computed.to_string(),
+    }))
+}
+
+/// Merkle nodes and version blobs the branch trees reference but the repository does not hold.
+async fn check_reachable_objects(
+    repo: &LocalRepository,
+    heads: &[Commit],
+    report: &mut VerifyReport,
+) -> Result<(), OxenError> {
+    let mut seen_nodes = HashSet::new();
+    let mut seen_versions = HashSet::new();
+
+    for head in heads {
+        // `None` as the base widens the walk from a delta to the whole tree.
+        let missing = repositories::tree::find_missing_added_objects(repo, None, head).await?;
+        for node in missing.nodes {
+            if seen_nodes.insert(node.clone()) {
+                report.missing_nodes.record(node);
+            }
+        }
+        for version in missing.versions {
+            if seen_versions.insert(version.clone()) {
+                report.missing_versions.record(version);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Stored blob size against the size each file node declares.
+async fn check_entry_sizes(
+    repo: &LocalRepository,
+    heads: &[Commit],
+    report: &mut VerifyReport,
+) -> Result<(), OxenError> {
+    let version_store = repo.version_store();
+    let walk_repo = repo.clone();
+    let heads = heads.to_vec();
+    let (entries_checked, entries) =
+        tokio::task::spawn_blocking(move || -> Result<(usize, Vec<CommitEntry>), OxenError> {
+            let mut probed = HashSet::new();
+            let mut entries = Vec::new();
+            let mut entries_checked = 0;
+
+            for head in &heads {
+                // A head whose tree is absent has no entries to size, and the missing node is
+                // already reported.
+                if repositories::tree::get_root_with_children(&walk_repo, head)?.is_none() {
+                    continue;
+                }
+                for entry in repositories::entries::list_for_commit(&walk_repo, head)? {
+                    entries_checked += 1;
+                    if probed.insert(entry.hash.clone()) {
+                        entries.push(entry);
+                    }
+                }
+            }
+            Ok((entries_checked, entries))
+        })
+        .await??;
+
+    report.entries_checked = entries_checked;
+
+    let max_concurrent = MAX_CONCURRENT_SIZE_PROBES.min(entries.len().max(1));
+    let mut probes = futures_util::stream::iter(entries)
+        .map(|entry| {
+            let version_store = version_store.clone();
+            async move {
+                // An absent blob has no size and is already reported as a missing version.
+                let stored = version_store.get_version_size(&entry.hash).await.ok();
+                (entry, stored)
+            }
+        })
+        .buffer_unordered(max_concurrent);
+
+    while let Some((entry, stored)) = probes.next().await {
+        let Some(stored_bytes) = stored else { continue };
+        if stored_bytes != entry.num_bytes {
+            report.size_mismatches.record(SizeMismatch {
+                hash: entry.hash,
+                path: entry.path,
+                declared_bytes: entry.num_bytes,
+                stored_bytes,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test;
+    use crate::util;
+
+    /// The single stored version blob under `dir`, for tests that corrupt one deliberately.
+    fn find_only_version_blob(dir: &std::path::Path) -> Result<PathBuf, OxenError> {
+        let mut found = Vec::new();
+        let mut stack = vec![dir.to_path_buf()];
+        while let Some(path) = stack.pop() {
+            for entry in std::fs::read_dir(&path)? {
+                let entry = entry?;
+                let entry_path = entry.path();
+                if entry.metadata()?.is_dir() {
+                    stack.push(entry_path);
+                } else if entry_path.file_name().is_some_and(|name| name == "data") {
+                    found.push(entry_path);
+                }
+            }
+        }
+        match found.len() {
+            1 => Ok(found.remove(0)),
+            n => Err(OxenError::basic_str(format!(
+                "expected exactly one version blob, found {n}"
+            ))),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_a_sound_repository_reports_no_problems() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let path = repo.path.join("a.txt");
+            util::fs::write_to_path(&path, "alpha")?;
+            repositories::add(&repo, &path).await?;
+            repositories::commit(&repo, "Add a")?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert!(report.is_healthy(), "a sound repository has no findings");
+            assert_eq!(report.branches_checked, 1);
+            assert_eq!(report.entries_checked, 1);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_an_absent_version_blob_is_reported_missing() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let path = repo.path.join("a.txt");
+            util::fs::write_to_path(&path, "alpha")?;
+            repositories::add(&repo, &path).await?;
+            let commit = repositories::commit(&repo, "Add a")?;
+
+            let entries = repositories::entries::list_for_commit(&repo, &commit)?;
+            let hash = entries.first().expect("one entry").hash.clone();
+            repo.version_store().delete_version(&hash).await?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(report.missing_versions.count, 1);
+            assert_eq!(report.missing_versions.sample, vec![hash]);
+            assert_eq!(
+                report.size_mismatches.count, 0,
+                "an absent blob is missing, not the wrong size"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_a_blob_whose_size_disagrees_with_the_tree_is_reported() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let path = repo.path.join("a.txt");
+            util::fs::write_to_path(&path, "the original contents")?;
+            repositories::add(&repo, &path).await?;
+            let commit = repositories::commit(&repo, "Add a")?;
+
+            let entries = repositories::entries::list_for_commit(&repo, &commit)?;
+            let entry = entries.first().expect("one entry").clone();
+
+            // Shorten the stored blob, leaving the tree's declared size alone. Written straight
+            // to the file because `store_version` verifies content against the hash, which is
+            // exactly the guarantee this condition violates.
+            let blob = find_only_version_blob(&repo.path.join(".oxen").join("versions"))?;
+            std::fs::write(&blob, b"short")?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(report.size_mismatches.count, 1);
+            let mismatch = &report.size_mismatches.sample[0];
+            assert_eq!(mismatch.declared_bytes, entry.num_bytes);
+            assert_eq!(mismatch.stored_bytes, 5);
+            assert_eq!(
+                report.missing_versions.count, 0,
+                "a present blob is the wrong size, not missing"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_a_commit_that_does_not_hash_to_its_id_is_reported() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let path = repo.path.join("a.txt");
+            util::fs::write_to_path(&path, "alpha")?;
+            repositories::add(&repo, &path).await?;
+            let commit = repositories::commit(&repo, "Add a")?;
+
+            // The id is the hash of the commit's own fields, so altering one leaves the commit
+            // filed under an id its contents no longer produce.
+            let tampered = Commit {
+                message: "Add a, but edited afterwards".to_string(),
+                ..commit.clone()
+            };
+            assert!(
+                misaddressed_commit(&tampered)?.is_some(),
+                "a commit whose fields changed no longer hashes to its id"
+            );
+            assert!(
+                misaddressed_commit(&commit)?.is_none(),
+                "an untouched commit hashes to its id"
+            );
+
+            let report = verify_repo(&repo).await?;
+            assert_eq!(
+                report.misaddressed_commits.count, 0,
+                "the repository's own commit is sound"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_a_branch_head_naming_an_absent_commit_is_reported() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let path = repo.path.join("a.txt");
+            util::fs::write_to_path(&path, "alpha")?;
+            repositories::add(&repo, &path).await?;
+            let commit = repositories::commit(&repo, "Add a")?;
+
+            repo.merkle_node_store().delete(&commit.hash()?)?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(report.dangling_branches.count, 1);
+            assert_eq!(report.dangling_branches.sample[0].commit_id, commit.id);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_a_commit_naming_an_absent_parent_is_reported() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let first_path = repo.path.join("a.txt");
+            util::fs::write_to_path(&first_path, "alpha")?;
+            repositories::add(&repo, &first_path).await?;
+            let first = repositories::commit(&repo, "Add a")?;
+
+            let second_path = repo.path.join("b.txt");
+            util::fs::write_to_path(&second_path, "beta")?;
+            repositories::add(&repo, &second_path).await?;
+            let second = repositories::commit(&repo, "Add b")?;
+
+            repo.merkle_node_store().delete(&first.hash()?)?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(report.dangling_parents.count, 1);
+            let dangling = &report.dangling_parents.sample[0];
+            assert_eq!(dangling.commit_id, second.id);
+            assert_eq!(dangling.parent_id, first.id);
+            assert_eq!(
+                report.dangling_branches.count, 0,
+                "the branch head itself still resolves"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+}

--- a/crates/liboxen/src/repositories/verify.rs
+++ b/crates/liboxen/src/repositories/verify.rs
@@ -84,6 +84,13 @@ pub struct SizeMismatch {
     pub stored_bytes: u64,
 }
 
+/// A merkle node the repository holds but cannot read, leaving whatever it contains unexamined.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnreadableNode {
+    pub hash: String,
+    pub error: String,
+}
+
 /// A version blob whose metadata probe failed, leaving its size neither confirmed nor refuted.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UncheckedVersion {
@@ -105,6 +112,7 @@ pub struct VerifyReport {
     pub dangling_parents: Findings<DanglingParent>,
     pub misaddressed_commits: Findings<MisaddressedCommit>,
     pub missing_nodes: Findings<String>,
+    pub unreadable_nodes: Findings<UnreadableNode>,
     pub missing_versions: Findings<String>,
     pub size_mismatches: Findings<SizeMismatch>,
     pub unchecked_versions: Findings<UncheckedVersion>,
@@ -117,6 +125,7 @@ impl VerifyReport {
             && self.dangling_parents.is_empty()
             && self.misaddressed_commits.is_empty()
             && self.missing_nodes.is_empty()
+            && self.unreadable_nodes.is_empty()
             && self.missing_versions.is_empty()
             && self.size_mismatches.is_empty()
             && self.unchecked_versions.is_empty()
@@ -128,6 +137,7 @@ impl VerifyReport {
             + self.dangling_parents.count
             + self.misaddressed_commits.count
             + self.missing_nodes.count
+            + self.unreadable_nodes.count
             + self.missing_versions.count
             + self.size_mismatches.count
             + self.unchecked_versions.count
@@ -260,12 +270,16 @@ async fn check_tree_nodes(
     commits: &[Commit],
     report: &mut VerifyReport,
 ) -> Result<HashMap<String, DeclaredSizes>, OxenError> {
-    type TreeFindings = (HashMap<String, DeclaredSizes>, Findings<String>);
+    type TreeFindings = (
+        HashMap<String, DeclaredSizes>,
+        Findings<String>,
+        Findings<UnreadableNode>,
+    );
 
     // Sync core: the merkle walk and the node-existence probes are sync DB IO, one blocking unit.
     let walk_repo = repo.clone();
     let commits = commits.to_vec();
-    let (versions, missing_nodes) =
+    let (versions, missing_nodes, unreadable_nodes) =
         tokio::task::spawn_blocking(move || -> Result<TreeFindings, OxenError> {
             let mut by_hash: HashMap<MerkleHash, &Commit> = HashMap::new();
             for commit in &commits {
@@ -275,7 +289,9 @@ async fn check_tree_nodes(
             let store = walk_repo.merkle_node_store();
             let mut versions: HashMap<String, DeclaredSizes> = HashMap::new();
             let mut seen_nodes: HashSet<MerkleHash> = HashSet::new();
+            let mut seen_unreadable: HashSet<MerkleHash> = HashSet::new();
             let mut missing_nodes = Findings::default();
+            let mut unreadable_nodes = Findings::default();
 
             for commit in &commits {
                 // Parents resolve by the rule the dangling-parent check uses, so a parent that
@@ -285,12 +301,34 @@ async fn check_tree_nodes(
                     .first()
                     .and_then(|id| id.parse::<MerkleHash>().ok())
                     .and_then(|hash| by_hash.get(&hash).copied());
-                let Some(added) = repositories::tree::added_objects(&walk_repo, base, commit)?
-                else {
-                    // No root directory node means the commit's tree was never written.
-                    missing_nodes.record(commit.hash()?.to_string());
-                    continue;
+                let added = match repositories::tree::added_objects(&walk_repo, base, commit) {
+                    Ok(Some(added)) => added,
+                    Ok(None) => {
+                        // No root directory node means the commit's tree was never written.
+                        missing_nodes.record(commit.hash()?.to_string());
+                        continue;
+                    }
+                    // The commit's own node did not parse, so its tree cannot be entered at all.
+                    Err(err) => {
+                        let hash = commit.hash()?;
+                        if seen_unreadable.insert(hash) {
+                            unreadable_nodes.record(UnreadableNode {
+                                hash: hash.to_string(),
+                                error: err.to_string(),
+                            });
+                        }
+                        continue;
+                    }
                 };
+
+                for (hash, error) in added.unreadable {
+                    if seen_unreadable.insert(hash) {
+                        unreadable_nodes.record(UnreadableNode {
+                            hash: hash.to_string(),
+                            error,
+                        });
+                    }
+                }
 
                 for hash in added.nodes {
                     if seen_nodes.insert(hash) && !store.exists(&hash)? {
@@ -301,12 +339,13 @@ async fn check_tree_nodes(
                     versions.entry(hash).or_default().extend(declared);
                 }
             }
-            Ok((versions, missing_nodes))
+            Ok((versions, missing_nodes, unreadable_nodes))
         })
         .await??;
 
     report.versions_checked = versions.len();
     report.missing_nodes = missing_nodes;
+    report.unreadable_nodes = unreadable_nodes;
     Ok(versions)
 }
 
@@ -370,6 +409,7 @@ mod tests {
     use super::*;
     use crate::test;
     use crate::util;
+    use bytes::Bytes;
     use std::path::Path;
 
     /// The single stored version blob under `dir`, for tests that corrupt one deliberately.
@@ -564,6 +604,49 @@ mod tests {
                 "the absent directory node is a finding: {report:?}"
             );
             assert_eq!(report.missing_nodes.sample, vec![dir.hash.to_string()]);
+            assert!(!report.is_healthy());
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_an_unreadable_node_is_reported_and_the_rest_still_checked()
+    -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let nested = repo.path.join("nested");
+            util::fs::create_dir_all(&nested)?;
+            util::fs::write_to_path(nested.join("buried.txt"), "buried")?;
+            util::fs::write_to_path(repo.path.join("top.txt"), "top")?;
+            repositories::add(&repo, &repo.path).await?;
+            let commit = repositories::commit(&repo, "Add both")?;
+
+            let dir = repositories::tree::get_dir_with_children(&repo, &commit, "nested", None)?
+                .expect("the nested directory has a node");
+
+            // Present but unparseable, which is the case a missing-node check cannot see.
+            repo.merkle_node_store().write_node(
+                &dir.hash,
+                Bytes::from_static(b"not a node"),
+                Bytes::from_static(b"not children"),
+            )?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(
+                report.unreadable_nodes.count, 1,
+                "the unreadable node is a finding: {report:?}"
+            );
+            assert_eq!(report.unreadable_nodes.sample[0].hash, dir.hash.to_string());
+            assert_eq!(
+                report.missing_nodes.count, 0,
+                "a node that is present but unreadable is not a missing one"
+            );
+            assert!(
+                report.versions_checked >= 1,
+                "only the damaged subtree is skipped, not the whole commit: {report:?}"
+            );
             assert!(!report.is_healthy());
 
             Ok(())

--- a/crates/liboxen/src/repositories/verify.rs
+++ b/crates/liboxen/src/repositories/verify.rs
@@ -84,6 +84,13 @@ pub struct SizeMismatch {
     pub stored_bytes: u64,
 }
 
+/// A version blob whose metadata probe failed, leaving its size neither confirmed nor refuted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UncheckedVersion {
+    pub hash: String,
+    pub error: String,
+}
+
 /// What a [`verify_repo`] pass found.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct VerifyReport {
@@ -96,6 +103,7 @@ pub struct VerifyReport {
     pub missing_nodes: Findings<String>,
     pub missing_versions: Findings<String>,
     pub size_mismatches: Findings<SizeMismatch>,
+    pub unchecked_versions: Findings<UncheckedVersion>,
 }
 
 impl VerifyReport {
@@ -107,6 +115,7 @@ impl VerifyReport {
             && self.missing_nodes.is_empty()
             && self.missing_versions.is_empty()
             && self.size_mismatches.is_empty()
+            && self.unchecked_versions.is_empty()
     }
 
     /// Findings across every class.
@@ -117,14 +126,15 @@ impl VerifyReport {
             + self.missing_nodes.count
             + self.missing_versions.count
             + self.size_mismatches.count
+            + self.unchecked_versions.count
     }
 }
 
 /// Check that everything the repository's commits reference is present and the right size.
 ///
 /// Reads only. Cost scales with the repository's distinct object count, which is also held in
-/// memory: no blob contents are read, and each distinct content hash costs at most one
-/// version-store existence probe and one metadata probe.
+/// memory: no blob contents are read, and each distinct content hash costs one version-store
+/// metadata probe however many paths reference it.
 pub async fn verify_repo(repo: &LocalRepository) -> Result<VerifyReport, OxenError> {
     let mut report = VerifyReport::default();
 
@@ -296,11 +306,13 @@ async fn check_tree_nodes(
     Ok(versions)
 }
 
-/// Version blobs the repository does not hold, and blobs whose stored size disagrees with a size
-/// a file node declares for them.
+/// Version blobs the repository does not hold, blobs whose stored size disagrees with a size a
+/// file node declares for them, and blobs whose size could not be established.
 ///
-/// Each blob is probed once and its stored size compared against every size declared for it, so
-/// nodes that disagree about one blob each get their own finding.
+/// One metadata probe per blob answers all three, so a blob referenced from a thousand paths costs
+/// one round trip and its stored size is compared against every size declared for it. A probe that
+/// fails for any reason other than the blob being absent is reported rather than passed over, so a
+/// pass that could not reach part of the store never reads as a clean one.
 async fn check_versions(
     repo: &LocalRepository,
     versions: HashMap<String, DeclaredSizes>,
@@ -308,35 +320,33 @@ async fn check_versions(
 ) -> Result<(), OxenError> {
     let version_store = repo.version_store();
 
-    let hashes: Vec<String> = versions.keys().cloned().collect();
-    let missing: HashSet<String> = version_store
-        .find_missing_versions(&hashes)
-        .await?
-        .into_iter()
-        .collect();
-    for hash in &missing {
-        report.missing_versions.record(hash.clone());
-    }
-
-    // An absent blob has no size to disagree with, and is already reported.
-    let present: Vec<(String, DeclaredSizes)> = versions
-        .into_iter()
-        .filter(|(hash, _)| !missing.contains(hash))
-        .collect();
-
-    let max_concurrent = MAX_CONCURRENT_SIZE_PROBES.min(present.len().max(1));
-    let mut probes = futures_util::stream::iter(present)
+    let max_concurrent = MAX_CONCURRENT_SIZE_PROBES.min(versions.len().max(1));
+    let mut probes = futures_util::stream::iter(versions)
         .map(|(hash, declared)| {
             let version_store = version_store.clone();
             async move {
-                let stored = version_store.get_version_size(&hash).await.ok();
+                let stored = version_store.get_version_size(&hash).await;
                 (hash, declared, stored)
             }
         })
         .buffer_unordered(max_concurrent);
 
     while let Some((hash, declared, stored)) = probes.next().await {
-        let Some(stored_bytes) = stored else { continue };
+        let stored_bytes = match stored {
+            Ok(stored_bytes) => stored_bytes,
+            Err(OxenError::VersionStoreBlobMissing { .. }) => {
+                report.missing_versions.record(hash);
+                continue;
+            }
+            Err(err) => {
+                report.unchecked_versions.record(UncheckedVersion {
+                    hash,
+                    error: err.to_string(),
+                });
+                continue;
+            }
+        };
+
         for (declared_bytes, path) in declared {
             if stored_bytes != declared_bytes {
                 report.size_mismatches.record(SizeMismatch {
@@ -517,6 +527,53 @@ mod tests {
             assert_eq!(
                 report.size_mismatches.count, 0,
                 "an absent blob is missing, not the wrong size"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_a_blob_whose_size_cannot_be_read_is_not_called_healthy() -> Result<(), OxenError>
+    {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let path = repo.path.join("a.txt");
+            util::fs::write_to_path(&path, "alpha")?;
+            repositories::add(&repo, &path).await?;
+            let commit = repositories::commit(&repo, "Add a")?;
+
+            let entries = repositories::entries::list_for_commit(&repo, &commit)?;
+            let hash = entries.first().expect("one entry").hash.clone();
+
+            // A regular file where the blob's directory belongs, so probing the blob inside it
+            // fails with something other than "absent".
+            let blob = find_only_version_blob(&repo.path.join(".oxen").join("versions"))?;
+            let blob_dir = blob
+                .parent()
+                .expect("a blob lives in a directory")
+                .to_path_buf();
+            std::fs::remove_dir_all(&blob_dir)?;
+            std::fs::write(&blob_dir, b"not a directory")?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(
+                report.unchecked_versions.count, 1,
+                "a blob that could not be probed is reported: {report:?}"
+            );
+            assert_eq!(report.unchecked_versions.sample[0].hash, hash);
+            assert_eq!(
+                report.missing_versions.count, 0,
+                "a probe that failed is not evidence the blob is absent"
+            );
+            assert_eq!(
+                report.size_mismatches.count, 0,
+                "a size that was never read cannot disagree"
+            );
+            assert!(
+                !report.is_healthy(),
+                "a pass that could not check a blob is not a clean one"
             );
 
             Ok(())

--- a/crates/liboxen/src/repositories/verify.rs
+++ b/crates/liboxen/src/repositories/verify.rs
@@ -2,8 +2,9 @@
 //!
 //! Read-only integrity checks for a repository.
 //!
-//! Answers one question: does everything this repository's commits reference actually exist, and
-//! does it look like what the tree says it is. Nothing here mutates a repository.
+//! Answers one question: does everything this repository's commits and workspaces reference
+//! actually exist, and does it look like what the tree says it is. Nothing here mutates a
+//! repository.
 //!
 //! Findings are reported as counts plus a bounded sample.
 
@@ -15,8 +16,10 @@ use std::path::PathBuf;
 use crate::error::OxenError;
 use crate::model::{Commit, LocalRepository, MerkleHash, NewCommit};
 use crate::repositories;
+use crate::repositories::commits;
 use crate::repositories::commits::commit_writer::compute_commit_id;
 use crate::repositories::tree::DeclaredSizes;
+use crate::repositories::workspaces;
 
 /// Examples of each finding a report carries alongside the count.
 const SAMPLE_LIMIT: usize = 10;
@@ -58,6 +61,15 @@ impl<T> Findings<T> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DanglingBranch {
     pub branch: String,
+    pub commit_id: String,
+}
+
+/// A workspace pinned to a commit the repository does not have.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DanglingWorkspace {
+    /// The workspace's own id when its config records one, else the directory it lives in.
+    pub workspace: String,
+    pub name: Option<String>,
     pub commit_id: String,
 }
 
@@ -108,7 +120,9 @@ pub struct VerifyReport {
     pub branches_checked: usize,
     pub commits_checked: usize,
     pub versions_checked: usize,
+    pub workspaces_checked: usize,
     pub dangling_branches: Findings<DanglingBranch>,
+    pub dangling_workspaces: Findings<DanglingWorkspace>,
     pub dangling_parents: Findings<DanglingParent>,
     pub misaddressed_commits: Findings<MisaddressedCommit>,
     pub missing_nodes: Findings<String>,
@@ -122,6 +136,7 @@ impl VerifyReport {
     /// Whether the pass found nothing wrong.
     pub fn is_healthy(&self) -> bool {
         self.dangling_branches.is_empty()
+            && self.dangling_workspaces.is_empty()
             && self.dangling_parents.is_empty()
             && self.misaddressed_commits.is_empty()
             && self.missing_nodes.is_empty()
@@ -134,6 +149,7 @@ impl VerifyReport {
     /// Findings across every class.
     pub fn total_findings(&self) -> usize {
         self.dangling_branches.count
+            + self.dangling_workspaces.count
             + self.dangling_parents.count
             + self.misaddressed_commits.count
             + self.missing_nodes.count
@@ -144,7 +160,8 @@ impl VerifyReport {
     }
 }
 
-/// Check that everything the repository's commits reference is present and the right size.
+/// Check that everything the repository's commits and workspaces reference is present and the
+/// right size.
 ///
 /// Reads only. Cost scales with the repository's distinct object count, which is also held in
 /// memory: no blob contents are read, and each distinct content hash costs one version-store
@@ -153,6 +170,7 @@ pub async fn verify_repo(repo: &LocalRepository) -> Result<VerifyReport, OxenErr
     let mut report = VerifyReport::default();
 
     check_branch_heads(repo, &mut report).await?;
+    check_workspace_pins(repo, &mut report).await?;
     let commits = check_commits(repo, &mut report).await?;
     let versions = check_tree_nodes(repo, &commits, &mut report).await?;
     check_versions(repo, versions, &mut report).await?;
@@ -185,6 +203,57 @@ async fn check_branch_heads(
         .await??;
 
     report.dangling_branches = dangling;
+    Ok(())
+}
+
+/// Every workspace's pinned commit resolves.
+///
+/// A workspace pins the commit it was created against, independently of where any branch points.
+/// The commit walk covers branch ancestry only.
+async fn check_workspace_pins(
+    repo: &LocalRepository,
+    report: &mut VerifyReport,
+) -> Result<(), OxenError> {
+    type WorkspaceFindings = (usize, Findings<DanglingWorkspace>);
+
+    // Sync core: listing workspace dirs, reading each config, and resolving each pin is file and
+    // DB IO, one blocking unit.
+    let walk_repo = repo.clone();
+    let (checked, dangling) =
+        tokio::task::spawn_blocking(move || -> Result<WorkspaceFindings, OxenError> {
+            let mut checked = 0;
+            let mut dangling = Findings::default();
+
+            for dir in workspaces::list_dirs(&walk_repo)? {
+                // A directory holding no config is not a workspace.
+                let Some(config) = workspaces::read_config(&dir)? else {
+                    continue;
+                };
+                checked += 1;
+
+                if commits::get_by_id(&walk_repo, &config.workspace_commit_id)?.is_some() {
+                    continue;
+                }
+
+                let workspace = config.workspace_id.unwrap_or_else(|| {
+                    dir.file_name().map_or_else(
+                        || dir.display().to_string(),
+                        |name| name.to_string_lossy().into_owned(),
+                    )
+                });
+                dangling.record(DanglingWorkspace {
+                    workspace,
+                    name: config.workspace_name,
+                    commit_id: config.workspace_commit_id,
+                });
+            }
+
+            Ok((checked, dangling))
+        })
+        .await??;
+
+    report.workspaces_checked = checked;
+    report.dangling_workspaces = dangling;
     Ok(())
 }
 
@@ -407,6 +476,7 @@ async fn check_versions(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::Workspace;
     use crate::model::merkle_tree::node::{EMerkleTreeNode, MerkleTreeNode};
     use crate::test;
     use crate::util;
@@ -947,6 +1017,127 @@ mod tests {
                 report.dangling_branches.count, 0,
                 "the branch head itself still resolves"
             );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_a_workspace_whose_pin_resolves_is_counted_and_not_a_finding()
+    -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let path = repo.path.join("a.txt");
+            util::fs::write_to_path(&path, "alpha")?;
+            repositories::add(&repo, &path).await?;
+            let commit = repositories::commit(&repo, "Add a")?;
+
+            workspaces::create(&repo, &commit, "ws-sound", true)?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(report.workspaces_checked, 1);
+            assert!(report.dangling_workspaces.is_empty());
+            assert!(report.is_healthy(), "a resolvable pin is not a finding");
+
+            Ok(())
+        })
+        .await
+    }
+
+    /// Nothing but the pin references the commit. The total-findings assertion holds the line
+    /// that no other class covers it.
+    #[tokio::test]
+    async fn test_a_workspace_pinned_to_a_missing_commit_is_reported() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let path = repo.path.join("a.txt");
+            util::fs::write_to_path(&path, "alpha")?;
+            repositories::add(&repo, &path).await?;
+            let commit = repositories::commit(&repo, "Add a")?;
+
+            let workspace = workspaces::create_with_name(
+                &repo,
+                &commit,
+                "ws-stranded",
+                Some("history_workspace".to_string()),
+                true,
+            )
+            .await?;
+            let absent = "deadbeefdeadbeefdeadbeefdeadbeef";
+            workspaces::update_commit(&workspace, absent)?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(report.workspaces_checked, 1);
+            assert_eq!(report.dangling_workspaces.count, 1, "{report:?}");
+            let dangling = &report.dangling_workspaces.sample[0];
+            assert_eq!(dangling.workspace, "ws-stranded");
+            assert_eq!(dangling.name.as_deref(), Some("history_workspace"));
+            assert_eq!(dangling.commit_id, absent);
+            assert!(!report.is_healthy());
+
+            assert_eq!(
+                report.total_findings(),
+                1,
+                "the commit walk reaches nothing that names the pinned commit: {report:?}"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_a_directory_holding_no_config_is_not_counted_as_a_workspace()
+    -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let path = repo.path.join("a.txt");
+            util::fs::write_to_path(&path, "alpha")?;
+            repositories::add(&repo, &path).await?;
+            repositories::commit(&repo, "Add a")?;
+
+            util::fs::create_dir_all(Workspace::workspaces_dir(&repo).join("leftover"))?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(report.workspaces_checked, 0);
+            assert!(report.dangling_workspaces.is_empty());
+            assert!(report.is_healthy());
+
+            Ok(())
+        })
+        .await
+    }
+
+    /// A config written before the id was recorded still identifies its workspace, by the
+    /// directory it lives in.
+    #[tokio::test]
+    async fn test_a_workspace_config_without_an_id_is_named_by_its_directory()
+    -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let path = repo.path.join("a.txt");
+            util::fs::write_to_path(&path, "alpha")?;
+            repositories::add(&repo, &path).await?;
+            let commit = repositories::commit(&repo, "Add a")?;
+
+            let workspace = workspaces::create(&repo, &commit, "ws-idless", true)?;
+            let dir = workspace.dir();
+            let config_path = Workspace::config_path_from_dir(&dir);
+            util::fs::write_to_path(
+                &config_path,
+                "workspace_commit_id = \"deadbeefdeadbeefdeadbeefdeadbeef\"\nis_editable = true\n",
+            )?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(report.dangling_workspaces.count, 1, "{report:?}");
+            let dangling = &report.dangling_workspaces.sample[0];
+            let dir_name = dir
+                .file_name()
+                .expect("the workspace directory has a name")
+                .to_string_lossy();
+            assert_eq!(dangling.workspace, dir_name);
+            assert_eq!(dangling.name, None);
 
             Ok(())
         })

--- a/crates/liboxen/src/repositories/verify.rs
+++ b/crates/liboxen/src/repositories/verify.rs
@@ -16,7 +16,7 @@ use crate::error::OxenError;
 use crate::model::{Commit, LocalRepository, MerkleHash, NewCommit};
 use crate::repositories;
 use crate::repositories::commits::commit_writer::compute_commit_id;
-use crate::repositories::tree::AddedFile;
+use crate::repositories::tree::DeclaredSizes;
 
 /// Examples of each finding a report carries alongside the count.
 const SAMPLE_LIMIT: usize = 10;
@@ -245,8 +245,8 @@ async fn check_tree_nodes(
     repo: &LocalRepository,
     commits: &[Commit],
     report: &mut VerifyReport,
-) -> Result<HashMap<String, AddedFile>, OxenError> {
-    type TreeFindings = (HashMap<String, AddedFile>, Findings<String>);
+) -> Result<HashMap<String, DeclaredSizes>, OxenError> {
+    type TreeFindings = (HashMap<String, DeclaredSizes>, Findings<String>);
 
     // Sync core: the merkle walk and the node-existence probes are sync DB IO, one blocking unit.
     let walk_repo = repo.clone();
@@ -259,7 +259,7 @@ async fn check_tree_nodes(
             }
 
             let store = walk_repo.merkle_node_store();
-            let mut versions: HashMap<String, AddedFile> = HashMap::new();
+            let mut versions: HashMap<String, DeclaredSizes> = HashMap::new();
             let mut seen_nodes: HashSet<MerkleHash> = HashSet::new();
             let mut missing_nodes = Findings::default();
 
@@ -283,8 +283,8 @@ async fn check_tree_nodes(
                         missing_nodes.record(hash.to_string());
                     }
                 }
-                for (hash, file) in added.versions {
-                    versions.entry(hash).or_insert(file);
+                for (hash, declared) in added.versions {
+                    versions.entry(hash).or_default().extend(declared);
                 }
             }
             Ok((versions, missing_nodes))
@@ -296,11 +296,14 @@ async fn check_tree_nodes(
     Ok(versions)
 }
 
-/// Version blobs the repository does not hold, and blobs whose stored size disagrees with the size
-/// the file node referencing them declares.
+/// Version blobs the repository does not hold, and blobs whose stored size disagrees with a size
+/// a file node declares for them.
+///
+/// Each blob is probed once and its stored size compared against every size declared for it, so
+/// nodes that disagree about one blob each get their own finding.
 async fn check_versions(
     repo: &LocalRepository,
-    versions: HashMap<String, AddedFile>,
+    versions: HashMap<String, DeclaredSizes>,
     report: &mut VerifyReport,
 ) -> Result<(), OxenError> {
     let version_store = repo.version_store();
@@ -316,31 +319,33 @@ async fn check_versions(
     }
 
     // An absent blob has no size to disagree with, and is already reported.
-    let present: Vec<(String, AddedFile)> = versions
+    let present: Vec<(String, DeclaredSizes)> = versions
         .into_iter()
         .filter(|(hash, _)| !missing.contains(hash))
         .collect();
 
     let max_concurrent = MAX_CONCURRENT_SIZE_PROBES.min(present.len().max(1));
     let mut probes = futures_util::stream::iter(present)
-        .map(|(hash, file)| {
+        .map(|(hash, declared)| {
             let version_store = version_store.clone();
             async move {
                 let stored = version_store.get_version_size(&hash).await.ok();
-                (hash, file, stored)
+                (hash, declared, stored)
             }
         })
         .buffer_unordered(max_concurrent);
 
-    while let Some((hash, file, stored)) = probes.next().await {
+    while let Some((hash, declared, stored)) = probes.next().await {
         let Some(stored_bytes) = stored else { continue };
-        if stored_bytes != file.num_bytes {
-            report.size_mismatches.record(SizeMismatch {
-                hash,
-                path: file.path,
-                declared_bytes: file.num_bytes,
-                stored_bytes,
-            });
+        for (declared_bytes, path) in declared {
+            if stored_bytes != declared_bytes {
+                report.size_mismatches.record(SizeMismatch {
+                    hash: hash.clone(),
+                    path,
+                    declared_bytes,
+                    stored_bytes,
+                });
+            }
         }
     }
     Ok(())
@@ -545,6 +550,48 @@ mod tests {
             assert_eq!(
                 report.missing_versions.count, 0,
                 "a present blob is the wrong size, not missing"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_every_size_declared_for_one_blob_is_checked() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let path = repo.path.join("a.txt");
+            util::fs::write_to_path(&path, "the original contents")?;
+            repositories::add(&repo, &path).await?;
+            let commit = repositories::commit(&repo, "Add a")?;
+
+            let entries = repositories::entries::list_for_commit(&repo, &commit)?;
+            let entry = entries.first().expect("one entry").clone();
+
+            // Two file nodes referencing one blob while disagreeing about its size. Identical
+            // content stats to an identical length, so the declarations are built here rather
+            // than committed.
+            let declared = DeclaredSizes::from([
+                (entry.num_bytes, PathBuf::from("a.txt")),
+                (entry.num_bytes + 1, PathBuf::from("copy.txt")),
+            ]);
+            let versions = HashMap::from([(entry.hash.clone(), declared)]);
+
+            let mut report = VerifyReport::default();
+            check_versions(&repo, versions, &mut report).await?;
+
+            assert_eq!(
+                report.size_mismatches.count, 1,
+                "only the declaration disagreeing with the stored blob is reported: {report:?}"
+            );
+            let mismatch = &report.size_mismatches.sample[0];
+            assert_eq!(mismatch.hash, entry.hash);
+            assert_eq!(mismatch.declared_bytes, entry.num_bytes + 1);
+            assert_eq!(mismatch.stored_bytes, entry.num_bytes);
+            assert_eq!(mismatch.path, PathBuf::from("copy.txt"));
+            assert!(
+                report.missing_versions.is_empty(),
+                "the blob is present, so nothing is missing"
             );
 
             Ok(())

--- a/crates/liboxen/src/repositories/verify.rs
+++ b/crates/liboxen/src/repositories/verify.rs
@@ -407,6 +407,7 @@ async fn check_versions(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::merkle_tree::node::{EMerkleTreeNode, MerkleTreeNode};
     use crate::test;
     use crate::util;
     use bytes::Bytes;
@@ -648,6 +649,51 @@ mod tests {
                 "only the damaged subtree is skipped, not the whole commit: {report:?}"
             );
             assert!(!report.is_healthy());
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_an_unreadable_vnode_is_named_and_its_siblings_still_checked()
+    -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let nested = repo.path.join("nested");
+            util::fs::create_dir_all(&nested)?;
+            util::fs::write_to_path(nested.join("buried.txt"), "buried")?;
+            util::fs::write_to_path(repo.path.join("top.txt"), "top")?;
+            repositories::add(&repo, &repo.path).await?;
+            let commit = repositories::commit(&repo, "Add both")?;
+
+            let dir = repositories::tree::get_dir_with_children(&repo, &commit, "nested", None)?
+                .expect("the nested directory has a node");
+            let (vnode_hash, _) = MerkleTreeNode::read_children_from_hash(&repo, &dir.hash)?
+                .into_iter()
+                .find(|(_, child)| matches!(child.node, EMerkleTreeNode::VNode(_)))
+                .expect("the nested directory has a vnode");
+
+            repo.merkle_node_store().write_node(
+                &vnode_hash,
+                Bytes::from_static(b"not a node"),
+                Bytes::from_static(b"not children"),
+            )?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(
+                report.unreadable_nodes.count, 1,
+                "the unreadable vnode is a finding: {report:?}"
+            );
+            assert_eq!(
+                report.unreadable_nodes.sample[0].hash,
+                vnode_hash.to_string(),
+                "the finding names the vnode that could not be read, not its parent directory"
+            );
+            assert!(
+                report.versions_checked >= 1,
+                "entries outside the damaged vnode are still checked: {report:?}"
+            );
 
             Ok(())
         })

--- a/crates/liboxen/src/repositories/verify.rs
+++ b/crates/liboxen/src/repositories/verify.rs
@@ -2,20 +2,21 @@
 //!
 //! Read-only integrity checks for a repository.
 //!
-//! Answers one question: does everything this repository's branches reference actually exist, and
+//! Answers one question: does everything this repository's commits reference actually exist, and
 //! does it look like what the tree says it is. Nothing here mutates a repository.
 //!
 //! Findings are reported as counts plus a bounded sample.
 
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use crate::error::OxenError;
-use crate::model::{Commit, CommitEntry, LocalRepository, MerkleHash, NewCommit};
+use crate::model::{Commit, LocalRepository, MerkleHash, NewCommit};
 use crate::repositories;
 use crate::repositories::commits::commit_writer::compute_commit_id;
+use crate::repositories::tree::AddedFile;
 
 /// Examples of each finding a report carries alongside the count.
 const SAMPLE_LIMIT: usize = 10;
@@ -88,7 +89,7 @@ pub struct SizeMismatch {
 pub struct VerifyReport {
     pub branches_checked: usize,
     pub commits_checked: usize,
-    pub entries_checked: usize,
+    pub versions_checked: usize,
     pub dangling_branches: Findings<DanglingBranch>,
     pub dangling_parents: Findings<DanglingParent>,
     pub misaddressed_commits: Findings<MisaddressedCommit>,
@@ -119,64 +120,67 @@ impl VerifyReport {
     }
 }
 
-/// Check that everything the repository's branches reference is present and the right size.
+/// Check that everything the repository's commits reference is present and the right size.
 ///
-/// Reads only. Cost scales with the number of reachable entries: one version-store metadata probe
-/// per distinct content hash, and no blob contents are read.
+/// Reads only. Cost scales with the repository's distinct object count, which is also held in
+/// memory: no blob contents are read, and each distinct content hash costs at most one
+/// version-store existence probe and one metadata probe.
 pub async fn verify_repo(repo: &LocalRepository) -> Result<VerifyReport, OxenError> {
     let mut report = VerifyReport::default();
 
-    let heads = resolve_branch_heads(repo, &mut report).await?;
-    check_commits(repo, &mut report).await?;
-    check_reachable_objects(repo, &heads, &mut report).await?;
-    check_entry_sizes(repo, &heads, &mut report).await?;
+    check_branch_heads(repo, &mut report).await?;
+    let commits = check_commits(repo, &mut report).await?;
+    let versions = check_tree_nodes(repo, &commits, &mut report).await?;
+    check_versions(repo, versions, &mut report).await?;
 
     Ok(report)
 }
 
-/// The commit each branch points at, recording the branches whose head does not resolve.
-async fn resolve_branch_heads(
+/// Every branch head names a commit the repository holds.
+async fn check_branch_heads(
     repo: &LocalRepository,
     report: &mut VerifyReport,
-) -> Result<Vec<Commit>, OxenError> {
+) -> Result<(), OxenError> {
     let branches = repositories::branches::list(repo).await?;
     report.branches_checked = branches.len();
 
     let walk_repo = repo.clone();
-    let (heads, dangling) = tokio::task::spawn_blocking(
-        move || -> Result<(Vec<Commit>, Findings<DanglingBranch>), OxenError> {
-            let mut heads = Vec::new();
+    let dangling =
+        tokio::task::spawn_blocking(move || -> Result<Findings<DanglingBranch>, OxenError> {
             let mut dangling = Findings::default();
             for branch in branches {
-                match repositories::commits::get_by_id(&walk_repo, &branch.commit_id)? {
-                    Some(commit) => heads.push(commit),
-                    None => dangling.record(DanglingBranch {
+                if repositories::commits::get_by_id(&walk_repo, &branch.commit_id)?.is_none() {
+                    dangling.record(DanglingBranch {
                         branch: branch.name,
                         commit_id: branch.commit_id,
-                    }),
+                    });
                 }
             }
-            Ok((heads, dangling))
-        },
-    )
-    .await??;
+            Ok(dangling)
+        })
+        .await??;
 
     report.dangling_branches = dangling;
-    Ok(heads)
+    Ok(())
 }
 
 /// Every reachable commit hashes to the id it is filed under, and every parent it names resolves.
-async fn check_commits(repo: &LocalRepository, report: &mut VerifyReport) -> Result<(), OxenError> {
+async fn check_commits(
+    repo: &LocalRepository,
+    report: &mut VerifyReport,
+) -> Result<Vec<Commit>, OxenError> {
     type CommitFindings = (
-        usize,
+        Vec<Commit>,
         Findings<DanglingParent>,
         Findings<MisaddressedCommit>,
     );
 
     let walk_repo = repo.clone();
-    let (commits_checked, dangling, misaddressed) =
+    let (commits, dangling, misaddressed) =
         tokio::task::spawn_blocking(move || -> Result<CommitFindings, OxenError> {
-            let commits = repositories::commits::list_all(&walk_repo)?;
+            let commits: Vec<Commit> = repositories::commits::list_all(&walk_repo)?
+                .into_iter()
+                .collect();
             let mut dangling = Findings::default();
             let mut misaddressed = Findings::default();
 
@@ -199,14 +203,14 @@ async fn check_commits(repo: &LocalRepository, report: &mut VerifyReport) -> Res
                     }
                 }
             }
-            Ok((commits.len(), dangling, misaddressed))
+            Ok((commits, dangling, misaddressed))
         })
         .await??;
 
-    report.commits_checked = commits_checked;
+    report.commits_checked = commits.len();
     report.dangling_parents = dangling;
     report.misaddressed_commits = misaddressed;
-    Ok(())
+    Ok(commits)
 }
 
 /// A commit's own fields, re-hashed, against the id it is filed under.
@@ -230,85 +234,111 @@ fn misaddressed_commit(commit: &Commit) -> Result<Option<MisaddressedCommit>, Ox
     }))
 }
 
-/// Merkle nodes and version blobs the branch trees reference but the repository does not hold.
-async fn check_reachable_objects(
+/// Merkle nodes the repository's commits reference but do not hold, returning the version blobs
+/// those commits reference so the store can be checked once for the whole set.
+///
+/// Every commit is covered, not only the branch heads, so a blob whose file was deleted in a later
+/// commit stays in scope for the commit that still has it. Each commit is walked as a delta against
+/// its first parent, and a commit whose parent the repository lacks is walked whole, so the total
+/// cost is the repository's distinct object count rather than the sum of every tree.
+async fn check_tree_nodes(
     repo: &LocalRepository,
-    heads: &[Commit],
+    commits: &[Commit],
     report: &mut VerifyReport,
-) -> Result<(), OxenError> {
-    let mut seen_nodes = HashSet::new();
-    let mut seen_versions = HashSet::new();
+) -> Result<HashMap<String, AddedFile>, OxenError> {
+    type TreeFindings = (HashMap<String, AddedFile>, Findings<String>);
 
-    for head in heads {
-        // `None` as the base widens the walk from a delta to the whole tree.
-        let missing = repositories::tree::find_missing_added_objects(repo, None, head).await?;
-        for node in missing.nodes {
-            if seen_nodes.insert(node.clone()) {
-                report.missing_nodes.record(node);
-            }
-        }
-        for version in missing.versions {
-            if seen_versions.insert(version.clone()) {
-                report.missing_versions.record(version);
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Stored blob size against the size each file node declares.
-async fn check_entry_sizes(
-    repo: &LocalRepository,
-    heads: &[Commit],
-    report: &mut VerifyReport,
-) -> Result<(), OxenError> {
-    let version_store = repo.version_store();
+    // Sync core: the merkle walk and the node-existence probes are sync DB IO, one blocking unit.
     let walk_repo = repo.clone();
-    let heads = heads.to_vec();
-    let (entries_checked, entries) =
-        tokio::task::spawn_blocking(move || -> Result<(usize, Vec<CommitEntry>), OxenError> {
-            let mut probed = HashSet::new();
-            let mut entries = Vec::new();
-            let mut entries_checked = 0;
+    let commits = commits.to_vec();
+    let (versions, missing_nodes) =
+        tokio::task::spawn_blocking(move || -> Result<TreeFindings, OxenError> {
+            let mut by_hash: HashMap<MerkleHash, &Commit> = HashMap::new();
+            for commit in &commits {
+                by_hash.insert(commit.hash()?, commit);
+            }
 
-            for head in &heads {
-                // A head whose tree is absent has no entries to size, and the missing node is
-                // already reported.
-                if repositories::tree::get_root_with_children(&walk_repo, head)?.is_none() {
+            let store = walk_repo.merkle_node_store();
+            let mut versions: HashMap<String, AddedFile> = HashMap::new();
+            let mut seen_nodes: HashSet<MerkleHash> = HashSet::new();
+            let mut missing_nodes = Findings::default();
+
+            for commit in &commits {
+                // Parents resolve by the rule the dangling-parent check uses, so a parent that
+                // check reports as present is one this walk takes a delta against.
+                let base = commit
+                    .parent_ids
+                    .first()
+                    .and_then(|id| id.parse::<MerkleHash>().ok())
+                    .and_then(|hash| by_hash.get(&hash).copied());
+                let Some(added) = repositories::tree::added_objects(&walk_repo, base, commit)?
+                else {
+                    // No root directory node means the commit's tree was never written.
+                    missing_nodes.record(commit.hash()?.to_string());
                     continue;
-                }
-                for entry in repositories::entries::list_for_commit(&walk_repo, head)? {
-                    entries_checked += 1;
-                    if probed.insert(entry.hash.clone()) {
-                        entries.push(entry);
+                };
+
+                for hash in added.nodes {
+                    if seen_nodes.insert(hash) && !store.exists(&hash)? {
+                        missing_nodes.record(hash.to_string());
                     }
                 }
+                for (hash, file) in added.versions {
+                    versions.entry(hash).or_insert(file);
+                }
             }
-            Ok((entries_checked, entries))
+            Ok((versions, missing_nodes))
         })
         .await??;
 
-    report.entries_checked = entries_checked;
+    report.versions_checked = versions.len();
+    report.missing_nodes = missing_nodes;
+    Ok(versions)
+}
 
-    let max_concurrent = MAX_CONCURRENT_SIZE_PROBES.min(entries.len().max(1));
-    let mut probes = futures_util::stream::iter(entries)
-        .map(|entry| {
+/// Version blobs the repository does not hold, and blobs whose stored size disagrees with the size
+/// the file node referencing them declares.
+async fn check_versions(
+    repo: &LocalRepository,
+    versions: HashMap<String, AddedFile>,
+    report: &mut VerifyReport,
+) -> Result<(), OxenError> {
+    let version_store = repo.version_store();
+
+    let hashes: Vec<String> = versions.keys().cloned().collect();
+    let missing: HashSet<String> = version_store
+        .find_missing_versions(&hashes)
+        .await?
+        .into_iter()
+        .collect();
+    for hash in &missing {
+        report.missing_versions.record(hash.clone());
+    }
+
+    // An absent blob has no size to disagree with, and is already reported.
+    let present: Vec<(String, AddedFile)> = versions
+        .into_iter()
+        .filter(|(hash, _)| !missing.contains(hash))
+        .collect();
+
+    let max_concurrent = MAX_CONCURRENT_SIZE_PROBES.min(present.len().max(1));
+    let mut probes = futures_util::stream::iter(present)
+        .map(|(hash, file)| {
             let version_store = version_store.clone();
             async move {
-                // An absent blob has no size and is already reported as a missing version.
-                let stored = version_store.get_version_size(&entry.hash).await.ok();
-                (entry, stored)
+                let stored = version_store.get_version_size(&hash).await.ok();
+                (hash, file, stored)
             }
         })
         .buffer_unordered(max_concurrent);
 
-    while let Some((entry, stored)) = probes.next().await {
+    while let Some((hash, file, stored)) = probes.next().await {
         let Some(stored_bytes) = stored else { continue };
-        if stored_bytes != entry.num_bytes {
+        if stored_bytes != file.num_bytes {
             report.size_mismatches.record(SizeMismatch {
-                hash: entry.hash,
-                path: entry.path,
-                declared_bytes: entry.num_bytes,
+                hash,
+                path: file.path,
+                declared_bytes: file.num_bytes,
                 stored_bytes,
             });
         }
@@ -321,6 +351,7 @@ mod tests {
     use super::*;
     use crate::test;
     use crate::util;
+    use std::path::Path;
 
     /// The single stored version blob under `dir`, for tests that corrupt one deliberately.
     fn find_only_version_blob(dir: &std::path::Path) -> Result<PathBuf, OxenError> {
@@ -366,6 +397,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_a_blob_only_older_commits_reference_is_still_checked() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let doomed = repo.path.join("doomed.txt");
+            util::fs::write_to_path(&doomed, "only in the first commit")?;
+            repositories::add(&repo, &doomed).await?;
+            let first = repositories::commit(&repo, "Add doomed")?;
+
+            let entries = repositories::entries::list_for_commit(&repo, &first)?;
+            let doomed_hash = entries.first().expect("one entry").hash.clone();
+
+            // Remove it, so the branch head's tree no longer references the blob but history does.
+            repositories::rm(
+                &repo,
+                &crate::opts::RmOpts::from_path(Path::new("doomed.txt")),
+            )
+            .await?;
+            repositories::commit(&repo, "Remove doomed")?;
+
+            repo.version_store().delete_version(&doomed_hash).await?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(
+                report.missing_versions.count, 1,
+                "a blob an older commit still references is missing: {report:?}"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_the_size_of_a_blob_only_older_commits_reference_is_checked()
+    -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let nested = repo.path.join("nested");
+            util::fs::create_dir_all(&nested)?;
+            let doomed = nested.join("doomed.txt");
+            util::fs::write_to_path(&doomed, "only in the first commit")?;
+            repositories::add(&repo, &doomed).await?;
+            let first = repositories::commit(&repo, "Add doomed")?;
+
+            let entries = repositories::entries::list_for_commit(&repo, &first)?;
+            let declared_bytes = entries.first().expect("one entry").num_bytes;
+
+            // Remove it, so the branch head's tree no longer references the blob but history does.
+            repositories::rm(
+                &repo,
+                &crate::opts::RmOpts::from_path(Path::new("nested/doomed.txt")),
+            )
+            .await?;
+            repositories::commit(&repo, "Remove doomed")?;
+
+            let blob = find_only_version_blob(&repo.path.join(".oxen").join("versions"))?;
+            std::fs::write(&blob, b"short")?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(
+                report.size_mismatches.count, 1,
+                "a blob an older commit still references is sized: {report:?}"
+            );
+            let mismatch = &report.size_mismatches.sample[0];
+            assert_eq!(mismatch.declared_bytes, declared_bytes);
+            assert_eq!(mismatch.stored_bytes, 5);
+            assert_eq!(
+                mismatch.path,
+                PathBuf::from("nested").join("doomed.txt"),
+                "the path is the one the tree records, not the blob's storage path"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
     async fn test_a_sound_repository_reports_no_problems() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async move {
             let path = repo.path.join("a.txt");
@@ -377,7 +486,7 @@ mod tests {
 
             assert!(report.is_healthy(), "a sound repository has no findings");
             assert_eq!(report.branches_checked, 1);
-            assert_eq!(report.entries_checked, 1);
+            assert_eq!(report.versions_checked, 1);
 
             Ok(())
         })

--- a/crates/liboxen/src/repositories/verify.rs
+++ b/crates/liboxen/src/repositories/verify.rs
@@ -659,22 +659,38 @@ mod tests {
     async fn test_an_unreadable_vnode_is_named_and_its_siblings_still_checked()
     -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async move {
-            let nested = repo.path.join("nested");
-            util::fs::create_dir_all(&nested)?;
-            util::fs::write_to_path(nested.join("buried.txt"), "buried")?;
-            util::fs::write_to_path(repo.path.join("top.txt"), "top")?;
+            let mut repo = repo;
+            // One entry per vnode, so a single directory holds several of them.
+            repo.set_vnode_size(1);
+            test::populate_dir_with_txt_files(repo.path.join("nested"), "file", 4)?;
             repositories::add(&repo, &repo.path).await?;
-            let commit = repositories::commit(&repo, "Add both")?;
+            let commit = repositories::commit(&repo, "Add four files")?;
 
             let dir = repositories::tree::get_dir_with_children(&repo, &commit, "nested", None)?
                 .expect("the nested directory has a node");
-            let (vnode_hash, _) = MerkleTreeNode::read_children_from_hash(&repo, &dir.hash)?
-                .into_iter()
-                .find(|(_, child)| matches!(child.node, EMerkleTreeNode::VNode(_)))
-                .expect("the nested directory has a vnode");
+            let mut vnodes = Vec::new();
+            for (hash, child) in MerkleTreeNode::read_children_from_hash(&repo, &dir.hash)? {
+                if matches!(child.node, EMerkleTreeNode::VNode(_)) {
+                    let files = MerkleTreeNode::read_children_from_hash(&repo, &hash)?.len();
+                    vnodes.push((hash, files));
+                }
+            }
+            // Entries bucket into vnodes by a hash of their path, so which vnode holds what is
+            // fixed by the file names rather than chosen here.
+            let (damaged, hidden) = vnodes
+                .iter()
+                .filter(|(_, files)| *files > 0)
+                .min_by_key(|(_, files)| *files)
+                .copied()
+                .expect("the nested directory has a vnode holding entries");
+            let survivors = vnodes.iter().map(|(_, files)| files).sum::<usize>() - hidden;
+            assert!(
+                survivors >= 1,
+                "the fixture needs entries outside the damaged vnode: {vnodes:?}"
+            );
 
             repo.merkle_node_store().write_node(
-                &vnode_hash,
+                &damaged,
                 Bytes::from_static(b"not a node"),
                 Bytes::from_static(b"not children"),
             )?;
@@ -687,13 +703,14 @@ mod tests {
             );
             assert_eq!(
                 report.unreadable_nodes.sample[0].hash,
-                vnode_hash.to_string(),
+                damaged.to_string(),
                 "the finding names the vnode that could not be read, not its parent directory"
             );
-            assert!(
-                report.versions_checked >= 1,
-                "entries outside the damaged vnode are still checked: {report:?}"
+            assert_eq!(
+                report.versions_checked, survivors,
+                "every blob outside the damaged vnode is still checked: {report:?}"
             );
+            assert!(!report.is_healthy());
 
             Ok(())
         })

--- a/crates/liboxen/src/repositories/verify.rs
+++ b/crates/liboxen/src/repositories/verify.rs
@@ -544,6 +544,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_a_missing_nested_directory_node_is_reported_not_raised() -> Result<(), OxenError>
+    {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let nested = repo.path.join("nested");
+            util::fs::create_dir_all(&nested)?;
+            util::fs::write_to_path(nested.join("a.txt"), "alpha")?;
+            repositories::add(&repo, &nested).await?;
+            let commit = repositories::commit(&repo, "Add nested")?;
+
+            let dir = repositories::tree::get_dir_with_children(&repo, &commit, "nested", None)?
+                .expect("the nested directory has a node");
+            repo.merkle_node_store().delete(&dir.hash)?;
+
+            let report = verify_repo(&repo).await?;
+
+            assert_eq!(
+                report.missing_nodes.count, 1,
+                "the absent directory node is a finding: {report:?}"
+            );
+            assert_eq!(report.missing_nodes.sample, vec![dir.hash.to_string()]);
+            assert!(!report.is_healthy());
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
     async fn test_an_absent_version_blob_is_reported_missing() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async move {
             let path = repo.path.join("a.txt");

--- a/crates/liboxen/src/repositories/verify.rs
+++ b/crates/liboxen/src/repositories/verify.rs
@@ -569,6 +569,9 @@ mod tests {
         .await
     }
 
+    /// Unix only: the induced failure is a non-directory path component, which Windows reports as
+    /// not-found and so classifies as an absent blob rather than an unreadable one.
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_a_blob_whose_size_cannot_be_read_is_not_called_healthy() -> Result<(), OxenError>
     {

--- a/crates/liboxen/src/repositories/verify.rs
+++ b/crates/liboxen/src/repositories/verify.rs
@@ -144,13 +144,13 @@ async fn resolve_branch_heads(
 
     let walk_repo = repo.clone();
     let (heads, dangling) = tokio::task::spawn_blocking(
-        move || -> Result<(Vec<Commit>, Vec<DanglingBranch>), OxenError> {
+        move || -> Result<(Vec<Commit>, Findings<DanglingBranch>), OxenError> {
             let mut heads = Vec::new();
-            let mut dangling = Vec::new();
+            let mut dangling = Findings::default();
             for branch in branches {
                 match repositories::commits::get_by_id(&walk_repo, &branch.commit_id)? {
                     Some(commit) => heads.push(commit),
-                    None => dangling.push(DanglingBranch {
+                    None => dangling.record(DanglingBranch {
                         branch: branch.name,
                         commit_id: branch.commit_id,
                     }),
@@ -161,26 +161,28 @@ async fn resolve_branch_heads(
     )
     .await??;
 
-    for branch in dangling {
-        report.dangling_branches.record(branch);
-    }
+    report.dangling_branches = dangling;
     Ok(heads)
 }
 
 /// Every reachable commit hashes to the id it is filed under, and every parent it names resolves.
 async fn check_commits(repo: &LocalRepository, report: &mut VerifyReport) -> Result<(), OxenError> {
-    type CommitFindings = (usize, Vec<DanglingParent>, Vec<MisaddressedCommit>);
+    type CommitFindings = (
+        usize,
+        Findings<DanglingParent>,
+        Findings<MisaddressedCommit>,
+    );
 
     let walk_repo = repo.clone();
     let (commits_checked, dangling, misaddressed) =
         tokio::task::spawn_blocking(move || -> Result<CommitFindings, OxenError> {
             let commits = repositories::commits::list_all(&walk_repo)?;
-            let mut dangling = Vec::new();
-            let mut misaddressed = Vec::new();
+            let mut dangling = Findings::default();
+            let mut misaddressed = Findings::default();
 
             for commit in &commits {
                 if let Some(finding) = misaddressed_commit(commit)? {
-                    misaddressed.push(finding);
+                    misaddressed.record(finding);
                 }
                 for parent_id in &commit.parent_ids {
                     let resolves = match parent_id.parse::<MerkleHash>() {
@@ -190,7 +192,7 @@ async fn check_commits(repo: &LocalRepository, report: &mut VerifyReport) -> Res
                         Err(_) => false,
                     };
                     if !resolves {
-                        dangling.push(DanglingParent {
+                        dangling.record(DanglingParent {
                             commit_id: commit.id.clone(),
                             parent_id: parent_id.clone(),
                         });
@@ -202,12 +204,8 @@ async fn check_commits(repo: &LocalRepository, report: &mut VerifyReport) -> Res
         .await??;
 
     report.commits_checked = commits_checked;
-    for parent in dangling {
-        report.dangling_parents.record(parent);
-    }
-    for commit in misaddressed {
-        report.misaddressed_commits.record(commit);
-    }
+    report.dangling_parents = dangling;
+    report.misaddressed_commits = misaddressed;
     Ok(())
 }
 
@@ -345,6 +343,26 @@ mod tests {
                 "expected exactly one version blob, found {n}"
             ))),
         }
+    }
+
+    #[test]
+    fn test_findings_count_everything_but_keep_a_bounded_sample() {
+        let mut findings = Findings::default();
+        for i in 0..(SAMPLE_LIMIT * 3) {
+            findings.record(i);
+        }
+
+        assert_eq!(findings.count, SAMPLE_LIMIT * 3, "every finding is counted");
+        assert_eq!(
+            findings.sample.len(),
+            SAMPLE_LIMIT,
+            "a badly damaged repository does not grow the report"
+        );
+        assert_eq!(
+            findings.sample,
+            (0..SAMPLE_LIMIT).collect::<Vec<_>>(),
+            "the sample is the first findings seen"
+        );
     }
 
     #[tokio::test]

--- a/crates/oxen-cli/src/cmd.rs
+++ b/crates/oxen-cli/src/cmd.rs
@@ -119,6 +119,9 @@ pub use prune::PruneCmd;
 pub mod fsck;
 pub use fsck::FsckCmd;
 
+pub mod verify;
+pub use verify::VerifyCmd;
+
 /// Maps the name of a [`RunCmd`] to its implementation.
 pub type Runners = HashMap<String, Box<dyn RunCmd>>;
 

--- a/crates/oxen-cli/src/cmd/verify.rs
+++ b/crates/oxen-cli/src/cmd/verify.rs
@@ -1,0 +1,111 @@
+use async_trait::async_trait;
+use clap::{Arg, ArgMatches, Command};
+
+use crate::helpers::check_repo_migration_needed;
+use liboxen::model::LocalRepository;
+use liboxen::repositories;
+use liboxen::repositories::verify::{Findings, VerifyReport};
+
+use crate::cmd::RunCmd;
+
+pub const NAME: &str = "verify";
+pub struct VerifyCmd;
+
+pub fn verify_args() -> Command {
+    Command::new(NAME)
+        .about("Report commit, merkle tree, and version file corruption. Never modifies the repository")
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Print the report as JSON")
+                .action(clap::ArgAction::SetTrue),
+        )
+}
+
+#[async_trait]
+impl RunCmd for VerifyCmd {
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn args(&self) -> Command {
+        verify_args()
+    }
+
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
+        let repository = LocalRepository::from_current_dir()?;
+        check_repo_migration_needed(&repository)?;
+
+        let report = repositories::verify::verify_repo(&repository).await?;
+
+        if args.get_flag("json") {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        } else {
+            print_report(&report);
+        }
+
+        // A corrupt repository is a finding, not a failure to run, so the exit code stays 0 and
+        // callers branch on the report.
+        Ok(())
+    }
+}
+
+fn print_report(report: &VerifyReport) {
+    println!(
+        "Checked {} branches, {} commits, {} entries",
+        report.branches_checked, report.commits_checked, report.entries_checked
+    );
+
+    if report.is_healthy() {
+        println!("\nNo problems found.");
+        return;
+    }
+
+    println!("\nFound {} problem(s):", report.total_findings());
+    print_findings(
+        "Branches whose head commit is missing",
+        &report.dangling_branches,
+        |d| format!("{} -> {}", d.branch, d.commit_id),
+    );
+    print_findings(
+        "Commits naming a missing parent",
+        &report.dangling_parents,
+        |d| format!("{} -> {}", d.commit_id, d.parent_id),
+    );
+    print_findings(
+        "Commits that do not hash to their own id",
+        &report.misaddressed_commits,
+        |c| format!("{} hashes to {}", c.recorded_id, c.computed_id),
+    );
+    print_findings("Merkle nodes missing", &report.missing_nodes, |h| h.clone());
+    print_findings("Version files missing", &report.missing_versions, |h| {
+        h.clone()
+    });
+    print_findings(
+        "Version files of the wrong size",
+        &report.size_mismatches,
+        |m| {
+            format!(
+                "{} declared {} bytes, stored {} ({})",
+                m.path.display(),
+                m.declared_bytes,
+                m.stored_bytes,
+                m.hash
+            )
+        },
+    );
+}
+
+fn print_findings<T>(label: &str, findings: &Findings<T>, show: impl Fn(&T) -> String) {
+    if findings.is_empty() {
+        return;
+    }
+    println!("\n  {label}: {}", findings.count);
+    for item in &findings.sample {
+        println!("    {}", show(item));
+    }
+    let hidden = findings.count - findings.sample.len();
+    if hidden > 0 {
+        println!("    ... and {hidden} more");
+    }
+}

--- a/crates/oxen-cli/src/cmd/verify.rs
+++ b/crates/oxen-cli/src/cmd/verify.rs
@@ -78,6 +78,11 @@ fn print_report(report: &VerifyReport) {
         |c| format!("{} hashes to {}", c.recorded_id, c.computed_id),
     );
     print_findings("Merkle nodes missing", &report.missing_nodes, |h| h.clone());
+    print_findings(
+        "Merkle nodes that could not be read",
+        &report.unreadable_nodes,
+        |u| format!("{}: {}", u.hash, u.error),
+    );
     print_findings("Version files missing", &report.missing_versions, |h| {
         h.clone()
     });

--- a/crates/oxen-cli/src/cmd/verify.rs
+++ b/crates/oxen-cli/src/cmd/verify.rs
@@ -82,6 +82,11 @@ fn print_report(report: &VerifyReport) {
         h.clone()
     });
     print_findings(
+        "Version files that could not be checked",
+        &report.unchecked_versions,
+        |u| format!("{}: {}", u.hash, u.error),
+    );
+    print_findings(
         "Version files of the wrong size",
         &report.size_mismatches,
         |m| {

--- a/crates/oxen-cli/src/cmd/verify.rs
+++ b/crates/oxen-cli/src/cmd/verify.rs
@@ -52,8 +52,11 @@ impl RunCmd for VerifyCmd {
 
 fn print_report(report: &VerifyReport) {
     println!(
-        "Checked {} branches, {} commits, {} version files",
-        report.branches_checked, report.commits_checked, report.versions_checked
+        "Checked {} branches, {} workspaces, {} commits, {} version files",
+        report.branches_checked,
+        report.workspaces_checked,
+        report.commits_checked,
+        report.versions_checked
     );
 
     if report.is_healthy() {
@@ -66,6 +69,14 @@ fn print_report(report: &VerifyReport) {
         "Branches whose head commit is missing",
         &report.dangling_branches,
         |d| format!("{} -> {}", d.branch, d.commit_id),
+    );
+    print_findings(
+        "Workspaces pinned to a missing commit",
+        &report.dangling_workspaces,
+        |w| match &w.name {
+            Some(name) => format!("{} ({name}) -> {}", w.workspace, w.commit_id),
+            None => format!("{} -> {}", w.workspace, w.commit_id),
+        },
     );
     print_findings(
         "Commits naming a missing parent",

--- a/crates/oxen-cli/src/cmd/verify.rs
+++ b/crates/oxen-cli/src/cmd/verify.rs
@@ -52,8 +52,8 @@ impl RunCmd for VerifyCmd {
 
 fn print_report(report: &VerifyReport) {
     println!(
-        "Checked {} branches, {} commits, {} entries",
-        report.branches_checked, report.commits_checked, report.entries_checked
+        "Checked {} branches, {} commits, {} version files",
+        report.branches_checked, report.commits_checked, report.versions_checked
     );
 
     if report.is_healthy() {

--- a/crates/oxen-cli/src/main.rs
+++ b/crates/oxen-cli/src/main.rs
@@ -164,7 +164,7 @@ fn main_oxen_command() -> (Command, Runners) {
 }
 
 /// Every command that is used by the `oxen` CLI **MUST** be listed here!
-fn all_commands() -> [Box<dyn cmd::RunCmd>; 38] {
+fn all_commands() -> [Box<dyn cmd::RunCmd>; 39] {
     [
         Box::new(cmd::AddCmd),
         Box::new(cmd::BranchCmd),
@@ -193,6 +193,7 @@ fn all_commands() -> [Box<dyn cmd::RunCmd>; 38] {
         Box::new(cmd::NodeCmd),
         Box::new(cmd::PruneCmd),
         Box::new(cmd::FsckCmd),
+        Box::new(cmd::VerifyCmd),
         Box::new(cmd::PullCmd),
         Box::new(cmd::PushCmd),
         Box::new(cmd::RestoreCmd),

--- a/crates/oxen-server/src/controllers.rs
+++ b/crates/oxen-server/src/controllers.rs
@@ -21,5 +21,6 @@ pub mod repositories;
 pub mod revisions;
 pub mod schemas;
 pub mod tree;
+pub mod verify;
 pub mod versions;
 pub mod workspaces;

--- a/crates/oxen-server/src/controllers/verify.rs
+++ b/crates/oxen-server/src/controllers/verify.rs
@@ -101,7 +101,7 @@ mod tests {
         let response = call_verify(&sync_dir, namespace, name).await?;
 
         assert!(response.report.is_healthy());
-        assert_eq!(response.report.entries_checked, 1);
+        assert_eq!(response.report.versions_checked, 1);
 
         test::cleanup_repo_and_sync_dir(repo, &sync_dir)?;
         Ok(())

--- a/crates/oxen-server/src/controllers/verify.rs
+++ b/crates/oxen-server/src/controllers/verify.rs
@@ -1,0 +1,136 @@
+use crate::errors::OxenHttpError;
+use crate::helpers::get_repo;
+use crate::params::{app_data, path_param};
+
+use actix_web::{HttpRequest, HttpResponse};
+use liboxen::repositories;
+use liboxen::repositories::verify::VerifyReport;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct VerifyResponse {
+    pub status_message: String,
+    pub report: VerifyReport,
+}
+
+/// POST /verify
+///
+/// Report the repository's commit, merkle tree, and version file corruption. Reads only, so it is
+/// safe to run against a live repository and safe to run in a loop across many of them.
+pub async fn verify(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?.to_string();
+    let repo_name = path_param(&req, "repo_name")?.to_string();
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
+
+    let report = repositories::verify::verify_repo(&repo).await?;
+
+    let status_message = if report.is_healthy() {
+        format!("Verified {namespace}/{repo_name}; no problems found")
+    } else {
+        format!(
+            "Verified {namespace}/{repo_name}; {} problem(s) found",
+            report.total_findings()
+        )
+    };
+    if !report.is_healthy() {
+        log::warn!(
+            "verify: {namespace}/{repo_name} found {} problem(s)",
+            report.total_findings()
+        );
+    }
+
+    Ok(HttpResponse::Ok().json(VerifyResponse {
+        status_message,
+        report,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::app_data::OxenAppData;
+    use crate::controllers;
+    use crate::test;
+    use actix_web::{App, web};
+
+    use liboxen::error::OxenError;
+    use liboxen::repositories;
+    use liboxen::util;
+
+    use super::VerifyResponse;
+
+    /// Run the endpoint against `repo` and hand back the deserialized response.
+    async fn call_verify(
+        sync_dir: &std::path::Path,
+        namespace: &str,
+        name: &str,
+    ) -> Result<VerifyResponse, OxenError> {
+        let app = actix_web::test::init_service(
+            App::new()
+                .app_data(OxenAppData::new(sync_dir.to_path_buf()))
+                .route(
+                    "/oxen/{namespace}/{repo_name}/verify",
+                    web::post().to(controllers::verify::verify),
+                ),
+        )
+        .await;
+
+        let uri = format!("/oxen/{namespace}/{name}/verify");
+        let req = actix_web::test::TestRequest::post().uri(&uri).to_request();
+        let resp = actix_web::test::call_service(&app, req).await;
+        let bytes = actix_http::body::to_bytes(resp.into_body())
+            .await
+            .map_err(|e| OxenError::basic_str(format!("could not read body: {e}")))?;
+        let body = std::str::from_utf8(&bytes)?;
+        Ok(serde_json::from_str(body)?)
+    }
+
+    #[actix_web::test]
+    async fn test_controllers_verify_reports_a_sound_repository() -> Result<(), OxenError> {
+        liboxen::test::init_test_env();
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let name = "Testing-Name";
+        let repo = test::create_local_repo(&sync_dir, namespace, name)?;
+
+        let path = repo.path.join("a.txt");
+        util::fs::write_to_path(&path, "alpha")?;
+        repositories::add(&repo, &path).await?;
+        repositories::commit(&repo, "Add a")?;
+
+        let response = call_verify(&sync_dir, namespace, name).await?;
+
+        assert!(response.report.is_healthy());
+        assert_eq!(response.report.entries_checked, 1);
+
+        test::cleanup_repo_and_sync_dir(repo, &sync_dir)?;
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_controllers_verify_reports_a_missing_version_file() -> Result<(), OxenError> {
+        liboxen::test::init_test_env();
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let name = "Testing-Name";
+        let repo = test::create_local_repo(&sync_dir, namespace, name)?;
+
+        let path = repo.path.join("a.txt");
+        util::fs::write_to_path(&path, "alpha")?;
+        repositories::add(&repo, &path).await?;
+        let commit = repositories::commit(&repo, "Add a")?;
+
+        let entries = repositories::entries::list_for_commit(&repo, &commit)?;
+        let hash = entries.first().expect("one entry").hash.clone();
+        repo.version_store().delete_version(&hash).await?;
+
+        let response = call_verify(&sync_dir, namespace, name).await?;
+
+        assert!(!response.report.is_healthy());
+        assert_eq!(response.report.missing_versions.count, 1);
+        assert_eq!(response.report.missing_versions.sample, vec![hash]);
+
+        test::cleanup_repo_and_sync_dir(repo, &sync_dir)?;
+        Ok(())
+    }
+}

--- a/crates/oxen-server/src/routes.rs
+++ b/crates/oxen-server/src/routes.rs
@@ -38,6 +38,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
                 .service(services::migrations())
                 .service(services::prune())
                 .service(services::revisions())
+                .service(services::verify())
                 .service(services::size())
                 .service(services::schemas())
                 .service(services::stats())

--- a/crates/oxen-server/src/services.rs
+++ b/crates/oxen-server/src/services.rs
@@ -21,6 +21,7 @@ pub mod stats;
 pub mod tabular;
 pub mod transfer;
 pub mod tree;
+pub mod verify;
 pub mod versions;
 pub mod workspaces;
 
@@ -47,5 +48,6 @@ pub use stats::stats;
 pub use tabular::tabular;
 pub use transfer::transfer;
 pub use tree::tree;
+pub use verify::verify;
 pub use versions::versions;
 pub use workspaces::workspace;

--- a/crates/oxen-server/src/services/verify.rs
+++ b/crates/oxen-server/src/services/verify.rs
@@ -1,0 +1,8 @@
+use actix_web::Scope;
+use actix_web::web;
+
+use crate::controllers;
+
+pub fn verify() -> Scope {
+    web::scope("/verify").route("", web::post().to(controllers::verify::verify))
+}


### PR DESCRIPTION
Nothing could fully answer whether a repository's branches actually reference objects that exist, so a broken repository stayed invisible until someone tried to read it and got a 500. We had some endpoints that would look at part of the picture, but nothing comprehensive.

Add `oxen verify` and a matching oxen-server endpoint to report the whole picture for one repository: branch heads and commit parents that name missing commits, commits that do not hash to their own id, merkle nodes and version files a tree references but the repository lacks, and version files whose stored size disagrees with the tree.

Findings come back as counts with a bounded sample, and as JSON.

Note that we don't do any verification of vnodes, because they mix a random salt into their hash every time they are modified after initial creation (which will be fixed it a future merkle tree redesign).

ENG-1655
Sentry: OXEN-SERVER-23, OXEN-SERVER-25