### PR TITLE
Add `iter_keys` method to produce references to LMDB keys without allocating/copying the values

### DIFF
--- a/crates/liboxen/src/core/db/merkle_node/lmdb_merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/lmdb_merkle_node_store.rs
@@ -187,8 +187,8 @@ impl MerkleNodeStore for LmdbMerkleNodeStore {
             // Each complete node contributes two keys; key off the node-tagged one so each hash
             // appears once, and require the children key to also be present so an incomplete
             // record (node key without its children key) is not reported as a valid node.
-            for item in db.iter(txn)? {
-                let (key, _value) = item?;
+            for item in db.iter_keys(txn)? {
+                let key = item?;
                 if key.len() == KEY_LEN && key[16] == NODE_TAG {
                     let mut hash_le = [0u8; 16];
                     hash_le.copy_from_slice(&key[..16]);

--- a/crates/liboxen/src/lmdb/lmdb_db.rs
+++ b/crates/liboxen/src/lmdb/lmdb_db.rs
@@ -8,10 +8,10 @@
 //! multi-byte integer scanned in numeric order — would have to be encoded big-endian so byte order
 //! matches numeric order, so this layer does not model it (and exposes no scan API).
 //!
-//! READ SAFETY: every read COPIES the value out of the read txn into owned `bytes::Bytes` before
-//! returning. No method hands a caller a slice that borrows the mmap, so a returned value can
-//! outlive the short `RoTxn` it was read under — callers never have to keep a txn open just to
-//! hold onto a value.
+//! READ SAFETY: every value a read returns is COPIED out of the read txn into owned `bytes::Bytes`,
+//! so it can outlive the short `RoTxn` it was read under and no caller has to keep a txn open just
+//! to hold a value. Keys are copied the same way except in `iter_keys`, which borrows them from the
+//! mmap: its items cannot outlive the txn, so copy any key that has to be kept.
 
 use bytes::Bytes;
 use heed::types::{Bytes as HeedBytes, DecodeIgnore};

--- a/crates/liboxen/src/lmdb/lmdb_db.rs
+++ b/crates/liboxen/src/lmdb/lmdb_db.rs
@@ -99,6 +99,22 @@ impl LmdbDb {
         let inner = self.db.iter(txn).map_err(LmdbLayerError::Read)?;
         Ok(LmdbDbIter { inner })
     }
+
+    /// Iterate every key, borrowing each one out of the txn and leaving the value bytes undecoded.
+    /// Same full-scan, ordering-carries-no-meaning caveat as [`iter`][Self::iter]. Prefer this over
+    /// `iter` when the values are discarded. The borrowed keys cannot outlive the txn: copy any key
+    /// that has to be kept.
+    pub(crate) fn iter_keys<'txn>(
+        &self,
+        txn: &'txn RoTxn<'_, WithoutTls>,
+    ) -> Result<LmdbDbKeysIter<'txn>, LmdbLayerError> {
+        let inner = self
+            .db
+            .remap_data_type::<DecodeIgnore>()
+            .iter(txn)
+            .map_err(LmdbLayerError::Read)?;
+        Ok(LmdbDbKeysIter { inner })
+    }
 }
 
 /// Open or create a single named sub-database in `lmdb_env`, running the heed-required write txn.
@@ -125,6 +141,21 @@ impl Iterator for LmdbDbIter<'_> {
             item.map(|(key, value)| (Bytes::copy_from_slice(key), Bytes::copy_from_slice(value)))
                 .map_err(LmdbLayerError::Read),
         )
+    }
+}
+
+/// Full-scan iterator over a [`LmdbDb`]'s keys, yielding each key borrowed from the txn's mapped
+/// pages. Nothing is allocated per key, and the values are never decoded.
+pub(crate) struct LmdbDbKeysIter<'txn> {
+    inner: RoIter<'txn, HeedBytes, DecodeIgnore>,
+}
+
+impl<'txn> Iterator for LmdbDbKeysIter<'txn> {
+    type Item = Result<&'txn [u8], LmdbLayerError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let item = self.inner.next()?;
+        Some(item.map(|(key, ())| key).map_err(LmdbLayerError::Read))
     }
 }
 
@@ -226,6 +257,44 @@ mod tests {
                 (Bytes::from_static(b"c"), Bytes::from_static(b"3")),
             ]
         );
+    }
+
+    #[test]
+    fn iter_keys_yields_every_key_without_the_values() {
+        let (_dir, lmdb_env) = test_lmdb_env();
+        let db =
+            with_write_txn(&lmdb_env, |txn| LmdbDb::open(&lmdb_env, txn, "kv")).expect("open db");
+        with_write_txn(&lmdb_env, |txn| {
+            db.put(txn, b"c", b"3")?;
+            db.put(txn, b"a", b"1")?;
+            db.put(txn, b"b", b"2")
+        })
+        .expect("put");
+
+        // The keys borrow from the txn, so anything kept past the closure is copied here.
+        let keys: Vec<Bytes> = with_read_txn(&lmdb_env, |txn| {
+            db.iter_keys(txn)?
+                .map(|item| item.map(Bytes::copy_from_slice))
+                .collect::<Result<_, _>>()
+        })
+        .expect("iterate keys");
+        assert_eq!(
+            keys,
+            vec![
+                Bytes::from_static(b"a"),
+                Bytes::from_static(b"b"),
+                Bytes::from_static(b"c"),
+            ]
+        );
+
+        // Same keys, same order as the pair-yielding iterator.
+        let paired: Vec<Bytes> = with_read_txn(&lmdb_env, |txn| {
+            db.iter(txn)?
+                .map(|item| item.map(|(key, _)| key))
+                .collect::<Result<_, _>>()
+        })
+        .expect("iterate pairs");
+        assert_eq!(keys, paired);
     }
 
     #[test]


### PR DESCRIPTION
`list_hashes` walks the whole node store to collect the keys (hashes) but discards every value, which is relatively expensive because each value is copied into a newly-allocated `Bytes`.

This PR adds `LmdbDb::iter_keys` which borrows each key and avoids allocating anything, and changes `list_hashes` to use it.

ENG-1234