### PR TITLE
Serialize row writes on a workspace data frame

### DIFF
--- a/crates/liboxen/src/core.rs
+++ b/crates/liboxen/src/core.rs
@@ -1,6 +1,7 @@
 //! Core functionality for Oxen
 //!
 
+pub mod data_frame_locks;
 pub mod db;
 pub mod df;
 pub mod merge;

--- a/crates/liboxen/src/core/data_frame_locks.rs
+++ b/crates/liboxen/src/core/data_frame_locks.rs
@@ -1,0 +1,215 @@
+//! Process-global per-data-frame write lock: serializes the row operations that mutate a single
+//! workspace data frame's staged table.
+//!
+//! # Why it exists
+//!
+//! Opening a DuckDB database file that this process already has open yields a second, independent
+//! database rather than joining the first, because DuckDB's single-writer protection is a file lock
+//! that excludes other processes. The two then diverge, and whichever folds its state into the file
+//! last is the version that survives, so the other's rows are gone while both callers were told
+//! they succeeded. That is true of any write, a lone `INSERT` included, so making a write atomic in
+//! SQL would not remove the need for this lock.
+//!
+//! What normally keeps one database per file is the connection cache in
+//! [`crate::core::db::data_frames::df_db`]. A cache entry is a connection behind a mutex, so
+//! writers that find the same entry are serialized by it. That is incidental, and it stops holding
+//! the moment the entry is gone: the cache evicts under LRU pressure, and `rename`, workspace
+//! delete, and repo delete evict by hand. An eviction while one writer is still inside its
+//! operation hands the next writer its own database over the same file. This lock keys on the same
+//! identity the connection cache does, and its entry lives for as long as any caller holds it, so
+//! exclusion holds regardless of what the cache is currently holding.
+//!
+//! # Scope and ordering
+//!
+//! One lock per data frame, keyed by the path of its staged DuckDB file, which is the identity of a
+//! (repository, workspace, data frame path) triple. Writes to different data frames, different
+//! workspaces, or different repositories never contend.
+//!
+//! It composes with [`crate::core::repo_locks`] rather than replacing it: a write entry point still
+//! takes the repo's shared write reservation, which is what makes writes block against exclusive
+//! maintenance operations. This lock only orders writers against each other.
+//!
+//! Two ordering rules keep it deadlock-free, and both are structural rather than conventional:
+//!
+//! - It is always taken *before* the DuckDB connection lock, never the other way around, because
+//!   [`with_data_frame_write`] wraps whole row operations and the connection lock is taken inside
+//!   them.
+//! - It cannot be held across an `.await`, because [`with_data_frame_write`] takes a synchronous
+//!   closure. Nothing that indexes or rebuilds the table (all of which is async) can be waiting on
+//!   this lock, so no cycle with the read path, which indexes on demand, is possible.
+//!
+//! shortcut: an in-process lock, which serializes writers only within one oxen-server process. If
+//! the server is ever run as more than one process per repository, this needs to become a lock the
+//! processes share, such as a lock file on the workspace directory. Note that a row operation that
+//! is atomic in DuckDB is *not* an alternative: the hazard is two databases over one file, which no
+//! single statement addresses.
+//!
+//! The registry reclaims an entry once its last user is done, so it holds one small mutex per data
+//! frame currently being written rather than one per data frame ever written. The reclaim runs from
+//! a `Drop`, so it covers a panic inside the guarded work as well as a clean return.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock};
+
+use parking_lot::Mutex;
+
+static REGISTRY: LazyLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Holds a caller's reference to one data frame's lock, and drops the registry entry with it once
+/// no other caller wants it. Reclaiming from `Drop` covers the unwind path, so a panic inside the
+/// guarded work cannot leave the entry behind.
+struct Reclaim<'a> {
+    db_path: &'a Path,
+    lock: Arc<Mutex<()>>,
+}
+
+impl Drop for Reclaim<'_> {
+    fn drop(&mut self) {
+        // A count of two means the map's reference and this one, so nobody else wants this lock.
+        // Observing that while holding the registry lock is what makes removal safe: every clone
+        // is taken under this same lock, so a caller blocked on the data frame's mutex, or one
+        // that has cloned but not yet locked, is already counted here. The next caller for this
+        // path simply creates a fresh entry.
+        let mut registry = REGISTRY.lock();
+        if Arc::strong_count(&self.lock) == 2 {
+            registry.remove(self.db_path);
+        }
+    }
+}
+
+/// Run `work` with exclusive access to the data frame whose staged DuckDB table lives at
+/// `db_path`, blocking until any other row write on that same data frame finishes.
+pub fn with_data_frame_write<T>(db_path: &Path, work: impl FnOnce() -> T) -> T {
+    // The registry guard is released at the end of this statement, before the data frame's own
+    // lock is taken: holding both would serialize unrelated data frames.
+    let reclaim = Reclaim {
+        db_path,
+        lock: REGISTRY
+            .lock()
+            .entry(db_path.to_path_buf())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone(),
+    };
+
+    // Declared after `reclaim` so it drops before it: the entry becomes reclaimable only once this
+    // caller has released the data frame.
+    let _guard = reclaim.lock.lock();
+    work()
+}
+
+/// Whether the registry currently holds a lock for `db_path`. Keyed on one path rather than
+/// reporting a total, so a sibling test writing to its own data frame cannot perturb it.
+#[cfg(test)]
+fn registry_holds(db_path: &Path) -> bool {
+    REGISTRY.lock().contains_key(db_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // Writers on one data frame run one at a time: a second writer cannot enter while the first
+    // is inside its critical section.
+    #[test]
+    fn test_writes_to_one_data_frame_do_not_overlap() {
+        let db_path = PathBuf::from("/data-frame-locks-test/one");
+        let inside = Arc::new(AtomicUsize::new(0));
+        let max_inside = Arc::new(AtomicUsize::new(0));
+
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                let db_path = db_path.clone();
+                let inside = inside.clone();
+                let max_inside = max_inside.clone();
+                scope.spawn(move || {
+                    for _ in 0..500 {
+                        with_data_frame_write(&db_path, || {
+                            let now = inside.fetch_add(1, Ordering::SeqCst) + 1;
+                            max_inside.fetch_max(now, Ordering::SeqCst);
+                            std::hint::spin_loop();
+                            inside.fetch_sub(1, Ordering::SeqCst);
+                        });
+                    }
+                });
+            }
+        });
+
+        assert_eq!(
+            max_inside.load(Ordering::SeqCst),
+            1,
+            "two row writes on the same data frame overlapped"
+        );
+    }
+
+    // The registry tracks the data frames being written, not every one ever written: an entry
+    // exists while a write is in flight and is gone once the writers finish.
+    #[test]
+    fn test_registry_reclaims_a_data_frame_once_its_writers_finish() {
+        let db_path = PathBuf::from("/data-frame-locks-test/reclaimed");
+
+        with_data_frame_write(&db_path, || {
+            assert!(
+                registry_holds(&db_path),
+                "a write in flight must hold its registry entry"
+            );
+        });
+        assert!(
+            !registry_holds(&db_path),
+            "the registry kept a lock for a data frame with no writers"
+        );
+
+        // Same under contention, where the last writer out is the one that reclaims.
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                let db_path = db_path.clone();
+                scope.spawn(move || {
+                    for _ in 0..100 {
+                        with_data_frame_write(&db_path, std::hint::spin_loop);
+                    }
+                });
+            }
+        });
+        assert!(
+            !registry_holds(&db_path),
+            "the registry kept a lock after concurrent writers finished"
+        );
+    }
+
+    // A panic inside the guarded work reclaims the entry too, and leaves the lock usable rather
+    // than held by the unwound caller.
+    #[test]
+    fn test_a_panic_inside_the_guarded_work_still_reclaims() {
+        let db_path = PathBuf::from("/data-frame-locks-test/panicked");
+
+        // The panic below is deliberate, so its output in the test log is expected.
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            with_data_frame_write(&db_path, || {
+                panic!("deliberate panic under the data frame lock")
+            });
+        }));
+        assert!(outcome.is_err(), "the panic should have propagated");
+
+        assert!(
+            !registry_holds(&db_path),
+            "a panic left its registry entry behind"
+        );
+
+        // Still acquirable: `parking_lot`'s mutex does not poison, and the unwind released it.
+        with_data_frame_write(&db_path, || {});
+    }
+
+    // Each data frame gets its own lock, so a write to one never waits on a write to another.
+    // Nesting proves it: two keys sharing a lock would deadlock here.
+    #[test]
+    fn test_writes_to_different_data_frames_take_different_locks() {
+        let b = PathBuf::from("/data-frame-locks-test/b");
+        let reached_inner =
+            with_data_frame_write(&PathBuf::from("/data-frame-locks-test/a"), || {
+                with_data_frame_write(&b, || true)
+            });
+        assert!(reached_inner);
+    }
+}

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -483,6 +483,8 @@ fn add_exclude_to_sql(sql: &str) -> Result<String, DataFrameError> {
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::SystemTime;
 
     use serde_json::json;
@@ -501,6 +503,105 @@ mod tests {
     use crate::repositories::workspaces;
     use crate::test;
     use crate::util::fs::AtomicFile;
+
+    /// Stops a spinning helper thread when the test scope ends, on the assertion-failure path as
+    /// well as the happy one — a blocking task left spinning keeps the test binary alive forever.
+    struct StopOnDrop(Arc<AtomicBool>);
+
+    impl Drop for StopOnDrop {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Every concurrent append to one data frame lands. Writers that overlap can end up on
+    /// separate DuckDB databases over the same file, and the one that folds its state into the
+    /// file last wins, so the other's rows are gone while each caller was told its own row was
+    /// saved.
+    ///
+    /// Evicting the data frame's cached DuckDB connection is what makes the hazard reachable.
+    /// That connection is per-file and serializes writes only while every writer shares it; LRU
+    /// pressure drops the entry on its own, and once it is gone an in-flight writer keeps the old
+    /// connection while the next writer opens its own to the same file. Exclusion therefore has
+    /// to come from something the cache cannot take away.
+    #[tokio::test]
+    async fn test_concurrent_row_appends_all_land() -> Result<(), OxenError> {
+        // Skip duckdb if on windows
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+
+        test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
+            let branch = repositories::branches::create_checkout(&repo, "test-concurrent-append")?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?
+                .expect("branch should have a commit");
+            let workspace =
+                repositories::workspaces::create(&repo, &commit, UserConfig::identifier()?, true)?;
+            let file_path = Path::new("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+
+            let committed_rows = workspaces::data_frames::count(&workspace, &file_path)?;
+            let db_path = workspaces::data_frames::duckdb_path(&workspace, &file_path);
+
+            let stop = Arc::new(AtomicBool::new(false));
+            let stopper = StopOnDrop(stop.clone());
+            let evictor = {
+                let db_path = db_path.clone();
+                let stop = stop.clone();
+                tokio::task::spawn_blocking(move || {
+                    // Scoped to this data frame's entry, so it cannot disturb the connections a
+                    // sibling test in this binary has cached.
+                    while !stop.load(Ordering::Relaxed) {
+                        df_db::remove_df_db_from_cache(&db_path)
+                            .expect("evicting a cache entry cannot fail");
+                    }
+                })
+            };
+
+            // Successive rounds compound the loss: once two connections disagree about the table,
+            // a write through the stale one discards everything the other added.
+            let appends_per_round = 16;
+            for round in 0..3 {
+                let mut handles = Vec::new();
+                for i in 0..appends_per_round {
+                    let repo = repo.clone();
+                    let workspace = workspace.clone();
+                    let file_path = file_path.clone();
+                    handles.push(tokio::task::spawn_blocking(move || {
+                        let json_data = json!({
+                            "file": format!("concurrent-{round}-{i}.jpg"),
+                            "label": "dog",
+                            "min_x": 1.0,
+                            "min_y": 2.0,
+                            "width": 10.0,
+                            "height": 10.0
+                        });
+                        workspaces::data_frames::rows::add(
+                            &repo, &workspace, &file_path, &json_data,
+                        )
+                    }));
+                }
+                for handle in handles {
+                    handle.await.expect("join append task")?;
+                }
+
+                let expected = committed_rows + appends_per_round * (round + 1);
+                let count = workspaces::data_frames::count(&workspace, &file_path)?;
+                assert_eq!(
+                    count, expected,
+                    "round {round}: appends reported success but their rows are missing"
+                );
+            }
+
+            drop(stopper);
+            evictor.await.expect("join evictor task");
+
+            Ok(())
+        })
+        .await
+    }
 
     #[tokio::test]
     async fn test_add_row() -> Result<(), OxenError> {

--- a/crates/liboxen/src/repositories/workspaces/data_frames/rows.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames/rows.rs
@@ -9,20 +9,34 @@ use crate::{core, repositories};
 
 use crate::constants::{OXEN_ID_COL, OXEN_ROW_ID_COL, TABLE_NAME};
 
+use crate::core::data_frame_locks::with_data_frame_write;
 use crate::core::db::data_frames::df_db::{self, with_df_db_manager};
 use crate::model::LocalRepository;
+use crate::repositories::workspaces::data_frames::duckdb_path;
 
 use std::path::Path;
 
+/// Append `data` as a new row and return it as staged, `_oxen_id` included.
+///
+/// Serialized against the other writes on this data frame: overlapping writes can end up on
+/// separate DuckDB databases over the same file and discard one another's rows. See
+/// [`crate::core::data_frame_locks`].
 pub fn add(
     _repo: &LocalRepository,
     workspace: &Workspace,
     file_path: impl AsRef<Path>,
     data: &serde_json::Value,
 ) -> Result<DataFrame, OxenError> {
-    core::v_latest::workspaces::data_frames::rows::add(workspace, file_path.as_ref(), data)
+    let file_path = file_path.as_ref();
+    with_data_frame_write(&duckdb_path(workspace, file_path), || {
+        core::v_latest::workspaces::data_frames::rows::add(workspace, file_path, data)
+    })
 }
 
+/// Overwrite the row `row_id` with `data` and return it as staged.
+///
+/// Serialized against the other writes on this data frame, which here also covers the gap between
+/// reading the row and writing it back. See [`add`].
 pub fn update(
     _repo: &LocalRepository,
     workspace: &Workspace,
@@ -30,25 +44,40 @@ pub fn update(
     row_id: &str,
     data: &serde_json::Value,
 ) -> Result<DataFrame, OxenError> {
-    core::v_latest::workspaces::data_frames::rows::update(workspace, path.as_ref(), row_id, data)
+    let path = path.as_ref();
+    with_data_frame_write(&duckdb_path(workspace, path), || {
+        core::v_latest::workspaces::data_frames::rows::update(workspace, path, row_id, data)
+    })
 }
 
+/// Overwrite each `{row_id, value}` pair in `data` and return the ids updated.
+///
+/// Serialized against the other writes on this data frame. See [`add`].
 pub fn batch_update(
     _repo: &LocalRepository,
     workspace: &Workspace,
     path: impl AsRef<Path>,
     data: &serde_json::Value,
 ) -> Result<Vec<UpdateResult>, OxenError> {
-    core::v_latest::workspaces::data_frames::rows::batch_update(workspace, path.as_ref(), data)
+    let path = path.as_ref();
+    with_data_frame_write(&duckdb_path(workspace, path), || {
+        core::v_latest::workspaces::data_frames::rows::batch_update(workspace, path, data)
+    })
 }
 
+/// Remove the row `row_id` and return it as it was before the delete.
+///
+/// Serialized against the other writes on this data frame. See [`add`].
 pub fn delete(
     _repo: &LocalRepository,
     workspace: &Workspace,
     path: impl AsRef<Path>,
     row_id: &str,
 ) -> Result<DataFrame, OxenError> {
-    core::v_latest::workspaces::data_frames::rows::delete(workspace, path.as_ref(), row_id)
+    let path = path.as_ref();
+    with_data_frame_write(&duckdb_path(workspace, path), || {
+        core::v_latest::workspaces::data_frames::rows::delete(workspace, path, row_id)
+    })
 }
 
 pub fn get_by_id(


### PR DESCRIPTION
First of three stacked PRs: #896 (this one) → #897 → #898.

Opening a DuckDB file the process already has open yields a second, independent database rather than joining the first, since DuckDB's single-writer protection is a file lock that excludes other *processes*. The two diverge, and whichever writes its state to the file last wins, so the other's rows are gone while both callers were told they succeeded. A lone `INSERT` is exposed to this too, so SQL-level atomicity would not fix it.

What normally keeps one database per file is the `df_db` connection cache, whose entry is a connection behind a mutex. That only serializes writers who share the entry, and the entry can vanish: LRU eviction, plus `rename`, workspace delete, and repo delete evicting by hand. An eviction while one writer is mid-operation hands the next writer its own database over the same file.

`core::data_frame_locks` adds one lock per data frame, keyed by its staged DuckDB path, so exclusion no longer depends on the cache. The four row operations in `repositories::workspaces::data_frames::rows` take it, covering every caller: the server's row endpoints, the CLI, and the Python bindings. Different data frames never contend, and the repo's shared write reservation is unchanged.

Deadlock-free structurally: always taken outside the connection lock, and never held across an `.await` because `with_data_frame_write` takes a synchronous closure.

**Tests.** `test_concurrent_row_appends_all_land` fires 3 rounds of 16 concurrent appends while a task evicts the cached connection, asserting exact row counts. Fails 10/10 runs without the lock (round 0: 20 rows, expected 22), passes 10/10 with it. It amplifies the hazard rather than forcing it, since the eviction has to land inside another writer's critical section. Two unit tests cover the primitive. Rust and Python suites green.

**Follow-ups, not here.** #897 extends the lock to the other staged-table writers. Separately, this path runs synchronous DuckDB IO on async runtime threads and the lock puts a reliable queue in front of it; that is pre-existing and spans the row handlers, so it gets its own PR.