### PR TITLE
Rename a workspace data frame with both databases closed and held

### DIFF
--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
@@ -404,80 +404,89 @@ pub async fn reindex_preserving_rows(workspace: &Workspace, path: &Path) -> Resu
     }
 
     let recovered = tokio::task::spawn_blocking(move || -> Result<bool, OxenError> {
+        // The export and the rebuild that consumes it must be one step: a row written after the
+        // export but before the drop below is not in the export, so the rebuilt table would not
+        // contain it.
         let outcome = with_df_db_manager(&db_path, |manager| {
-            manager.with_conn(|conn| -> Result<bool, DataFrameError> {
-                let schema = df_db::get_schema(conn, TABLE_NAME)?;
-                let has_col = |name: &str| schema.fields.iter().any(|f| f.name == name);
-                let has_user_col = schema
-                    .fields
-                    .iter()
-                    .any(|f| !LEGACY_AND_CURRENT_INTERNAL_COLS.contains(&f.name.as_str()));
-                if !has_user_col {
-                    // Nothing but internal columns — no user data to preserve.
-                    return Ok(false);
-                }
+            manager.with_conn(|conn| {
+                let outcome = (|| -> Result<bool, DataFrameError> {
+                    let schema = df_db::get_schema(conn, TABLE_NAME)?;
+                    let has_col = |name: &str| schema.fields.iter().any(|f| f.name == name);
+                    let has_user_col = schema
+                        .fields
+                        .iter()
+                        .any(|f| !LEGACY_AND_CURRENT_INTERNAL_COLS.contains(&f.name.as_str()));
+                    if !has_user_col {
+                        // Nothing but internal columns — no user data to preserve.
+                        return Ok(false);
+                    }
 
-                let projection = build_export_projection_excluding(
-                    conn,
-                    TABLE_NAME,
-                    &LEGACY_AND_CURRENT_INTERNAL_COLS,
-                )?;
+                    let projection = build_export_projection_excluding(
+                        conn,
+                        TABLE_NAME,
+                        &LEGACY_AND_CURRENT_INTERNAL_COLS,
+                    )?;
 
-                // Keep row order: prefer the persisted ordering column, falling
-                // back to DuckDB's physical rowid (insertion order) for older
-                // tables that predate it.
-                let order_by = if has_col(OXEN_ROW_ID_COL) {
-                    format!("ORDER BY {OXEN_ROW_ID_COL}")
-                } else {
-                    "ORDER BY rowid".to_string()
-                };
+                    // Keep row order: prefer the persisted ordering column, falling
+                    // back to DuckDB's physical rowid (insertion order) for older
+                    // tables that predate it.
+                    let order_by = if has_col(OXEN_ROW_ID_COL) {
+                        format!("ORDER BY {OXEN_ROW_ID_COL}")
+                    } else {
+                        "ORDER BY rowid".to_string()
+                    };
 
-                // Honor the old soft-delete semantics: a row tombstoned as
-                // 'removed' is a pending deletion and must not be resurrected.
-                let where_clause = if has_col(LEGACY_DIFF_STATUS_COL) {
-                    format!("WHERE \"{LEGACY_DIFF_STATUS_COL}\" IS DISTINCT FROM 'removed'")
-                } else {
-                    String::new()
-                };
+                    // Honor the old soft-delete semantics: a row tombstoned as
+                    // 'removed' is a pending deletion and must not be resurrected.
+                    let where_clause = if has_col(LEGACY_DIFF_STATUS_COL) {
+                        format!("WHERE \"{LEGACY_DIFF_STATUS_COL}\" IS DISTINCT FROM 'removed'")
+                    } else {
+                        String::new()
+                    };
 
-                // Quote the table name as an identifier so it binds as a table
-                // reference rather than relying on DuckDB's string-literal
-                // replacement-scan fallback.
-                let select = format!(
-                    "SELECT {projection} FROM {} {where_clause} {order_by}",
-                    df_db::quote_ident(TABLE_NAME)
-                );
-                let copy = wrap_sql_for_export(&select, &recover_path);
-                conn.execute(&copy, [])?;
+                    // Quote the table name as an identifier so it binds as a table
+                    // reference rather than relying on DuckDB's string-literal
+                    // replacement-scan fallback.
+                    let select = format!(
+                        "SELECT {projection} FROM {} {where_clause} {order_by}",
+                        df_db::quote_ident(TABLE_NAME)
+                    );
+                    let copy = wrap_sql_for_export(&select, &recover_path);
+                    conn.execute(&copy, [])?;
 
-                // Rebuild inside a transaction: drop the stale table, then index
-                // the exported rows in the current format. On failure roll back
-                // so the original stale table is left intact.
-                conn.execute_batch("BEGIN TRANSACTION")?;
-                let build = (|| -> Result<(), DataFrameError> {
-                    df_db::drop_table(conn, TABLE_NAME)?;
-                    df_db::index_file_with_id(&recover_path, conn, &extension)?;
-                    Ok(())
-                })();
-                match build {
-                    Ok(()) => {
-                        conn.execute_batch("COMMIT")?;
-                        if let Err(e) = conn.execute_batch("CHECKPOINT") {
-                            log::warn!(
-                                "reindex_preserving_rows: CHECKPOINT failed for {db_path:?}: {e}"
-                            );
+                    // Rebuild inside a transaction: drop the stale table, then index
+                    // the exported rows in the current format. On failure roll back
+                    // so the original stale table is left intact.
+                    conn.execute_batch("BEGIN TRANSACTION")?;
+                    let build = (|| -> Result<(), DataFrameError> {
+                        df_db::drop_table(conn, TABLE_NAME)?;
+                        df_db::index_file_with_id(&recover_path, conn, &extension)?;
+                        Ok(())
+                    })();
+                    match build {
+                        Ok(()) => {
+                            conn.execute_batch("COMMIT")?;
+                            if let Err(e) = conn.execute_batch("CHECKPOINT") {
+                                log::warn!(
+                                    "reindex: CHECKPOINT after rebuild failed for {db_path:?}: {e}"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            let _ = conn.execute_batch("ROLLBACK");
+                            return Err(e);
                         }
                     }
-                    Err(e) => {
-                        let _ = conn.execute_batch("ROLLBACK");
-                        return Err(e);
-                    }
-                }
-                Ok(true)
+                    Ok(true)
+                })();
+                // Clean up the intermediate export regardless of the rebuild's result, and before
+                // releasing the connection: every recovery of this data frame in this process
+                // exports to the same path, so removing it after the connection is released can
+                // delete an export that a second recovery has just written and is about to read.
+                let _ = std::fs::remove_file(&recover_path);
+                outcome
             })
         });
-        // Clean up the intermediate export regardless of the rebuild's result.
-        let _ = std::fs::remove_file(&recover_path);
         Ok(outcome?)
     })
     .await??;
@@ -506,22 +515,60 @@ pub async fn rename(
 
     // Handle duckdb file operations first
     let og_db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
-    let og_db_path_parent = og_db_path.parent().unwrap();
     let new_db_path = repositories::workspaces::data_frames::duckdb_path(workspace, new_path);
-    let new_db_path_parent = new_db_path.parent().unwrap();
 
-    // The source database is closed and held while its files are copied and removed, so nothing
-    // can write into a database that is about to be deleted. Closing checkpoints the WAL into the
-    // database file first, so the copy carries a whole database and no WAL file that would be
-    // replayed against the copy.
-    with_db_closed(&og_db_path, || -> Result<(), OxenError> {
-        if !new_db_path_parent.exists() {
-            util::fs::create_dir_all(new_db_path_parent)?;
-        }
-        util::fs::copy_dir_all(og_db_path_parent, new_db_path_parent)?;
-        util::fs::remove_dir_all(og_db_path_parent)?;
-        Ok(())
-    })?;
+    // A rename onto the data frame's own path changes nothing, and carrying on would destroy it:
+    // the move removes the destination directory, which is the data frame's own, and the staged
+    // entry is upserted at the new path only to be deleted at the old one, which is the same entry.
+    // Compared by DuckDB path, the data frame's identity, so two spellings of one path count as
+    // the same data frame.
+    if og_db_path == new_db_path {
+        return util::fs::path_relative_to_dir(new_path, &workspace_repo.path);
+    }
+
+    let Some(og_db_path_parent) = og_db_path.parent().map(Path::to_path_buf) else {
+        return Err(OxenError::basic_str(format!(
+            "Failed to get parent directory for {og_db_path:?}"
+        )));
+    };
+    let Some(new_db_path_parent) = new_db_path.parent().map(Path::to_path_buf) else {
+        return Err(OxenError::basic_str(format!(
+            "Failed to get parent directory for {new_db_path:?}"
+        )));
+    };
+
+    // Both databases closed and held for the move. The source's directory is moved away, so a
+    // connection left open on it would write into files that are gone; renaming onto an existing
+    // data frame replaces the destination's directory, so a connection left open on it would go
+    // on serving a catalog and pages for files that no longer exist. Closing checkpoints each WAL
+    // into its own database file first, so the moved directory carries a whole database. Taken in
+    // sorted path order, which is what keeps two renames between the same pair from deadlocking by
+    // taking them in opposite orders. The two are always distinct here, since a rename onto the
+    // same data frame returned above, so taking both never asks a non-reentrant hold for a second
+    // entry.
+    //
+    // All of it on the blocking pool: waiting for the holds, and then the filesystem work they
+    // guard. Only the staged-entry work below still runs on the async worker.
+    tokio::task::spawn_blocking(move || {
+        let move_db = || -> Result<(), OxenError> {
+            // Replace the destination's directory rather than merge into it. A file left over
+            // from the destination's own database, its WAL above all, would otherwise sit beside
+            // the moved database and be replayed against it on the next open.
+            if new_db_path_parent.exists() {
+                util::fs::remove_dir_all(&new_db_path_parent)?;
+            }
+            util::fs::rename(&og_db_path_parent, &new_db_path_parent)?;
+            Ok(())
+        };
+
+        let (first, second) = if og_db_path < new_db_path {
+            (&og_db_path, &new_db_path)
+        } else {
+            (&new_db_path, &og_db_path)
+        };
+        with_db_closed(first, || with_db_closed(second, move_db))
+    })
+    .await??;
 
     // Use staged_db_manager
     let staged_db_manager = get_staged_db_manager(workspace_repo)?;

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -83,6 +83,8 @@ pub async fn reindex_preserving_rows(workspace: &Workspace, path: &Path) -> Resu
 
 pub use crate::core::v_latest::workspaces::data_frames::rename;
 
+/// Drop the staged table for `path`, discarding any staged edits it holds. The path has to be
+/// indexed again before it can be edited.
 pub fn unindex(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), DataFrameError> {
     let path = path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
@@ -100,11 +102,23 @@ pub async fn restore(
     workspace: &Workspace,
     path: impl AsRef<Path>,
 ) -> Result<(), OxenError> {
-    // Unstage and then restage the df
-    unindex(workspace, &path)?;
+    let path = path.as_ref();
+    // Unstage and then restage the df.
+    //
+    // Two separate steps, not one: the data frame's connection cannot be held across the `.await`
+    // below. A row write landing in the gap therefore fails rather than being silently
+    // discarded by the rebuild, which is the right outcome for a caller that asked for the staged
+    // edits to be thrown away. The index check in oxen-server is what turns that into a clean
+    // rejection (`OxenHttpError::DatasetNotIndexed`).
+    //
+    // `unindex` waits for the data frame's connection, which a rebuild can hold for a whole file
+    // parse, so it runs on the blocking pool rather than the async worker.
+    let unindex_workspace = workspace.clone();
+    let unindex_path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || unindex(&unindex_workspace, unindex_path)).await??;
 
     // TODO: we could do this more granularly without a full reset
-    index(repo, workspace, path.as_ref()).await?;
+    index(repo, workspace, path).await?;
 
     Ok(())
 }
@@ -485,7 +499,8 @@ mod tests {
     use std::path::Path;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::time::SystemTime;
+    use std::sync::mpsc;
+    use std::time::{Duration, SystemTime};
 
     use serde_json::json;
 
@@ -511,6 +526,168 @@ mod tests {
         fn drop(&mut self) {
             self.0.store(true, Ordering::Relaxed);
         }
+    }
+
+    /// `rename` holds the destination data frame as well as the source. It replaces the
+    /// destination's DuckDB directory with the source's, so a write to the destination that
+    /// overlapped would be lost. Holding the destination's connection must therefore make the
+    /// rename wait.
+    #[tokio::test]
+    async fn test_rename_waits_for_a_write_to_the_destination() -> Result<(), OxenError> {
+        // Skip duckdb if on windows
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+
+        test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
+            let branch = repositories::branches::create_checkout(&repo, "test-rename-dest-lock")?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?
+                .expect("branch should have a commit");
+            let workspace =
+                repositories::workspaces::create(&repo, &commit, UserConfig::identifier()?, true)?;
+            let file_path = Path::new("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+            let new_path = Path::new("annotations").join("train").join("renamed.csv");
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+
+            // Hold the destination's connection from another thread until this test releases it.
+            let (holding_tx, holding_rx) = mpsc::channel();
+            let (release_tx, release_rx) = mpsc::channel();
+            let dest_db_path = workspaces::data_frames::duckdb_path(&workspace, &new_path);
+            let holder = std::thread::spawn(move || {
+                with_df_db_manager(&dest_db_path, |manager| {
+                    manager.with_conn(|_conn| {
+                        holding_tx.send(()).expect("signal the destination is held");
+                        release_rx.recv().expect("await release");
+                        Ok(())
+                    })
+                })
+                .expect("hold the destination's connection");
+            });
+            holding_rx.recv().expect("destination connection should be held");
+
+            // `rename` waits for the hold on the blocking pool, so awaiting it here cannot stall
+            // this test's runtime.
+            let mut renamer = tokio::spawn({
+                let workspace = workspace.clone();
+                let file_path = file_path.clone();
+                let new_path = new_path.clone();
+                async move {
+                    workspaces::data_frames::rename(&workspace, &file_path, &new_path).await
+                }
+            });
+
+            assert!(
+                tokio::time::timeout(Duration::from_millis(500), &mut renamer)
+                    .await
+                    .is_err(),
+                "rename proceeded while a write to the destination was in flight"
+            );
+
+            release_tx.send(()).expect("release the destination");
+            tokio::time::timeout(Duration::from_secs(30), renamer)
+                .await
+                .expect("rename should finish once the destination is released")
+                .expect("join the rename task")?;
+
+            holder.join().expect("join the destination holder");
+
+            Ok(())
+        })
+        .await
+    }
+
+    /// Renaming a data frame onto its own path leaves it exactly as it was. Carrying on through
+    /// the move would remove its DuckDB directory as the destination, and delete the staged entry
+    /// it had just written at the same path.
+    #[tokio::test]
+    async fn test_rename_to_the_same_path_leaves_the_data_frame_alone() -> Result<(), OxenError> {
+        // Skip duckdb if on windows
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+
+        test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
+            let branch = repositories::branches::create_checkout(&repo, "test-rename-same-path")?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?
+                .expect("branch should have a commit");
+            let workspace =
+                repositories::workspaces::create(&repo, &commit, UserConfig::identifier()?, true)?;
+            let file_path = Path::new("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+            let rows_before = workspaces::data_frames::count(&workspace, &file_path)?;
+
+            workspaces::data_frames::rename(&workspace, &file_path, &file_path).await?;
+
+            assert!(
+                workspaces::data_frames::is_indexed(&workspace, &file_path)?,
+                "renaming a data frame onto its own path unindexed it"
+            );
+            assert_eq!(
+                workspaces::data_frames::count(&workspace, &file_path)?,
+                rows_before,
+                "renaming a data frame onto its own path changed its rows"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    /// `rename` replaces the destination's DuckDB directory with the source's, so a connection the
+    /// destination had open no longer describes the files at that path. It has to be closed along
+    /// with the source's, or reads of the renamed-to path keep going to the old database.
+    #[tokio::test]
+    async fn test_rename_drops_the_destinations_cached_connection() -> Result<(), OxenError> {
+        // Skip duckdb if on windows
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+
+        test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
+            // A second committed data frame to rename onto, with a row count of its own.
+            let dest_path = Path::new("annotations").join("train").join("two_rows.csv");
+            test::write_txt_file_to_path(
+                repo.path.join(&dest_path),
+                "file,label\ntrain/dog_9.jpg,dog\ntrain/cat_9.jpg,cat\n",
+            )?;
+            repositories::add(&repo, &repo.path).await?;
+            let commit = repositories::commit(&repo, "add a data frame to rename onto")?;
+
+            let workspace =
+                repositories::workspaces::create(&repo, &commit, UserConfig::identifier()?, true)?;
+            let source_path = Path::new("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+
+            // Indexing leaves each data frame's connection in the cache, which is what makes a
+            // stale destination connection reachable after the rename.
+            workspaces::data_frames::index(&repo, &workspace, &source_path).await?;
+            workspaces::data_frames::index(&repo, &workspace, &dest_path).await?;
+
+            let source_rows = workspaces::data_frames::count(&workspace, &source_path)?;
+            let dest_rows = workspaces::data_frames::count(&workspace, &dest_path)?;
+            assert_ne!(
+                source_rows, dest_rows,
+                "the two data frames need different row counts for the assertion below to \
+                 distinguish them"
+            );
+
+            workspaces::data_frames::rename(&workspace, &source_path, &dest_path).await?;
+
+            assert_eq!(
+                workspaces::data_frames::count(&workspace, &dest_path)?,
+                source_rows,
+                "reading the renamed-to path served the destination's pre-rename database"
+            );
+
+            Ok(())
+        })
+        .await
     }
 
     /// Every concurrent append to one data frame lands, with the connection cache under enough


### PR DESCRIPTION
Follow-up to #921. `rename` now closes and holds both the source and the destination through the move (sorted order, on the blocking pool), replaces the destination directory instead of merging into it, and is a no-op onto the data frame's own path. `reindex_preserving_rows` cleans up its export inside the connection hold, and `restore` runs `unindex` on the blocking pool.

Three rename tests: the rename waits for a held destination, a same-path rename leaves the data frame alone, and a stale destination connection is not served after the rename.

#898 stacks on this.
