### PR TITLE
Serialize writes to a workspace data frame's staged table

### DIFF
--- a/crates/liboxen/src/core.rs
+++ b/crates/liboxen/src/core.rs
@@ -1,6 +1,7 @@
 //! Core functionality for Oxen
 //!
 
+pub mod data_frame_locks;
 pub mod db;
 pub mod df;
 pub mod merge;

--- a/crates/liboxen/src/core/data_frame_locks.rs
+++ b/crates/liboxen/src/core/data_frame_locks.rs
@@ -1,20 +1,27 @@
-//! Process-global per-data-frame write lock — serializes the read-modify-write row operations on
-//! a single workspace data frame's staged table.
+//! Process-global per-data-frame write lock: serializes the operations that mutate a single
+//! workspace data frame's staged table.
 //!
 //! # Why it exists
 //!
-//! Appending, updating, or deleting a row reads the staged DuckDB table, derives new contents, and
-//! writes them back. Two of those running at once on the same table produce last-writer-wins: the
-//! loser's rows are discarded while both callers are told they succeeded. The cached DuckDB
-//! connection ([`crate::core::db::data_frames::df_db`]) serializes writes only while both callers
-//! share the cached connection — its cache evicts under LRU pressure, and an eviction between two
-//! in-flight row writes hands each caller its own connection to the same file, at which point
-//! nothing serializes them. This lock keys on the same identity the connection cache does but is
-//! never evicted, so exclusion holds regardless of what the cache is currently holding.
+//! Opening a DuckDB database file that this process already has open yields a second, independent
+//! database rather than joining the first, because DuckDB's single-writer protection is a file lock
+//! that excludes other processes. The two then diverge, and whichever folds its state into the file
+//! last is the version that survives, so the other's rows are gone while both callers were told
+//! they succeeded. That is true of any write, a lone `INSERT` included, so making a write atomic in
+//! SQL would not remove the need for this lock.
+//!
+//! What normally keeps one database per file is the connection cache in
+//! [`crate::core::db::data_frames::df_db`]. A cache entry is a connection behind a mutex, so
+//! writers that find the same entry are serialized by it. That is incidental, and it stops holding
+//! the moment the entry is gone: the cache evicts under LRU pressure, and `rename`, workspace
+//! delete, and repo delete evict by hand. An eviction while one writer is still inside its
+//! operation hands the next writer its own database over the same file. This lock keys on the same
+//! identity the connection cache does but is never evicted, so exclusion holds regardless of what
+//! the cache is currently holding.
 //!
 //! # Scope and ordering
 //!
-//! One lock per data frame, keyed by the path of its staged DuckDB file — the identity of a
+//! One lock per data frame, keyed by the path of its staged DuckDB file, which is the identity of a
 //! (repository, workspace, data frame path) triple. Writes to different data frames, different
 //! workspaces, or different repositories never contend.
 //!
@@ -25,16 +32,17 @@
 //! Two ordering rules keep it deadlock-free, and both are structural rather than conventional:
 //!
 //! - It is always taken *before* the DuckDB connection lock, never the other way around, because
-//!   [`with_data_frame_write`] wraps whole row operations and the connection lock is taken inside
-//!   them.
+//!   [`with_data_frame_write`] wraps whole operations and the connection lock is taken inside them.
 //! - It cannot be held across an `.await`, because [`with_data_frame_write`] takes a synchronous
-//!   closure. Nothing that indexes or rebuilds the table (all of which is async) can be waiting on
-//!   this lock, so no cycle with the read path — which indexes on demand — is possible.
+//!   closure. The rebuild paths are async overall, but each takes the guard inside a
+//!   `spawn_blocking` and around synchronous work only, so a holder is never suspended waiting on a
+//!   future that needs the same guard.
 //!
 //! shortcut: an in-process lock, which serializes writers only within one oxen-server process. If
 //! the server is ever run as more than one process per repository, this needs to become a lock the
-//! processes share (a lock file on the workspace directory, or a row op that is atomic in DuckDB
-//! itself).
+//! processes share, such as a lock file on the workspace directory. Note that a row operation that
+//! is atomic in DuckDB is *not* an alternative: the hazard is two databases over one file, which no
+//! single statement addresses.
 //!
 //! The registry never evicts: it holds one small mutex per data frame the process has written to,
 //! for the life of the process.

--- a/crates/liboxen/src/core/data_frame_locks.rs
+++ b/crates/liboxen/src/core/data_frame_locks.rs
@@ -1,0 +1,114 @@
+//! Process-global per-data-frame write lock — serializes the read-modify-write row operations on
+//! a single workspace data frame's staged table.
+//!
+//! # Why it exists
+//!
+//! Appending, updating, or deleting a row reads the staged DuckDB table, derives new contents, and
+//! writes them back. Two of those running at once on the same table produce last-writer-wins: the
+//! loser's rows are discarded while both callers are told they succeeded. The cached DuckDB
+//! connection ([`crate::core::db::data_frames::df_db`]) serializes writes only while both callers
+//! share the cached connection — its cache evicts under LRU pressure, and an eviction between two
+//! in-flight row writes hands each caller its own connection to the same file, at which point
+//! nothing serializes them. This lock keys on the same identity the connection cache does but is
+//! never evicted, so exclusion holds regardless of what the cache is currently holding.
+//!
+//! # Scope and ordering
+//!
+//! One lock per data frame, keyed by the path of its staged DuckDB file — the identity of a
+//! (repository, workspace, data frame path) triple. Writes to different data frames, different
+//! workspaces, or different repositories never contend.
+//!
+//! It composes with [`crate::core::repo_locks`] rather than replacing it: a write entry point still
+//! takes the repo's shared write reservation, which is what makes writes block against exclusive
+//! maintenance operations. This lock only orders writers against each other.
+//!
+//! Two ordering rules keep it deadlock-free, and both are structural rather than conventional:
+//!
+//! - It is always taken *before* the DuckDB connection lock, never the other way around, because
+//!   [`with_data_frame_write`] wraps whole row operations and the connection lock is taken inside
+//!   them.
+//! - It cannot be held across an `.await`, because [`with_data_frame_write`] takes a synchronous
+//!   closure. Nothing that indexes or rebuilds the table (all of which is async) can be waiting on
+//!   this lock, so no cycle with the read path — which indexes on demand — is possible.
+//!
+//! shortcut: an in-process lock, which serializes writers only within one oxen-server process. If
+//! the server is ever run as more than one process per repository, this needs to become a lock the
+//! processes share (a lock file on the workspace directory, or a row op that is atomic in DuckDB
+//! itself).
+//!
+//! The registry never evicts: it holds one small mutex per data frame the process has written to,
+//! for the life of the process.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock};
+
+use parking_lot::Mutex;
+
+static REGISTRY: LazyLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Run `work` with exclusive access to the data frame whose staged DuckDB table lives at
+/// `db_path`, blocking until any other row write on that same data frame finishes.
+pub fn with_data_frame_write<T>(db_path: &Path, work: impl FnOnce() -> T) -> T {
+    // The registry guard is released at the end of this statement, before the data frame's own
+    // lock is taken — holding both would serialize unrelated data frames.
+    let lock = REGISTRY
+        .lock()
+        .entry(db_path.to_path_buf())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone();
+    let _guard = lock.lock();
+    work()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // Writers on one data frame run one at a time: a second writer cannot enter while the first
+    // is inside its critical section.
+    #[test]
+    fn test_writes_to_one_data_frame_do_not_overlap() {
+        let db_path = PathBuf::from("/data-frame-locks-test/one");
+        let inside = Arc::new(AtomicUsize::new(0));
+        let max_inside = Arc::new(AtomicUsize::new(0));
+
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                let db_path = db_path.clone();
+                let inside = inside.clone();
+                let max_inside = max_inside.clone();
+                scope.spawn(move || {
+                    for _ in 0..500 {
+                        with_data_frame_write(&db_path, || {
+                            let now = inside.fetch_add(1, Ordering::SeqCst) + 1;
+                            max_inside.fetch_max(now, Ordering::SeqCst);
+                            std::hint::spin_loop();
+                            inside.fetch_sub(1, Ordering::SeqCst);
+                        });
+                    }
+                });
+            }
+        });
+
+        assert_eq!(
+            max_inside.load(Ordering::SeqCst),
+            1,
+            "two row writes on the same data frame overlapped"
+        );
+    }
+
+    // Each data frame gets its own lock, so a write to one never waits on a write to another.
+    // Nesting proves it: two keys sharing a lock would deadlock here.
+    #[test]
+    fn test_writes_to_different_data_frames_take_different_locks() {
+        let b = PathBuf::from("/data-frame-locks-test/b");
+        let reached_inner =
+            with_data_frame_write(&PathBuf::from("/data-frame-locks-test/a"), || {
+                with_data_frame_write(&b, || true)
+            });
+        assert!(reached_inner);
+    }
+}

--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
@@ -271,6 +271,23 @@ async fn p_index(workspace: &Workspace, path: &Path, rebuild: Rebuild) -> Result
     };
     util::fs::create_dir_all(parent)?;
 
+    // Fast path: an already-indexed table needs no committed file, and materializing one is a
+    // whole-file fetch from the version store. This read is advisory only. The authoritative check
+    // is the one under the data frame's write guard below, which is what makes the decision and the
+    // rebuild atomic, so a table that looks indexed here and is gone by then still rebuilds.
+    if rebuild == Rebuild::OnlyIfAbsent {
+        let db_path = db_path.clone();
+        let already_indexed = tokio::task::spawn_blocking(move || {
+            with_df_db_manager(&db_path, |manager| {
+                manager.with_conn(|conn| Ok(df_db::table_is_fully_indexed(conn, TABLE_NAME)?))
+            })
+        })
+        .await??;
+        if already_indexed {
+            return Ok(());
+        }
+    }
+
     let version_store = repo.version_store();
     let hash_str = file_hash.to_string();
 
@@ -436,8 +453,12 @@ pub async fn reindex_preserving_rows(workspace: &Workspace, path: &Path) -> Resu
     }
 
     let recovered = tokio::task::spawn_blocking(move || -> Result<bool, OxenError> {
-        let outcome = with_df_db_manager(&db_path, |manager| {
-            manager.with_conn(|conn| -> Result<bool, DataFrameError> {
+        // The export and the rebuild that consumes it must be one step: a row written after the
+        // export but before the drop below is not in the export, so the rebuilt table would not
+        // contain it.
+        let outcome = with_data_frame_write(&db_path, || {
+            with_df_db_manager(&db_path, |manager| {
+                manager.with_conn(|conn| -> Result<bool, DataFrameError> {
                 let schema = df_db::get_schema(conn, TABLE_NAME)?;
                 let has_col = |name: &str| schema.fields.iter().any(|f| f.name == name);
                 let has_user_col = schema
@@ -507,6 +528,7 @@ pub async fn reindex_preserving_rows(workspace: &Workspace, path: &Path) -> Resu
                 }
                 Ok(true)
             })
+            })
         });
         // Clean up the intermediate export regardless of the rebuild's result.
         let _ = std::fs::remove_file(&recover_path);
@@ -542,27 +564,35 @@ pub async fn rename(
     let new_db_path = repositories::workspaces::data_frames::duckdb_path(workspace, new_path);
     let new_db_path_parent = new_db_path.parent().unwrap();
 
-    // Explicitly checkpoint and then close the cached connection before copying.
-    // CHECKPOINT forces DuckDB to flush its WAL into the main database file.
-    // Without this, the copy could include a WAL file that references the
-    // original catalog name, causing replay failures when the copy is opened.
-    with_df_db_manager(&og_db_path, |manager| {
-        manager.with_conn(|conn| {
-            if let Err(e) = conn.execute_batch("CHECKPOINT") {
-                log::warn!("rename: CHECKPOINT before copy failed for {og_db_path:?}: {e}");
-            }
-            Ok(())
-        })
+    // Hold the source data frame for the whole move: it drops the cached connection and then
+    // copies and removes the directory that connection was reading, so a write that overlaps lands
+    // in a database about to be deleted. Only the source is held. The destination has no writers
+    // until this returns, so one lock is enough and there is no lock ordering to reason about.
+    with_data_frame_write(&og_db_path, || -> Result<(), OxenError> {
+        // Explicitly checkpoint and then close the cached connection before copying.
+        // CHECKPOINT forces DuckDB to flush its WAL into the main database file.
+        // Without this, the copy could include a WAL file that references the
+        // original catalog name, causing replay failures when the copy is opened.
+        with_df_db_manager(&og_db_path, |manager| {
+            manager.with_conn(|conn| {
+                if let Err(e) = conn.execute_batch("CHECKPOINT") {
+                    log::warn!("rename: CHECKPOINT before copy failed for {og_db_path:?}: {e}");
+                }
+                Ok(())
+            })
+        })?;
+        df_db::remove_df_db_from_cache(&og_db_path)?;
+
+        if !new_db_path_parent.exists() {
+            util::fs::create_dir_all(new_db_path_parent)?;
+        }
+
+        util::fs::copy_dir_all(og_db_path_parent, new_db_path_parent)?;
+
+        util::fs::remove_dir_all(og_db_path_parent)?;
+
+        Ok(())
     })?;
-    df_db::remove_df_db_from_cache(&og_db_path)?;
-
-    if !new_db_path_parent.exists() {
-        util::fs::create_dir_all(new_db_path_parent)?;
-    }
-
-    util::fs::copy_dir_all(og_db_path_parent, new_db_path_parent)?;
-
-    util::fs::remove_dir_all(og_db_path_parent)?;
 
     // Use staged_db_manager
     let staged_db_manager = get_staged_db_manager(workspace_repo)?;

--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
@@ -4,6 +4,7 @@ use crate::constants::{
     EVAL_DURATION_COL, EVAL_ERROR_COL, EVAL_STATUS_COL, EXCLUDE_OXEN_COLS, OXEN_ID_COL,
     OXEN_ROW_ID_COL, TABLE_NAME,
 };
+use crate::core::data_frame_locks::with_data_frame_write;
 use crate::core::db::data_frames::DataFrameError;
 use crate::core::db::data_frames::df_db;
 use crate::core::db::data_frames::df_db::with_df_db_manager;
@@ -211,7 +212,25 @@ pub fn get_queryable_data_frame_workspace(
     get_queryable_data_frame_workspace_from_file_node(repo, &commit.id.parse()?, path)
 }
 
+/// Rebuild the staged table for `path` from the committed file, discarding any staged edits.
 pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
+    p_index(workspace, path, Rebuild::Always).await
+}
+
+/// Index `path` only if its staged table is absent, leaving an already-indexed frame and the
+/// staged edits it holds untouched.
+pub async fn index_if_absent(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
+    p_index(workspace, path, Rebuild::OnlyIfAbsent).await
+}
+
+/// Whether [`p_index`] rebuilds a table that is already fully indexed.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Rebuild {
+    Always,
+    OnlyIfAbsent,
+}
+
+async fn p_index(workspace: &Workspace, path: &Path, rebuild: Rebuild) -> Result<(), OxenError> {
     // Is tabular just looks at the file extensions
     let file_node =
         repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
@@ -277,46 +296,59 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     // (it never crosses an `.await`), and `version_file` is held on the async side until the
     // blocking work finishes, so a materialized S3 temp file outlives the read.
     tokio::task::spawn_blocking(move || {
-        with_df_db_manager(&db_path, |manager| {
-            manager.with_conn(|conn| {
-                // Drop any prior table (possibly partial or stale) and commit that
-                // drop before the rebuild, so a failed rebuild leaves no table at
-                // all rather than rolling back to a partial one.
-                if df_db::table_exists(conn, TABLE_NAME)? {
-                    df_db::drop_table(conn, TABLE_NAME)?;
-                }
+        // Hold the data frame exclusively for the whole rebuild. Under `OnlyIfAbsent` that also
+        // covers the emptiness check, so the rebuild cannot proceed on a table another caller
+        // populated after the caller's own check.
+        with_data_frame_write(&db_path, || {
+            with_df_db_manager(&db_path, |manager| {
+                manager.with_conn(|conn| {
+                    if rebuild == Rebuild::OnlyIfAbsent
+                        && df_db::table_is_fully_indexed(conn, TABLE_NAME)?
+                    {
+                        return Ok(());
+                    }
 
-                // A workspace data frame is only queryable once the hidden
-                // `_oxen_id` column is present, so build the table inside a
-                // transaction and publish it only on success. On any failure, roll
-                // back (and drop defensively) so the read path never sees a
-                // half-built table.
-                conn.execute_batch("BEGIN TRANSACTION")?;
-                let build = (|| -> Result<(), DataFrameError> {
-                    df_db::index_file_with_id(&version_path, conn, &extension)?;
-                    Ok(())
-                })();
-                match build {
-                    Ok(()) => {
-                        conn.execute_batch("COMMIT")?;
-                        // Fold the WAL into the db file right away. The
-                        // indexing DDL includes function defaults (uuid(),
-                        // nextval()) whose WAL entries the bundled DuckDB
-                        // cannot replay after an unclean shutdown; once
-                        // checkpointed they are out of the WAL entirely.
-                        // Best-effort: a concurrent transaction can block a
-                        // checkpoint, and the next clean open checkpoints too.
-                        if let Err(e) = conn.execute_batch("CHECKPOINT") {
-                            log::warn!("index: CHECKPOINT after build failed for {db_path:?}: {e}");
-                        }
+                    // Drop any prior table (possibly partial or stale) and commit that
+                    // drop before the rebuild, so a failed rebuild leaves no table at
+                    // all rather than rolling back to a partial one.
+                    if df_db::table_exists(conn, TABLE_NAME)? {
+                        df_db::drop_table(conn, TABLE_NAME)?;
+                    }
+
+                    // A workspace data frame is only queryable once the hidden
+                    // `_oxen_id` column is present, so build the table inside a
+                    // transaction and publish it only on success. On any failure, roll
+                    // back (and drop defensively) so the read path never sees a
+                    // half-built table.
+                    conn.execute_batch("BEGIN TRANSACTION")?;
+                    let build = (|| -> Result<(), DataFrameError> {
+                        df_db::index_file_with_id(&version_path, conn, &extension)?;
                         Ok(())
+                    })();
+                    match build {
+                        Ok(()) => {
+                            conn.execute_batch("COMMIT")?;
+                            // Fold the WAL into the db file right away. The
+                            // indexing DDL includes function defaults (uuid(),
+                            // nextval()) whose WAL entries the bundled DuckDB
+                            // cannot replay after an unclean shutdown; once
+                            // checkpointed they are out of the WAL entirely.
+                            // Best-effort: a concurrent transaction can block a
+                            // checkpoint, and the next clean open checkpoints too.
+                            if let Err(e) = conn.execute_batch("CHECKPOINT") {
+                                log::warn!(
+                                    "index: CHECKPOINT after build failed for {db_path:?}: {e}"
+                                );
+                            }
+                            Ok(())
+                        }
+                        Err(e) => {
+                            let _ = conn.execute_batch("ROLLBACK");
+                            let _ = df_db::drop_table(conn, TABLE_NAME);
+                            Err(e)
+                        }
                     }
-                    Err(e) => {
-                        let _ = conn.execute_batch("ROLLBACK");
-                        let _ = df_db::drop_table(conn, TABLE_NAME);
-                        Err(e)
-                    }
-                }
+                })
             })
         })
     })

--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames/columns.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames/columns.rs
@@ -1,6 +1,7 @@
 use polars::frame::DataFrame;
 
 use crate::constants::TABLE_NAME;
+use crate::core::data_frame_locks::with_data_frame_write;
 use crate::core::db::data_frames::DataFrameError;
 use crate::core::db::data_frames::columns;
 use crate::core::db::data_frames::df_db::with_df_db_manager;
@@ -22,8 +23,10 @@ pub fn add(
     let file_path = file_path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, file_path);
     log::debug!("add_column() got db_path: {db_path:?}");
-    let result = with_df_db_manager(&db_path, |manager| {
-        manager.with_conn(|conn| columns::add_column(conn, new_column))
+    let result = with_data_frame_write(&db_path, || {
+        with_df_db_manager(&db_path, |manager| {
+            manager.with_conn(|conn| columns::add_column(conn, new_column))
+        })
     })?;
 
     workspaces::files::track_modified_data_frame(workspace, file_path)?;
@@ -39,8 +42,10 @@ pub fn delete(
     let file_path = file_path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, file_path);
     log::debug!("delete_column() got db_path: {db_path:?}");
-    let result = with_df_db_manager(&db_path, |manager| {
-        manager.with_conn(|conn| columns::delete_column(conn, column_to_delete))
+    let result = with_data_frame_write(&db_path, || {
+        with_df_db_manager(&db_path, |manager| {
+            manager.with_conn(|conn| columns::delete_column(conn, column_to_delete))
+        })
     })?;
 
     workspaces::files::track_modified_data_frame(workspace, file_path)?;
@@ -56,10 +61,12 @@ pub async fn update(
     let file_path = file_path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, file_path);
     log::debug!("update_column() got db_path: {db_path:?}");
-    let result = with_df_db_manager(&db_path, |manager| {
-        manager.with_conn(|conn| {
-            let table_schema = schema_without_oxen_cols(conn, TABLE_NAME)?;
-            columns::update_column(conn, column_to_update, &table_schema)
+    let result = with_data_frame_write(&db_path, || {
+        with_df_db_manager(&db_path, |manager| {
+            manager.with_conn(|conn| {
+                let table_schema = schema_without_oxen_cols(conn, TABLE_NAME)?;
+                columns::update_column(conn, column_to_update, &table_schema)
+            })
         })
     })?;
 

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -680,6 +680,33 @@ mod tests {
                 "index must still rebuild from the committed file"
             );
 
+            // Present but partial: a table missing `_oxen_id`, which is what an interrupted index
+            // leaves behind. It cannot be queried, so "absent" has to include it. Otherwise the
+            // frame stays unqueryable no matter how many times a caller asks for it.
+            let db_path = workspaces::data_frames::duckdb_path(&workspace, &file_path);
+            with_df_db_manager(&db_path, |manager| {
+                manager.with_conn(|conn| {
+                    conn.execute(
+                        &format!("ALTER TABLE \"{TABLE_NAME}\" DROP COLUMN \"{OXEN_ID_COL}\""),
+                        [],
+                    )?;
+                    Ok(())
+                })
+            })?;
+            assert!(!workspaces::data_frames::is_indexed(
+                &workspace, &file_path
+            )?);
+
+            workspaces::data_frames::index_if_absent(&repo, &workspace, &file_path).await?;
+            assert!(
+                workspaces::data_frames::is_indexed(&workspace, &file_path)?,
+                "index_if_absent must rebuild a partially-indexed table rather than keep it"
+            );
+            assert_eq!(
+                workspaces::data_frames::count(&workspace, &file_path)?,
+                committed_rows
+            );
+
             Ok(())
         })
         .await

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -483,6 +483,8 @@ fn add_exclude_to_sql(sql: &str) -> Result<String, DataFrameError> {
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::SystemTime;
 
     use serde_json::json;
@@ -501,6 +503,104 @@ mod tests {
     use crate::repositories::workspaces;
     use crate::test;
     use crate::util::fs::AtomicFile;
+
+    /// Stops a spinning helper thread when the test scope ends, on the assertion-failure path as
+    /// well as the happy one — a blocking task left spinning keeps the test binary alive forever.
+    struct StopOnDrop(Arc<AtomicBool>);
+
+    impl Drop for StopOnDrop {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Every concurrent append to one data frame lands. An append reads the staged table and
+    /// writes derived contents back, so writers that overlap discard one another's rows while
+    /// each caller is told its own row was saved.
+    ///
+    /// Evicting the data frame's cached DuckDB connection is what makes the hazard reachable.
+    /// That connection is per-file and serializes writes only while every writer shares it; LRU
+    /// pressure drops the entry on its own, and once it is gone an in-flight writer keeps the old
+    /// connection while the next writer opens its own to the same file. Exclusion therefore has
+    /// to come from something the cache cannot take away.
+    #[tokio::test]
+    async fn test_concurrent_row_appends_all_land() -> Result<(), OxenError> {
+        // Skip duckdb if on windows
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+
+        test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
+            let branch = repositories::branches::create_checkout(&repo, "test-concurrent-append")?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?
+                .expect("branch should have a commit");
+            let workspace =
+                repositories::workspaces::create(&repo, &commit, UserConfig::identifier()?, true)?;
+            let file_path = Path::new("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+
+            let committed_rows = workspaces::data_frames::count(&workspace, &file_path)?;
+            let db_path = workspaces::data_frames::duckdb_path(&workspace, &file_path);
+
+            let stop = Arc::new(AtomicBool::new(false));
+            let stopper = StopOnDrop(stop.clone());
+            let evictor = {
+                let db_path = db_path.clone();
+                let stop = stop.clone();
+                tokio::task::spawn_blocking(move || {
+                    // Scoped to this data frame's entry, so it cannot disturb the connections a
+                    // sibling test in this binary has cached.
+                    while !stop.load(Ordering::Relaxed) {
+                        df_db::remove_df_db_from_cache(&db_path)
+                            .expect("evicting a cache entry cannot fail");
+                    }
+                })
+            };
+
+            // Successive rounds compound the loss: once two connections disagree about the table,
+            // a write through the stale one discards everything the other added.
+            let appends_per_round = 16;
+            for round in 0..3 {
+                let mut handles = Vec::new();
+                for i in 0..appends_per_round {
+                    let repo = repo.clone();
+                    let workspace = workspace.clone();
+                    let file_path = file_path.clone();
+                    handles.push(tokio::task::spawn_blocking(move || {
+                        let json_data = json!({
+                            "file": format!("concurrent-{round}-{i}.jpg"),
+                            "label": "dog",
+                            "min_x": 1.0,
+                            "min_y": 2.0,
+                            "width": 10.0,
+                            "height": 10.0
+                        });
+                        workspaces::data_frames::rows::add(
+                            &repo, &workspace, &file_path, &json_data,
+                        )
+                    }));
+                }
+                for handle in handles {
+                    handle.await.expect("join append task")?;
+                }
+
+                let expected = committed_rows + appends_per_round * (round + 1);
+                let count = workspaces::data_frames::count(&workspace, &file_path)?;
+                assert_eq!(
+                    count, expected,
+                    "round {round}: appends reported success but their rows are missing"
+                );
+            }
+
+            drop(stopper);
+            evictor.await.expect("join evictor task");
+
+            Ok(())
+        })
+        .await
+    }
 
     #[tokio::test]
     async fn test_add_row() -> Result<(), OxenError> {

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -8,6 +8,7 @@ use sql_query_builder::Select;
 use crate::constants::{MAX_QUERYABLE_ROWS, OXEN_COLS, OXEN_ROW_ID_COL, TABLE_NAME};
 use crate::constants::{MODS_DIR, OXEN_HIDDEN_DIR};
 use crate::core;
+use crate::core::data_frame_locks::with_data_frame_write;
 use crate::core::db::data_frames::df_db::{with_df_db_manager, with_hardened_query_conn};
 use crate::core::db::data_frames::{DataFrameError, df_db};
 use crate::core::df::sql;
@@ -66,12 +67,27 @@ pub fn is_queryable_data_frame_indexed(
 
 pub use crate::core::v_latest::workspaces::data_frames::get_queryable_data_frame_workspace;
 
+/// Rebuild the staged table for `path` from the committed file, discarding any staged edits.
 pub async fn index(
     _repo: &LocalRepository,
     workspace: &Workspace,
     path: impl AsRef<Path>,
 ) -> Result<(), OxenError> {
     core::v_latest::workspaces::data_frames::index(workspace, path.as_ref()).await
+}
+
+/// Index `path` only if its staged table is absent, leaving an already-indexed frame and the
+/// staged edits it holds untouched.
+///
+/// The emptiness check and the rebuild run under one exclusive hold on the data frame, so a
+/// rebuild can never be authorized by a check that another caller has since invalidated. Callers
+/// that want a rebuild regardless of the current contents want [`index`].
+pub async fn index_if_absent(
+    _repo: &LocalRepository,
+    workspace: &Workspace,
+    path: impl AsRef<Path>,
+) -> Result<(), OxenError> {
+    core::v_latest::workspaces::data_frames::index_if_absent(workspace, path.as_ref()).await
 }
 
 /// Rebuild a staged data frame left by an older version of oxen from its own
@@ -83,14 +99,18 @@ pub async fn reindex_preserving_rows(workspace: &Workspace, path: &Path) -> Resu
 
 pub use crate::core::v_latest::workspaces::data_frames::rename;
 
+/// Drop the staged table for `path`, discarding any staged edits it holds. Editing the path again
+/// re-indexes it from the committed file.
 pub fn unindex(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), DataFrameError> {
     let path = path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
-    with_df_db_manager(&db_path, |manager| {
-        manager.with_conn(|conn| {
-            df_db::drop_table(conn, TABLE_NAME)?;
-            Ok(())
+    with_data_frame_write(&db_path, || {
+        with_df_db_manager(&db_path, |manager| {
+            manager.with_conn(|conn| {
+                df_db::drop_table(conn, TABLE_NAME)?;
+                Ok(())
+            })
         })
     })
 }
@@ -596,6 +616,69 @@ mod tests {
 
             drop(stopper);
             evictor.await.expect("join evictor task");
+
+            Ok(())
+        })
+        .await
+    }
+
+    /// `index_if_absent` builds a staged table that is missing but never rebuilds one that is
+    /// present, so a caller acting on a stale "not indexed" observation cannot discard rows staged
+    /// since. `index` still rebuilds unconditionally, which is what `restore` depends on.
+    #[tokio::test]
+    async fn test_index_if_absent_leaves_staged_rows_alone() -> Result<(), OxenError> {
+        // Skip duckdb if on windows
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+
+        test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
+            let branch = repositories::branches::create_checkout(&repo, "test-index-if-absent")?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?
+                .expect("branch should have a commit");
+            let workspace =
+                repositories::workspaces::create(&repo, &commit, UserConfig::identifier()?, true)?;
+            let file_path = Path::new("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+
+            // Absent: it builds the table.
+            assert!(!workspaces::data_frames::is_indexed(
+                &workspace, &file_path
+            )?);
+            workspaces::data_frames::index_if_absent(&repo, &workspace, &file_path).await?;
+            assert!(workspaces::data_frames::is_indexed(&workspace, &file_path)?);
+            let committed_rows = workspaces::data_frames::count(&workspace, &file_path)?;
+
+            let json_data = json!({
+                "file": "staged.jpg",
+                "label": "dog",
+                "min_x": 1.0,
+                "min_y": 2.0,
+                "width": 10.0,
+                "height": 10.0
+            });
+            workspaces::data_frames::rows::add(&repo, &workspace, &file_path, &json_data)?;
+            assert_eq!(
+                workspaces::data_frames::count(&workspace, &file_path)?,
+                committed_rows + 1
+            );
+
+            // Present: the staged row survives a second call.
+            workspaces::data_frames::index_if_absent(&repo, &workspace, &file_path).await?;
+            assert_eq!(
+                workspaces::data_frames::count(&workspace, &file_path)?,
+                committed_rows + 1,
+                "index_if_absent rebuilt an already-indexed frame and discarded its staged row"
+            );
+
+            // The unconditional form is unchanged: it rebuilds from the commit.
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+            assert_eq!(
+                workspaces::data_frames::count(&workspace, &file_path)?,
+                committed_rows,
+                "index must still rebuild from the committed file"
+            );
 
             Ok(())
         })

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -120,7 +120,12 @@ pub async fn restore(
     workspace: &Workspace,
     path: impl AsRef<Path>,
 ) -> Result<(), OxenError> {
-    // Unstage and then restage the df
+    // Unstage and then restage the df.
+    //
+    // Two separately guarded steps, not one: the data frame's write guard cannot be held across the
+    // `.await` below. A row write landing in the gap therefore fails with `DatasetNotIndexed`
+    // rather than being silently discarded by the rebuild, which is the right outcome for a caller
+    // that asked for the staged edits to be thrown away.
     unindex(workspace, &path)?;
 
     // TODO: we could do this more granularly without a full reset
@@ -534,9 +539,10 @@ mod tests {
         }
     }
 
-    /// Every concurrent append to one data frame lands. An append reads the staged table and
-    /// writes derived contents back, so writers that overlap discard one another's rows while
-    /// each caller is told its own row was saved.
+    /// Every concurrent append to one data frame lands. Writers that overlap can end up on
+    /// separate DuckDB databases over the same file, and the one that folds its state into the
+    /// file last wins, so the other's rows are gone while each caller was told its own row was
+    /// saved.
     ///
     /// Evicting the data frame's cached DuckDB connection is what makes the hazard reachable.
     /// That connection is per-file and serializes writes only while every writer shares it; LRU

--- a/crates/liboxen/src/repositories/workspaces/data_frames/embeddings.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames/embeddings.rs
@@ -7,6 +7,7 @@ use crate::config::EMBEDDING_CONFIG_FILENAME;
 use crate::config::EmbeddingConfig;
 use crate::config::embedding_config::{EmbeddingColumn, EmbeddingStatus};
 use crate::constants::{EXCLUDE_OXEN_COLS, TABLE_NAME};
+use crate::core::data_frame_locks::with_data_frame_write;
 use crate::core::db::data_frames::DataFrameError;
 use crate::core::db::data_frames::df_db::{self, with_df_db_manager};
 use crate::model::data_frame::schema::Field;
@@ -103,19 +104,24 @@ fn perform_indexing(
     vector_length: usize,
 ) -> Result<(), DataFrameError> {
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
-    with_df_db_manager(&db_path, |manager| {
-        manager.with_conn(|conn| {
-            // Execute VSS commands separately
-            conn.execute("INSTALL vss;", [])?;
-            conn.execute("LOAD vss;", [])?;
-            conn.execute("SET hnsw_enable_experimental_persistence = true;", [])?;
+    // Retyping a column rewrites the table, so hold the data frame against the row and column
+    // writes for the duration.
+    with_data_frame_write(&db_path, || {
+        with_df_db_manager(&db_path, |manager| {
+            manager.with_conn(|conn| {
+                // Execute VSS commands separately
+                conn.execute("INSTALL vss;", [])?;
+                conn.execute("LOAD vss;", [])?;
+                conn.execute("SET hnsw_enable_experimental_persistence = true;", [])?;
 
-            // Convert column type
-            let sql =
-                format!("ALTER TABLE df ALTER COLUMN {column_name} TYPE FLOAT[{vector_length}];");
-            log::debug!("Updating column type: {sql}");
-            conn.execute(&sql, [])?;
-            Ok(())
+                // Convert column type
+                let sql = format!(
+                    "ALTER TABLE df ALTER COLUMN {column_name} TYPE FLOAT[{vector_length}];"
+                );
+                log::debug!("Updating column type: {sql}");
+                conn.execute(&sql, [])?;
+                Ok(())
+            })
         })
     })?;
 

--- a/crates/liboxen/src/repositories/workspaces/data_frames/rows.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames/rows.rs
@@ -18,8 +18,9 @@ use std::path::Path;
 
 /// Append `data` as a new row and return it as staged, `_oxen_id` included.
 ///
-/// Serialized against the other row writes on this data frame: the append reads the staged table
-/// and writes derived contents back, so overlapping writes would discard one another's rows.
+/// Serialized against the other writes on this data frame: overlapping writes can end up on
+/// separate DuckDB databases over the same file and discard one another's rows. See
+/// [`crate::core::data_frame_locks`].
 pub fn add(
     _repo: &LocalRepository,
     workspace: &Workspace,
@@ -34,7 +35,8 @@ pub fn add(
 
 /// Overwrite the row `row_id` with `data` and return it as staged.
 ///
-/// Serialized against the other row writes on this data frame — see [`add`].
+/// Serialized against the other writes on this data frame, which here also covers the gap between
+/// reading the row and writing it back. See [`add`].
 pub fn update(
     _repo: &LocalRepository,
     workspace: &Workspace,
@@ -50,7 +52,7 @@ pub fn update(
 
 /// Overwrite each `{row_id, value}` pair in `data` and return the ids updated.
 ///
-/// Serialized against the other row writes on this data frame — see [`add`].
+/// Serialized against the other writes on this data frame. See [`add`].
 pub fn batch_update(
     _repo: &LocalRepository,
     workspace: &Workspace,
@@ -65,7 +67,7 @@ pub fn batch_update(
 
 /// Remove the row `row_id` and return it as it was before the delete.
 ///
-/// Serialized against the other row writes on this data frame — see [`add`].
+/// Serialized against the other writes on this data frame. See [`add`].
 pub fn delete(
     _repo: &LocalRepository,
     workspace: &Workspace,

--- a/crates/liboxen/src/repositories/workspaces/data_frames/rows.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames/rows.rs
@@ -9,20 +9,32 @@ use crate::{core, repositories};
 
 use crate::constants::{OXEN_ID_COL, OXEN_ROW_ID_COL, TABLE_NAME};
 
+use crate::core::data_frame_locks::with_data_frame_write;
 use crate::core::db::data_frames::df_db::{self, with_df_db_manager};
 use crate::model::LocalRepository;
+use crate::repositories::workspaces::data_frames::duckdb_path;
 
 use std::path::Path;
 
+/// Append `data` as a new row and return it as staged, `_oxen_id` included.
+///
+/// Serialized against the other row writes on this data frame: the append reads the staged table
+/// and writes derived contents back, so overlapping writes would discard one another's rows.
 pub fn add(
     _repo: &LocalRepository,
     workspace: &Workspace,
     file_path: impl AsRef<Path>,
     data: &serde_json::Value,
 ) -> Result<DataFrame, OxenError> {
-    core::v_latest::workspaces::data_frames::rows::add(workspace, file_path.as_ref(), data)
+    let file_path = file_path.as_ref();
+    with_data_frame_write(&duckdb_path(workspace, file_path), || {
+        core::v_latest::workspaces::data_frames::rows::add(workspace, file_path, data)
+    })
 }
 
+/// Overwrite the row `row_id` with `data` and return it as staged.
+///
+/// Serialized against the other row writes on this data frame — see [`add`].
 pub fn update(
     _repo: &LocalRepository,
     workspace: &Workspace,
@@ -30,25 +42,40 @@ pub fn update(
     row_id: &str,
     data: &serde_json::Value,
 ) -> Result<DataFrame, OxenError> {
-    core::v_latest::workspaces::data_frames::rows::update(workspace, path.as_ref(), row_id, data)
+    let path = path.as_ref();
+    with_data_frame_write(&duckdb_path(workspace, path), || {
+        core::v_latest::workspaces::data_frames::rows::update(workspace, path, row_id, data)
+    })
 }
 
+/// Overwrite each `{row_id, value}` pair in `data` and return the ids updated.
+///
+/// Serialized against the other row writes on this data frame — see [`add`].
 pub fn batch_update(
     _repo: &LocalRepository,
     workspace: &Workspace,
     path: impl AsRef<Path>,
     data: &serde_json::Value,
 ) -> Result<Vec<UpdateResult>, OxenError> {
-    core::v_latest::workspaces::data_frames::rows::batch_update(workspace, path.as_ref(), data)
+    let path = path.as_ref();
+    with_data_frame_write(&duckdb_path(workspace, path), || {
+        core::v_latest::workspaces::data_frames::rows::batch_update(workspace, path, data)
+    })
 }
 
+/// Remove the row `row_id` and return it as it was before the delete.
+///
+/// Serialized against the other row writes on this data frame — see [`add`].
 pub fn delete(
     _repo: &LocalRepository,
     workspace: &Workspace,
     path: impl AsRef<Path>,
     row_id: &str,
 ) -> Result<DataFrame, OxenError> {
-    core::v_latest::workspaces::data_frames::rows::delete(workspace, path.as_ref(), row_id)
+    let path = path.as_ref();
+    with_data_frame_write(&duckdb_path(workspace, path), || {
+        core::v_latest::workspaces::data_frames::rows::delete(workspace, path, row_id)
+    })
 }
 
 pub fn get_by_id(

--- a/crates/oxen-server/src/controllers/workspaces/data_frames.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames.rs
@@ -668,12 +668,14 @@ pub async fn put(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHtt
     let data: DataFramePayload = serde_json::from_str(&body)?;
     log::debug!("workspace {workspace_id} data frame put {data:?}");
 
-    let to_index = data.is_indexed;
-    let is_indexed = repositories::workspaces::data_frames::is_indexed(&workspace, &file_path)?;
-
-    if !is_indexed && to_index {
-        repositories::workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
-    } else if is_indexed && !to_index {
+    // Both branches decide under an exclusive hold on the data frame rather than on an
+    // `is_indexed` read taken here, so a rebuild cannot discard rows a row write committed
+    // between the read and the rebuild. `unindex` drops the table if it exists, so it needs no
+    // pre-check of its own.
+    if data.is_indexed {
+        repositories::workspaces::data_frames::index_if_absent(&repo, &workspace, &file_path)
+            .await?;
+    } else {
         repositories::workspaces::data_frames::unindex(&workspace, &file_path)?;
     }
 


### PR DESCRIPTION
Opening a DuckDB database file that the process already has open yields a second, independent database rather than joining the first: DuckDB's single-writer protection is a file lock that excludes other *processes*. The two then diverge, and whichever folds its state into the file last is the version that survives, so the other's rows are gone while both callers were told they succeeded.

What normally keeps one database per file is the `df_db` connection cache, whose entry is a connection behind a mutex. That serializes writers only while they share the entry, and the entry is not guaranteed to be there: the cache evicts under LRU pressure, and `rename`, workspace delete, and repo delete evict by hand. An eviction while one writer is still inside its operation hands the next writer its own database over the same file.

`core::data_frame_locks` adds one lock per data frame, keyed by the path of its staged DuckDB file, so exclusion no longer depends on what the cache happens to be holding. Everything that mutates a staged table now takes it: the four row operations, the three column operations, `unindex`, the `index` rebuild, `reindex_preserving_rows`, `rename`, and the embeddings column retype. Different data frames, workspaces, and repositories never contend.

Serializing the writers leaves a second way to lose a row, and it survives precisely because every touch of the table is now ordered. The `PUT .../data_frames/resource/{path}` handler read `is_indexed` and then called `index`, with the read outside the guard and the rebuild inside it, so two list requests could both observe "not indexed" and the second one's rebuild would discard rows an append had committed in between. `index_if_absent` re-reads that check under the same guard that rebuilds, making the decision and the rebuild one step. Plain `index` stays unconditional, which is what `restore` depends on.

The repository's shared write reservation is unchanged; this lock only orders writers against each other. It cannot deadlock: it is always taken outside the DuckDB connection lock, and it is never held across an `.await`, because `with_data_frame_write` takes a synchronous closure and the rebuild paths take it inside a `spawn_blocking` around synchronous work only.

## Tests

`test_concurrent_row_appends_all_land` fires three rounds of 16 concurrent appends at one data frame while a task evicts its cache entry, asserting the exact row count after each round. It fails 10 out of 10 runs without the lock, first failing in round 0 with 20 rows where 22 were expected, and passes 10 out of 10 with it. Reaching the hazard needs the eviction to land inside another writer's critical section, so the test amplifies rather than forces it.

`test_index_if_absent_leaves_staged_rows_alone` covers the conditional rebuild deterministically: absent builds, fully indexed skips and the staged row survives, partial rebuilds, and plain `index` still discards.

## Also here

`index_if_absent` was materializing the committed file before checking whether it had anything to do, which on an S3-backed version store is a full object fetch discarded as soon as the check reports the table is present. The check now runs ahead of the materialize as an advisory fast path, with the authoritative check still under the guard.

## Follow-ups, not in this PR

The staged-table write path runs synchronous DuckDB IO on async runtime threads, and this guard puts a reliable queue in front of it, so a caller can park a runtime thread for the length of another caller's rebuild. That is pre-existing (the same wait existed via the connection mutex whenever two callers shared a cached connection) and the conversion spans the row handlers as well, so it wants its own change.