### PR TITLE
Dedup (1.1): Freeze FastCDC chunk boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,9 +3168,9 @@ checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastcdc"
-version = "3.2.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf51ceb43e96afbfe4dd5c6f6082af5dfd60e220820b8123792d61963f2ce6bc"
+checksum = "77af40d8a8dadb92dc178569a5f5edb5f3056e98255c2de48ab5d59a52892e0c"
 
 [[package]]
 name = "fastrand"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,6 +3167,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
+name = "fastcdc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf51ceb43e96afbfe4dd5c6f6082af5dfd60e220820b8123792d61963f2ce6bc"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3971,7 +3977,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4572,6 +4578,7 @@ dependencies = [
  "dirs",
  "duckdb",
  "dunce",
+ "fastcdc",
  "filetime",
  "flate2",
  "fs_extra",
@@ -6937,7 +6944,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6975,7 +6982,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ dotenvy = "0.15.7"
 duckdb = { package = "duckdb", version = "=1.10504.0", default-features = false, features = ["serde_json"] }
 dunce = "1.0.4"
 env_logger = "0.11.3"
+fastcdc = "3.2.1"
 filetime = "0.2.22"
 flate2 = { version = "1.1.0", default-features = false, features = ["zlib-ng"] }
 fs_extra = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ dotenvy = "0.15.7"
 duckdb = { package = "duckdb", version = "=1.10504.0", default-features = false, features = ["serde_json"] }
 dunce = "1.0.4"
 env_logger = "0.11.3"
-fastcdc = "3.2.1"
+fastcdc = "=4.0.1"
 filetime = "0.2.22"
 flate2 = { version = "1.1.0", default-features = false, features = ["zlib-ng"] }
 fs_extra = "1.3.0"

--- a/crates/liboxen/Cargo.toml
+++ b/crates/liboxen/Cargo.toml
@@ -73,6 +73,7 @@ difference = { workspace = true }
 dirs = { workspace = true }
 duckdb = { workspace = true, optional = true }
 dunce = { workspace = true }
+fastcdc = { workspace = true }
 filetime = { workspace = true }
 flate2 = { workspace = true }
 fs_extra = { workspace = true }

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -988,6 +988,11 @@ impl OxenError {
             OxenError::TabularFileMissingMetadata(_) => true,
             OxenError::InvalidDataFrameParam { .. } => true,
             OxenError::InvalidFileType(_) => true,
+            // An unknown ID stays unknown however many times it is asked.
+            // ChunkRead stays retryable, since a failed read can succeed later.
+            OxenError::ChunkedError(crate::storage::chunked::ChunkedError::UnknownChunkerId(_)) => {
+                true
+            }
             // A malformed file or an unsatisfiable query reads the same way every time. Only the
             // IO case can resolve on its own.
             OxenError::PolarsError(_) | OxenError::DataFrameError(DataFrameError::Polars(_)) => {

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -28,6 +28,7 @@ use crate::model::Schema;
 use crate::model::Workspace;
 use crate::model::merkle_tree::merkle_hash::HexHash;
 use crate::model::merkle_tree::node_type::InvalidMerkleTreeNodeType;
+use crate::storage::chunked::ChunkedError;
 
 pub mod path_buf_error;
 pub mod string_error;
@@ -299,6 +300,10 @@ pub enum OxenError {
     /// The repository was created by an Oxen version this CLI no longer supports.
     #[error("This repository was created by Oxen v{0}, which is no longer supported by this CLI.")]
     UnsupportedRepoVersion(StringError),
+
+    /// An error from the block-level dedup storage layer (`storage::chunked`).
+    #[error("{0}")]
+    ChunkedError(#[from] ChunkedError),
 
     #[error("Unknown migration: {0}")]
     UnknownMigration(String),
@@ -872,6 +877,9 @@ impl OxenError {
             }
             DirHashIndexMissing { .. } => {
                 "Re-push the commit from a clone with the full local history to repopulate the server's directory index."
+            }
+            ChunkedError(crate::storage::chunked::ChunkedError::UnknownChunkerId(_)) => {
+                "Upgrade oxen to a version that supports this repository's storage format. If this is already the latest version, the repository metadata may be corrupt."
             }
             UnsupportedRepoVersion(_) => {
                 "Use an older Oxen release to migrate this repository up to the current format, then retry with this CLI."

--- a/crates/liboxen/src/storage.rs
+++ b/crates/liboxen/src/storage.rs
@@ -1,3 +1,4 @@
+pub mod chunked;
 pub mod local;
 pub mod s3;
 pub mod version_store;

--- a/crates/liboxen/src/storage/chunked.rs
+++ b/crates/liboxen/src/storage/chunked.rs
@@ -16,6 +16,6 @@ pub use registry::{ChunkerId, chunker};
 // FastCDC's min_size, avg_size, and max_size.
 // These read like tuning knobs, but ChunkerId::GENERIC_FASTCDC_V1 names this triple,
 // and changing any of them belongs under a new ID.
-pub const MIN_CHUNK_SIZE: u32 = 8 * 1024;
-pub const AVG_CHUNK_SIZE: u32 = 64 * 1024;
-pub const MAX_CHUNK_SIZE: u32 = 128 * 1024;
+pub const MIN_CHUNK_SIZE: usize = 8 * 1024;
+pub const AVG_CHUNK_SIZE: usize = 64 * 1024;
+pub const MAX_CHUNK_SIZE: usize = 128 * 1024;

--- a/crates/liboxen/src/storage/chunked.rs
+++ b/crates/liboxen/src/storage/chunked.rs
@@ -1,0 +1,21 @@
+//! Block-level deduplication.
+//! Files are split into chunks of around 64 KiB, and identical chunks are stored once.
+//!
+//! Where a chunk ends is decided by the bytes themselves, never by a fixed offset.
+//! With fixed offsets, one inserted byte moves every boundary after it,
+//! and the edited file shares no chunk with the version before it.
+
+pub mod chunker;
+pub mod error;
+pub mod registry;
+
+pub use chunker::{Chunker, RawChunk};
+pub use error::ChunkedError;
+pub use registry::{ChunkerId, chunker};
+
+// FastCDC's min_size, avg_size, and max_size.
+// These read like tuning knobs, but ChunkerId::GENERIC_FASTCDC_V1 names this triple,
+// and changing any of them belongs under a new ID.
+pub const MIN_CHUNK_SIZE: u32 = 8 * 1024;
+pub const AVG_CHUNK_SIZE: u32 = 64 * 1024;
+pub const MAX_CHUNK_SIZE: u32 = 128 * 1024;

--- a/crates/liboxen/src/storage/chunked/chunker.rs
+++ b/crates/liboxen/src/storage/chunked/chunker.rs
@@ -103,12 +103,12 @@ mod tests {
             assert_eq!(chunk.offset, expected_offset, "chunk {i} offset");
             assert!(!chunk.data.is_empty(), "chunk {i} empty");
             assert!(
-                chunk.data.len() <= MAX_CHUNK_SIZE as usize,
+                chunk.data.len() <= MAX_CHUNK_SIZE,
                 "chunk {i} exceeds max size"
             );
             if i + 1 < chunks.len() {
                 assert!(
-                    chunk.data.len() >= MIN_CHUNK_SIZE as usize,
+                    chunk.data.len() >= MIN_CHUNK_SIZE,
                     "non-final chunk {i} under min size"
                 );
             }
@@ -165,19 +165,14 @@ mod tests {
     /// The maximum size is then the only thing that can end a chunk.
     #[test]
     fn zeros_chunk_at_max_size() {
-        let len = 3 * MAX_CHUNK_SIZE as usize + 1000;
+        let len = 3 * MAX_CHUNK_SIZE + 1000;
         let data = vec![0u8; len];
         let chunks = chunk_all(&data);
         assert_tiles_input(&chunks, &data);
         let lens: Vec<usize> = chunks.iter().map(|c| c.data.len()).collect();
         assert_eq!(
             lens,
-            vec![
-                MAX_CHUNK_SIZE as usize,
-                MAX_CHUNK_SIZE as usize,
-                MAX_CHUNK_SIZE as usize,
-                1000
-            ]
+            vec![MAX_CHUNK_SIZE, MAX_CHUNK_SIZE, MAX_CHUNK_SIZE, 1000]
         );
     }
 

--- a/crates/liboxen/src/storage/chunked/chunker.rs
+++ b/crates/liboxen/src/storage/chunked/chunker.rs
@@ -1,0 +1,242 @@
+//! Chunking is synchronous and streams.
+//! Memory stays bounded at one maximum-size chunk plus a hash window,
+//! whatever the file size.
+//!
+//! Callers cross into async at the operation boundary with spawn_blocking,
+//! per docs/async_policy.md.
+
+use std::io::Read;
+
+use fastcdc::v2020::StreamCDC;
+
+use super::error::ChunkedError;
+use super::registry::ChunkerId;
+use super::{AVG_CHUNK_SIZE, MAX_CHUNK_SIZE, MIN_CHUNK_SIZE};
+
+/// One content-defined slice of a file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawChunk {
+    /// Byte offset of this chunk in the original file.
+    pub offset: u64,
+    pub data: Vec<u8>,
+}
+
+/// Splits a stream into content-defined chunks.
+///
+/// The boundaries an implementation produces are part of the on-disk format.
+/// Identical bytes under the same chunker ID must yield identical offsets and lengths,
+/// on every machine, forever.
+/// An implementation streams with bounded memory,
+/// and decides boundaries from the content alone.
+pub trait Chunker: Send + Sync {
+    /// The registered ID recorded in manifests produced with this chunker.
+    fn id(&self) -> ChunkerId;
+
+    /// Yield the chunks in file order.
+    /// Concatenating the yielded bytes reconstructs the input exactly.
+    fn chunk<'r>(
+        &self,
+        reader: Box<dyn Read + Send + 'r>,
+    ) -> Box<dyn Iterator<Item = Result<RawChunk, ChunkedError>> + Send + 'r>;
+}
+
+/// FastCDC v2020 with normalized chunking, at the sizes this module declares.
+/// This is the boundary function frozen as ChunkerId::GENERIC_FASTCDC_V1.
+pub struct FastCdc2020Chunker;
+
+impl Chunker for FastCdc2020Chunker {
+    fn id(&self) -> ChunkerId {
+        ChunkerId::GENERIC_FASTCDC_V1
+    }
+
+    fn chunk<'r>(
+        &self,
+        reader: Box<dyn Read + Send + 'r>,
+    ) -> Box<dyn Iterator<Item = Result<RawChunk, ChunkedError>> + Send + 'r> {
+        let cdc = StreamCDC::new(reader, MIN_CHUNK_SIZE, AVG_CHUNK_SIZE, MAX_CHUNK_SIZE);
+        Box::new(cdc.map(|result| match result {
+            Ok(chunk) => Ok(RawChunk {
+                offset: chunk.offset,
+                data: chunk.data,
+            }),
+            Err(fastcdc::v2020::Error::IoError(err)) => Err(ChunkedError::ChunkRead(err)),
+            Err(other) => Err(ChunkedError::ChunkRead(std::io::Error::other(other))),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::hasher::hash_buffer_128bit;
+
+    /// Pseudo-random bytes from xorshift64*, identical on every run and platform.
+    /// Generating the golden input here keeps a binary file out of the repo.
+    fn deterministic_bytes(seed: u64, len: usize) -> Vec<u8> {
+        let mut state = seed;
+        let mut out = Vec::with_capacity(len);
+        while out.len() < len {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            let word = state.wrapping_mul(0x2545F4914F6CDD1D);
+            out.extend_from_slice(&word.to_le_bytes());
+        }
+        out.truncate(len);
+        out
+    }
+
+    fn chunk_all(data: &[u8]) -> Vec<RawChunk> {
+        FastCdc2020Chunker
+            .chunk(Box::new(data))
+            .collect::<Result<Vec<_>, _>>()
+            .expect("chunking in-memory data cannot fail")
+    }
+
+    /// Checks that the chunks tile the input exactly:
+    /// contiguous offsets from zero, sizes inside the bounds except for the last chunk,
+    /// and bytes matching the input.
+    /// Every test here runs this.
+    fn assert_tiles_input(chunks: &[RawChunk], data: &[u8]) {
+        let mut expected_offset = 0u64;
+        for (i, chunk) in chunks.iter().enumerate() {
+            assert_eq!(chunk.offset, expected_offset, "chunk {i} offset");
+            assert!(!chunk.data.is_empty(), "chunk {i} empty");
+            assert!(
+                chunk.data.len() <= MAX_CHUNK_SIZE as usize,
+                "chunk {i} exceeds max size"
+            );
+            if i + 1 < chunks.len() {
+                assert!(
+                    chunk.data.len() >= MIN_CHUNK_SIZE as usize,
+                    "non-final chunk {i} under min size"
+                );
+            }
+            let start = chunk.offset as usize;
+            assert_eq!(
+                &data[start..start + chunk.data.len()],
+                &chunk.data[..],
+                "chunk {i} bytes"
+            );
+            expected_offset += chunk.data.len() as u64;
+        }
+        assert_eq!(
+            expected_offset,
+            data.len() as u64,
+            "chunks must cover input"
+        );
+    }
+
+    /// Pins the exact boundary function behind ChunkerId::GENERIC_FASTCDC_V1.
+    /// A failure after a fastcdc upgrade means the boundaries moved,
+    /// and that change belongs under a new ID.
+    /// Editing this list to match new output makes every stored chunk unmatchable,
+    /// and nothing reports it.
+    #[test]
+    fn golden_fastcdc_boundaries() {
+        let data = deterministic_bytes(0x0DEDA7A5EED, 1024 * 1024);
+        let chunks = chunk_all(&data);
+        assert_tiles_input(&chunks, &data);
+
+        let boundaries: Vec<(u64, usize)> =
+            chunks.iter().map(|c| (c.offset, c.data.len())).collect();
+        let expected: Vec<(u64, usize)> = vec![
+            // Recorded offset and length pairs for seed 0x0DEDA7A5EED over 1 MiB.
+            (0, 75164),
+            (75164, 22447),
+            (97611, 74856),
+            (172467, 59977),
+            (232444, 131072),
+            (363516, 47514),
+            (411030, 26207),
+            (437237, 74500),
+            (511737, 71410),
+            (583147, 76703),
+            (659850, 45931),
+            (705781, 131072),
+            (836853, 74147),
+            (911000, 83126),
+            (994126, 54450),
+        ];
+        assert_eq!(boundaries, expected);
+    }
+
+    /// All-zero input never matches either mask.
+    /// The maximum size is then the only thing that can end a chunk.
+    #[test]
+    fn zeros_chunk_at_max_size() {
+        let len = 3 * MAX_CHUNK_SIZE as usize + 1000;
+        let data = vec![0u8; len];
+        let chunks = chunk_all(&data);
+        assert_tiles_input(&chunks, &data);
+        let lens: Vec<usize> = chunks.iter().map(|c| c.data.len()).collect();
+        assert_eq!(
+            lens,
+            vec![
+                MAX_CHUNK_SIZE as usize,
+                MAX_CHUNK_SIZE as usize,
+                MAX_CHUNK_SIZE as usize,
+                1000
+            ]
+        );
+    }
+
+    /// A file under the minimum size is one chunk, and an empty file is none.
+    /// The same path produces the short final chunk at the end of every file.
+    #[test]
+    fn small_inputs() {
+        assert!(chunk_all(&[]).is_empty());
+
+        let tiny = deterministic_bytes(7, 100);
+        let chunks = chunk_all(&tiny);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].offset, 0);
+        assert_eq!(chunks[0].data, tiny);
+    }
+
+    /// The property the feature rests on.
+    /// An insertion changes the chunks around it,
+    /// while everything before and far enough after keeps the same hashes.
+    #[test]
+    fn middle_insertion_preserves_most_chunks() {
+        let original = deterministic_bytes(42, 2 * 1024 * 1024);
+        let mut edited = original.clone();
+        let insert_at = original.len() / 2;
+        edited.splice(
+            insert_at..insert_at,
+            b"inserted row,1,2,3\n".iter().copied(),
+        );
+
+        let original_hashes: std::collections::HashSet<u128> = chunk_all(&original)
+            .iter()
+            .map(|c| hash_buffer_128bit(&c.data))
+            .collect();
+        let edited_chunks = chunk_all(&edited);
+        assert_tiles_input(&edited_chunks, &edited);
+
+        let shared = edited_chunks
+            .iter()
+            .filter(|c| original_hashes.contains(&hash_buffer_128bit(&c.data)))
+            .count();
+        let total = edited_chunks.len();
+        assert!(
+            shared * 10 >= total * 8,
+            "expected at least 80% of chunks shared after a middle insertion, got {shared}/{total}"
+        );
+    }
+
+    /// A failing reader yields an error from the iterator.
+    /// Swallowing it would end iteration early,
+    /// and the chunk list would look like a complete short file.
+    #[test]
+    fn read_errors_surface() {
+        struct FailingReader;
+        impl Read for FailingReader {
+            fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("boom"))
+            }
+        }
+        let mut iter = FastCdc2020Chunker.chunk(Box::new(FailingReader));
+        assert!(matches!(iter.next(), Some(Err(ChunkedError::ChunkRead(_)))));
+    }
+}

--- a/crates/liboxen/src/storage/chunked/error.rs
+++ b/crates/liboxen/src/storage/chunked/error.rs
@@ -1,0 +1,16 @@
+//! Errors from the dedup layer.
+//! crate::error absorbs these into OxenError through a #[from] declared there.
+
+use thiserror::Error;
+
+/// Failures from chunking.
+#[derive(Debug, Error)]
+pub enum ChunkedError {
+    #[error(
+        "Unknown chunker id {0}. This repository was written by a newer version of oxen, or its metadata is corrupt"
+    )]
+    UnknownChunkerId(u8),
+
+    #[error("Failed to read data while chunking: {0}")]
+    ChunkRead(std::io::Error),
+}

--- a/crates/liboxen/src/storage/chunked/registry.rs
+++ b/crates/liboxen/src/storage/chunked/registry.rs
@@ -26,10 +26,12 @@ pub struct ChunkerId(u8);
 impl ChunkerId {
     /// FastCDC v2020, normalized, min 8 KiB, target 64 KiB, max 128 KiB.
     ///
-    /// A crate release that moved a cut by one byte would keep the same API,
+    /// The fastcdc crate is pinned to an exact version.
+    /// A release that moved a cut by one byte would keep the same API,
     /// and it would break the format.
-    /// The golden boundary test is what catches that,
-    /// along with a change to the sizes above or to the chunking code.
+    /// Consumers of liboxen resolve their own dependencies, where no test of ours runs.
+    /// The golden boundary test covers the rest:
+    /// a change to the sizes above, to the chunking code, or to the pin.
     pub const GENERIC_FASTCDC_V1: ChunkerId = ChunkerId(1);
 
     // 0 stays permanently unassigned.

--- a/crates/liboxen/src/storage/chunked/registry.rs
+++ b/crates/liboxen/src/storage/chunked/registry.rs
@@ -1,0 +1,83 @@
+//! Chunker IDs.
+//!
+//! An ID is a u8 naming one exact boundary function, and a number is never reused.
+//! Editing what an ID means would make every chunk already stored unmatchable,
+//! and nothing would report it.
+//! Writes keep succeeding while storage quietly stops improving.
+//! A change to where FastCDC cuts arrives as a new ID and leaves the old one alone.
+//!
+//! An ID is consulted only when something needs to chunk.
+//! Reconstruction walks a manifest's chunk hashes and never re-chunks.
+//! A manifest carrying an unknown ID therefore stays readable,
+//! and manifest validation should not reject one.
+//!
+//! A new chunker needs golden boundary fixtures before it belongs here.
+
+use serde::{Deserialize, Serialize};
+
+use super::chunker::{Chunker, FastCdc2020Chunker};
+use super::error::ChunkedError;
+
+/// Names the exact boundary function that produced a manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ChunkerId(u8);
+
+impl ChunkerId {
+    /// FastCDC v2020, normalized, min 8 KiB, target 64 KiB, max 128 KiB.
+    ///
+    /// A crate release that moved a cut by one byte would keep the same API,
+    /// and it would break the format.
+    /// The golden boundary test is what catches that,
+    /// along with a change to the sizes above or to the chunking code.
+    pub const GENERIC_FASTCDC_V1: ChunkerId = ChunkerId(1);
+
+    // 0 stays permanently unassigned.
+    // Zeroed or corrupt metadata reads as 0, and it has to fail the lookup below.
+
+    pub fn as_u8(&self) -> u8 {
+        self.0
+    }
+}
+
+/// The only place an ID turns into an implementation,
+/// which makes it the only place an unrecognized ID gets caught.
+pub fn chunker(id: ChunkerId) -> Result<&'static dyn Chunker, ChunkedError> {
+    static FASTCDC: FastCdc2020Chunker = FastCdc2020Chunker;
+    match id {
+        ChunkerId::GENERIC_FASTCDC_V1 => Ok(&FASTCDC),
+        ChunkerId(other) => Err(ChunkedError::UnknownChunkerId(other)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unknown IDs are the case worth testing.
+    /// The lookup ends in a catch-all arm,
+    /// and an arm returning a default chunker would pass everything else here.
+    #[test]
+    fn registry_round_trips_ids() -> Result<(), ChunkedError> {
+        assert_eq!(
+            chunker(ChunkerId::GENERIC_FASTCDC_V1)?.id(),
+            ChunkerId::GENERIC_FASTCDC_V1
+        );
+        assert!(matches!(
+            chunker(ChunkerId(0)),
+            Err(ChunkedError::UnknownChunkerId(0))
+        ));
+        assert!(matches!(
+            chunker(ChunkerId(200)),
+            Err(ChunkedError::UnknownChunkerId(200))
+        ));
+        Ok(())
+    }
+
+    /// The number is what a manifest records.
+    /// Renaming the constant is harmless, and renumbering it is destructive.
+    #[test]
+    fn ids_are_stable() {
+        assert_eq!(ChunkerId::GENERIC_FASTCDC_V1.as_u8(), 1);
+    }
+}


### PR DESCRIPTION
First piece of block level dedup.

This does two important things
1. Chunker splits a stream into content-defined chunks using FastCDC 2020 with normalized chunking at min 8 KiB, target 64 KiB, max 128 KiB.
2. Freezes that exact boundary calculation behind an append only ID. The ID of this chunker is 1.

`Chunker::chunk` takes a reader and yields `RawChunk { offset, data }` in file order. Concatenating the chunks reproduces the input exactly. Chunking is sync and streams with bounded memory (at most one maximum chunk plus a window).

Same bytes with the same chunker id must always produce the same boundaries or deduplication would fail without any errors. `golden_fastcdc_boundaries` tests exact offset and length pairs to ensure boundaries never shift unintentionally. If boundaries ever move due to an intentional chunker update or a fastcdc upgrade or any other reason, we must set a new chunker ID. Also, ID 0 is permanently reserved, so that zeroed or corrupt metadata cannot point to an actual chunker.

`chunker()` which maps chunker id to implementation has no callers yet. Added here to ensure that unknown chunkers fail loudly.

Tests ensure (a) exact tiling, where offsets are contiguous, (b) every chunk except the last sits between the min and max size, (c) every chunk's bytes match the input at its offset, for these inputs:
* Input of all zeros, which doesn't match any mask and cuts at exactly the maximum size every time
* Empty and sub minimum input
* A mid file insertion, which must leave at least 80 percent of chunks sharing hashes with the original

This also introduces `ChunkedError` on the theory that dedup will have its own category of errors. If we want to handle errors differenty, I'm open to ideas.

Completes ENG-1693