### PR TITLE
Rebuild a listed workspace data frame only when its staged table is not fully indexed

### DIFF
--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
@@ -211,7 +211,26 @@ pub fn get_queryable_data_frame_workspace(
     get_queryable_data_frame_workspace_from_file_node(repo, &commit.id.parse()?, path)
 }
 
+/// Rebuild the staged table for `path` from the committed file, discarding any staged edits.
 pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
+    p_index(workspace, path, Rebuild::Always).await
+}
+
+/// Index `path` unless its staged table is already fully indexed. A table that is missing, or
+/// that lacks an Oxen tracking column, is rebuilt from the committed file; a fully indexed table
+/// keeps the staged edits it holds.
+pub async fn index_if_absent(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
+    p_index(workspace, path, Rebuild::OnlyIfAbsent).await
+}
+
+/// Whether [`p_index`] rebuilds a table that is already fully indexed.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Rebuild {
+    Always,
+    OnlyIfAbsent,
+}
+
+async fn p_index(workspace: &Workspace, path: &Path, rebuild: Rebuild) -> Result<(), OxenError> {
     // Is tabular just looks at the file extensions
     let file_node =
         repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
@@ -252,6 +271,23 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     };
     util::fs::create_dir_all(parent)?;
 
+    // Fast path: an already-indexed table needs no committed file, and materializing one is a
+    // whole-file fetch from the version store. This read is advisory only. The authoritative check
+    // is the one inside the connection hold below, which is what makes the decision and the
+    // rebuild atomic, so a table that looks indexed here and is gone by then still rebuilds.
+    if rebuild == Rebuild::OnlyIfAbsent {
+        let db_path = db_path.clone();
+        let already_indexed = tokio::task::spawn_blocking(move || {
+            with_df_db_manager(&db_path, |manager| {
+                manager.with_conn(|conn| Ok(df_db::table_is_fully_indexed(conn, TABLE_NAME)?))
+            })
+        })
+        .await??;
+        if already_indexed {
+            return Ok(());
+        }
+    }
+
     let version_store = repo.version_store();
     let hash_str = file_hash.to_string();
 
@@ -277,8 +313,17 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     // (it never crosses an `.await`), and `version_file` is held on the async side until the
     // blocking work finishes, so a materialized S3 temp file outlives the read.
     tokio::task::spawn_blocking(move || {
+        // The connection is held for the whole closure. Under `OnlyIfAbsent` that also covers the
+        // fully-indexed check, so the rebuild cannot proceed on a table another caller populated
+        // after the caller's own check.
         with_df_db_manager(&db_path, |manager| {
             manager.with_conn(|conn| {
+                if rebuild == Rebuild::OnlyIfAbsent
+                    && df_db::table_is_fully_indexed(conn, TABLE_NAME)?
+                {
+                    return Ok(());
+                }
+
                 // Drop any prior table (possibly partial or stale) and commit that
                 // drop before the rebuild, so a failed rebuild leaves no table at
                 // all rather than rolling back to a partial one.

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -66,12 +66,28 @@ pub fn is_queryable_data_frame_indexed(
 
 pub use crate::core::v_latest::workspaces::data_frames::get_queryable_data_frame_workspace;
 
+/// Rebuild the staged table for `path` from the committed file, discarding any staged edits.
 pub async fn index(
     _repo: &LocalRepository,
     workspace: &Workspace,
     path: impl AsRef<Path>,
 ) -> Result<(), OxenError> {
     core::v_latest::workspaces::data_frames::index(workspace, path.as_ref()).await
+}
+
+/// Index `path` unless its staged table is already fully indexed. A table that is missing, or
+/// that lacks an Oxen tracking column, is rebuilt from the committed file; a fully indexed table
+/// keeps the staged edits it holds.
+///
+/// The check and the rebuild run under one hold on the data frame's connection, so a rebuild can
+/// never be authorized by a check that another caller has since invalidated. Callers that want a
+/// rebuild regardless of the current contents want [`index`].
+pub async fn index_if_absent(
+    _repo: &LocalRepository,
+    workspace: &Workspace,
+    path: impl AsRef<Path>,
+) -> Result<(), OxenError> {
+    core::v_latest::workspaces::data_frames::index_if_absent(workspace, path.as_ref()).await
 }
 
 /// Rebuild a staged data frame left by an older version of oxen from its own
@@ -88,6 +104,10 @@ pub use crate::core::v_latest::workspaces::data_frames::rename;
 pub fn unindex(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), DataFrameError> {
     let path = path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
+    // Nothing to drop, and opening the database here would create an empty one.
+    if !db_path.exists() {
+        return Ok(());
+    }
 
     with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
@@ -787,6 +807,97 @@ mod tests {
 
             drop(stopper);
             evictor.await.expect("join evictor task");
+
+            Ok(())
+        })
+        .await
+    }
+
+    /// `index_if_absent` builds a staged table that is missing or incomplete but never rebuilds one
+    /// that is fully indexed, so a caller acting on a stale "not indexed" observation cannot
+    /// discard rows staged since. `index` still rebuilds unconditionally, which is what `restore`
+    /// depends on.
+    #[tokio::test]
+    async fn test_index_if_absent_leaves_staged_rows_alone() -> Result<(), OxenError> {
+        // Skip duckdb if on windows
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+
+        test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
+            let branch = repositories::branches::create_checkout(&repo, "test-index-if-absent")?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?
+                .expect("branch should have a commit");
+            let workspace =
+                repositories::workspaces::create(&repo, &commit, UserConfig::identifier()?, true)?;
+            let file_path = Path::new("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+
+            // Absent: it builds the table.
+            assert!(!workspaces::data_frames::is_indexed(
+                &workspace, &file_path
+            )?);
+            workspaces::data_frames::index_if_absent(&repo, &workspace, &file_path).await?;
+            assert!(workspaces::data_frames::is_indexed(&workspace, &file_path)?);
+            let committed_rows = workspaces::data_frames::count(&workspace, &file_path)?;
+
+            let json_data = json!({
+                "file": "staged.jpg",
+                "label": "dog",
+                "min_x": 1.0,
+                "min_y": 2.0,
+                "width": 10.0,
+                "height": 10.0
+            });
+            workspaces::data_frames::rows::add(&repo, &workspace, &file_path, &json_data)?;
+            assert_eq!(
+                workspaces::data_frames::count(&workspace, &file_path)?,
+                committed_rows + 1
+            );
+
+            // Present: the staged row survives a second call.
+            workspaces::data_frames::index_if_absent(&repo, &workspace, &file_path).await?;
+            assert_eq!(
+                workspaces::data_frames::count(&workspace, &file_path)?,
+                committed_rows + 1,
+                "index_if_absent rebuilt an already-indexed frame and discarded its staged row"
+            );
+
+            // The unconditional form is unchanged: it rebuilds from the commit.
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+            assert_eq!(
+                workspaces::data_frames::count(&workspace, &file_path)?,
+                committed_rows,
+                "index must still rebuild from the committed file"
+            );
+
+            // Present but partial: a table missing `_oxen_id`, which is what an interrupted index
+            // leaves behind. It cannot be queried, so "absent" has to include it. Otherwise the
+            // frame stays unqueryable no matter how many times a caller asks for it.
+            let db_path = workspaces::data_frames::duckdb_path(&workspace, &file_path);
+            with_df_db_manager(&db_path, |manager| {
+                manager.with_conn(|conn| {
+                    conn.execute(
+                        &format!("ALTER TABLE \"{TABLE_NAME}\" DROP COLUMN \"{OXEN_ID_COL}\""),
+                        [],
+                    )?;
+                    Ok(())
+                })
+            })?;
+            assert!(!workspaces::data_frames::is_indexed(
+                &workspace, &file_path
+            )?);
+
+            workspaces::data_frames::index_if_absent(&repo, &workspace, &file_path).await?;
+            assert!(
+                workspaces::data_frames::is_indexed(&workspace, &file_path)?,
+                "index_if_absent must rebuild a partially-indexed table rather than keep it"
+            );
+            assert_eq!(
+                workspaces::data_frames::count(&workspace, &file_path)?,
+                committed_rows
+            );
 
             Ok(())
         })

--- a/crates/oxen-server/src/controllers/workspaces/data_frames.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames.rs
@@ -657,12 +657,14 @@ pub async fn put(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHtt
     let data: DataFramePayload = serde_json::from_str(&body)?;
     log::debug!("workspace {workspace_id} data frame put {data:?}");
 
-    let to_index = data.is_indexed;
-    let is_indexed = repositories::workspaces::data_frames::is_indexed(&workspace, &file_path)?;
-
-    if !is_indexed && to_index {
-        repositories::workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
-    } else if is_indexed && !to_index {
+    // Both branches decide under an exclusive hold on the data frame rather than on an
+    // `is_indexed` read taken here, so a rebuild cannot discard rows a row write committed
+    // between the read and the rebuild. `unindex` drops the table if it exists, so it needs no
+    // pre-check of its own.
+    if data.is_indexed {
+        repositories::workspaces::data_frames::index_if_absent(&repo, &workspace, &file_path)
+            .await?;
+    } else {
         repositories::workspaces::data_frames::unindex(&workspace, &file_path)?;
     }
 


### PR DESCRIPTION
Stacks on #897. Listing a workspace data frame with `is_indexed: true` used to read `is_indexed` in the handler and then call `index`, so two list requests could both see "not indexed" and the second rebuild discarded rows appended in between. `index_if_absent` makes the check and the rebuild one step inside the connection hold, and `index` stays unconditional for `restore`. `unindex` no longer creates an empty database for a path that was never indexed.

`test_index_if_absent_leaves_staged_rows_alone` covers absent, fully indexed, and partially indexed tables, and checks that `index` still discards.
