### PR TITLE
Pick up the runner action version that can still register a Windows runner

### DIFF
--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: Oxen-AI/ec2-github-runner-windows@v2.0.0
+        uses: Oxen-AI/ec2-github-runner-windows@v2.1.0
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
@@ -376,7 +376,7 @@ jobs:
           aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Stop EC2 runner
-        uses: Oxen-AI/ec2-github-runner-windows@v2.0.0
+        uses: Oxen-AI/ec2-github-runner-windows@v2.1.0
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Move the Windows release jobs onto the action release that resolves the actions/runner version at boot, so the runner it installs satisfies GitHub's minimum version for registration and the Windows half of a release stops timing out before the build starts.