### PR TITLE
Export tracing events as OTLP log records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4777,6 +4777,7 @@ dependencies = [
  "mp4",
  "num_cpus",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "os_path",
@@ -5762,6 +5763,18 @@ dependencies = [
  "pin-project-lite",
  "thiserror 2.0.20",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,12 @@ mockito = "1.1.0"
 mp4 = "0.14.0"
 num_cpus = "1.16.0"
 opentelemetry = "0.32"
+# Bridges `tracing` events to OTLP log records. Its minor tracks the `opentelemetry` family's, so
+# bump the two together. It reads the trace and span id off whatever OpenTelemetry context is
+# current rather than off the `tracing` span, which only lines up because `tracing-opentelemetry`
+# activates a span's context on entry; a build that turns that off exports log records with no
+# trace id.
+opentelemetry-appender-tracing = "0.32"
 # The OTLP/HTTP encoding is chosen by this feature list, not at runtime. Binary protobuf comes
 # from the default "http-proto"; adding "http-json" back would make JSON the exporter's default
 # encoding, which is why the builder names its encoding instead of inheriting it.
@@ -113,14 +119,7 @@ opentelemetry = "0.32"
 # "tls-roots" supplies the platform trust store that `ClientTlsConfig::with_native_roots()` reads,
 # and "tls-ring" supplies the crypto provider it runs on. Without a provider feature the gRPC
 # exporter refuses to build for an `https://` endpoint, which disables export.
-opentelemetry-otlp = { version = "0.32", features = [
-    "grpc-tonic",
-    "gzip-http",
-    "gzip-tonic",
-    "tls-ring",
-    "tls-roots",
-    "trace",
-] }
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "gzip-http", "gzip-tonic", "logs", "tls-ring", "tls-roots", "trace"] }
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
 os_path = "0.8.0"
 page_size = "0.6.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,9 +91,10 @@ RUN cargo chef cook --release --features liboxen/ffmpeg,oxen-server/otel \
     -p oxen-cli -p oxen-server --recipe-path recipe.json
 
 COPY . .
-# `oxen-server/otel` compiles the OTLP span exporter and inbound W3C trace-context extraction into
-# the binary; both stay dormant until an OTLP endpoint is configured at runtime. Named explicitly
-# rather than via the `production` feature, which additionally turns on `perf-logging`.
+# `oxen-server/otel` compiles the OTLP span and log-record exporters and inbound W3C trace-context
+# extraction into the binary; all stay dormant until an OTLP endpoint is configured at runtime, and
+# log export additionally waits on OTEL_LOGS_EXPORTER. Named explicitly rather than via the
+# `production` feature, which additionally turns on `perf-logging`.
 RUN cargo build --workspace --exclude oxen-py --release --features liboxen/ffmpeg,oxen-server/otel
 
 # The CLI ships without a symbol table. Only oxen-server reports panics.

--- a/crates/liboxen/Cargo.toml
+++ b/crates/liboxen/Cargo.toml
@@ -37,6 +37,7 @@ metrics = ["dep:metrics"]
 otel = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
+    "dep:opentelemetry-appender-tracing",
     "dep:opentelemetry-otlp",
     "dep:tracing-opentelemetry",
 ]
@@ -99,6 +100,7 @@ minus = { workspace = true }
 mp4 = { workspace = true }
 num_cpus = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
+opentelemetry-appender-tracing = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 os_path = { workspace = true }

--- a/crates/liboxen/src/util/telemetry.rs
+++ b/crates/liboxen/src/util/telemetry.rs
@@ -38,10 +38,12 @@ pub struct TracingGuard {
     _file_guard: Option<WorkerGuard>,
     #[cfg(feature = "otel")]
     _tracer_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+    #[cfg(feature = "otel")]
+    _logger_provider: Option<opentelemetry_sdk::logs::SdkLoggerProvider>,
 }
 
 impl TracingGuard {
-    /// Export whatever spans are still queued and stop the OTLP pipeline.
+    /// Export whatever spans and log records are still queued and stop the OTLP pipelines.
     ///
     /// An async program should await this before its last return to the runtime, and is the reason
     /// this method exists: the exporter's transport is a task on that runtime, so the flush only
@@ -53,30 +55,43 @@ impl TracingGuard {
     /// Idempotent, and a no-op without an OTLP endpoint configured.
     pub async fn shutdown(&self) {
         #[cfg(feature = "otel")]
-        if let Some(provider) = self._tracer_provider.clone() {
-            // The provider's shutdown blocks until the batch processor has drained, so it goes to
-            // the blocking pool; awaiting the handle leaves the runtime free to carry the spans.
-            match tokio::task::spawn_blocking(move || shutdown_provider(&provider)).await {
-                Ok(()) => {}
-                Err(e) => eprintln!("warning: OTel tracer provider shutdown task failed: {e}"),
+        {
+            let tracer_provider = self._tracer_provider.clone();
+            let logger_provider = self._logger_provider.clone();
+            if tracer_provider.is_none() && logger_provider.is_none() {
+                return;
+            }
+            // A provider's shutdown blocks until its batch processor has drained, so it goes to
+            // the blocking pool; awaiting the handle leaves the runtime free to carry the batches.
+            let flush = tokio::task::spawn_blocking(move || {
+                if let Some(provider) = tracer_provider {
+                    report_shutdown("tracer", provider.shutdown());
+                }
+                if let Some(provider) = logger_provider {
+                    report_shutdown("logger", provider.shutdown());
+                }
+            });
+            if let Err(e) = flush.await {
+                eprintln!("warning: OTel provider shutdown task failed: {e}");
             }
         }
     }
 }
 
-/// Shut down `provider`, reporting anything but success and an already-completed shutdown.
+/// Report the result of shutting down the `what` provider, ignoring an already-completed shutdown.
 ///
-/// The global subscriber holds an Arc clone of the tracer provider (via OpenTelemetryLayer →
-/// SdkTracer → SdkTracerProvider), so dropping the provider alone never brings the Arc refcount to
-/// zero — `TracerProviderInner::drop()` never fires, and the `BatchSpanProcessor`'s pending spans
-/// are never flushed. Shutting it down explicitly is what exports them.
+/// The global subscriber holds an Arc clone of each provider (the tracer provider via
+/// OpenTelemetryLayer → SdkTracer → SdkTracerProvider, the logger provider via
+/// OpenTelemetryTracingBridge → SdkLogger → SdkLoggerProvider), so dropping a provider alone never
+/// brings the Arc refcount to zero — its inner `drop()` never fires, and the batch processor's
+/// pending records are never flushed. Shutting it down explicitly is what exports them.
 #[cfg(feature = "otel")]
-fn shutdown_provider(provider: &opentelemetry_sdk::trace::SdkTracerProvider) {
-    match provider.shutdown() {
+fn report_shutdown(what: &str, result: opentelemetry_sdk::error::OTelSdkResult) {
+    match result {
         // Already done by an earlier call, the atexit handler, or Drop. All three routes are
         // expected, and the SDK guards against double-shutdown with an atomic flag.
         Ok(()) | Err(opentelemetry_sdk::error::OTelSdkError::AlreadyShutdown) => {}
-        Err(e) => eprintln!("warning: OTel tracer provider shutdown failed: {e}"),
+        Err(e) => eprintln!("warning: OTel {what} provider shutdown failed: {e}"),
     }
 }
 
@@ -85,34 +100,56 @@ impl Drop for TracingGuard {
         // The last-resort flush, for a synchronous program and for an async one that returned
         // without awaiting `shutdown`. See that method for why it is not enough on its own.
         #[cfg(feature = "otel")]
-        if let Some(ref provider) = self._tracer_provider {
-            shutdown_provider(provider);
+        {
+            if let Some(ref provider) = self._tracer_provider {
+                report_shutdown("tracer", provider.shutdown());
+            }
+            if let Some(ref provider) = self._logger_provider {
+                report_shutdown("logger", provider.shutdown());
+            }
         }
     }
 }
 
-/// Ensures the OTel tracer provider is shut down (and pending spans flushed)
-/// when the process exits, even if [`TracingGuard`] is stored in a static
-/// whose `Drop` impl will never run.
+/// Ensures the OTel providers are shut down (and pending spans and log
+/// records flushed) when the process exits, even if [`TracingGuard`] is stored
+/// in a static whose `Drop` impl will never run.
 ///
-/// A clone of the [`SdkTracerProvider`] is stored in a process-global
-/// [`OnceLock`] and a C `atexit` callback is registered to call `shutdown()`
-/// on it. `shutdown()` is idempotent (guarded by an atomic flag), so it is
-/// safe for both [`TracingGuard::drop`] and the `atexit` handler to call it.
+/// A clone of each provider is stored in a process-global [`OnceLock`] and a C
+/// `atexit` callback is registered to call `shutdown()` on it. `shutdown()` is
+/// idempotent (guarded by an atomic flag), so it is safe for both
+/// [`TracingGuard::drop`] and the `atexit` handler to call it.
 #[cfg(feature = "otel")]
 mod atexit_flush {
-    use std::sync::OnceLock;
+    use std::sync::{Once, OnceLock};
 
-    static PROVIDER: OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> = OnceLock::new();
+    static TRACER_PROVIDER: OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> = OnceLock::new();
+    static LOGGER_PROVIDER: OnceLock<opentelemetry_sdk::logs::SdkLoggerProvider> = OnceLock::new();
+    static HANDLER: Once = Once::new();
 
     extern "C" fn on_exit() {
-        if let Some(provider) = PROVIDER.get() {
+        if let Some(provider) = TRACER_PROVIDER.get() {
+            let _ = provider.shutdown();
+        }
+        if let Some(provider) = LOGGER_PROVIDER.get() {
             let _ = provider.shutdown();
         }
     }
 
-    /// Store a clone of the provider and register the `atexit` callback.
-    /// Only the first call has any effect; subsequent calls are no-ops.
+    /// Flush this tracer provider from the `atexit` handler.
+    pub(super) fn register_tracer(provider: opentelemetry_sdk::trace::SdkTracerProvider) {
+        let _ = TRACER_PROVIDER.set(provider);
+        register();
+    }
+
+    /// Flush this logger provider from the `atexit` handler.
+    pub(super) fn register_logger(provider: opentelemetry_sdk::logs::SdkLoggerProvider) {
+        let _ = LOGGER_PROVIDER.set(provider);
+        register();
+    }
+
+    /// Register the `atexit` callback. Only the first call has any effect;
+    /// subsequent calls are no-ops, so the two providers share one handler.
     ///
     /// # Safety
     ///
@@ -123,24 +160,22 @@ mod atexit_flush {
     ///   every platform this project targets (Linux, macOS, Windows).
     /// - The registered callback (`on_exit`) is an `extern "C" fn` with no
     ///   captures, satisfying `atexit`'s function-pointer requirement.
-    /// - `on_exit` only accesses `PROVIDER`, a `OnceLock` that is `Sync` and
-    ///   fully initialized before the callback can ever fire.
-    /// - `SdkTracerProvider::shutdown()` is synchronous, blocking, and
+    /// - `on_exit` only accesses `TRACER_PROVIDER` and `LOGGER_PROVIDER`, both
+    ///   `OnceLock`s that are `Sync` and fully initialized before the callback
+    ///   can ever fire.
+    /// - Each provider's `shutdown()` is synchronous, blocking, and
     ///   idempotent (guarded by an atomic flag), so it is safe to call from
     ///   the single-threaded `atexit` context even if [`TracingGuard::drop`]
     ///   already called it.
-    pub(super) fn register(provider: opentelemetry_sdk::trace::SdkTracerProvider) -> bool {
-        if PROVIDER.set(provider).is_err() {
-            return false;
-        }
-        unsafe extern "C" {
-            safe fn atexit(f: extern "C" fn()) -> core::ffi::c_int;
-        }
-        let registered = atexit(on_exit) == 0;
-        if !registered {
-            eprintln!("warning: failed to register OTel atexit flush handler");
-        }
-        registered
+    fn register() {
+        HANDLER.call_once(|| {
+            unsafe extern "C" {
+                safe fn atexit(f: extern "C" fn()) -> core::ffi::c_int;
+            }
+            if atexit(on_exit) != 0 {
+                eprintln!("warning: failed to register OTel atexit flush handler");
+            }
+        });
     }
 }
 
@@ -168,13 +203,21 @@ mod atexit_flush {
 /// `"http/protobuf"`, or `"http/json"`, where the last three all mean HTTP. Unset, it defaults to
 /// HTTP. Spans are encoded as binary protobuf under either transport.
 ///
+/// **OTLP log export** (opt-in via `OTEL_LOGS_EXPORTER=otlp`, requires the `otel` feature): also
+/// export events as OTLP log records, over the endpoint and transport span export already uses.
+/// `none` or unset leaves it off, and stdout logging is unaffected either way. Each record carries
+/// the trace and span id of the span the event was recorded in, which is what correlates a log
+/// line with its trace.
+///
 /// **Filtering** is per-layer, not global. `RUST_LOG` (falling back to `default`) gates the log
-/// destinations — stderr, the JSON file, and the caller-supplied layer. Span export is gated
+/// destinations — stderr, the JSON file, and the caller-supplied layer. OTLP export is gated
 /// separately by `OXEN_OTEL_FILTER`, defaulting to `info`, the level `#[tracing::instrument]` and
 /// the HTTP root span are recorded at. Traces therefore export at the stock `RUST_LOG` level, and
 /// raising log verbosity for debugging does not change what is exported. Either variable set to a
 /// value the filter parser cannot use falls back to the level that applies when it is unset, and
-/// names the rejected directives on stderr.
+/// names the rejected directives on stderr. `OXEN_OTEL_FILTER` gates spans and OTLP log records
+/// alike, except that log records never carry the exporter's own crates; see
+/// [`OTEL_LOG_EXCLUDED_TARGETS`].
 ///
 /// Returns a [TracingGuard]. The caller **must** hold the guard in a named binding for the
 /// lifetime of the application — dropping it flushes the non-blocking writer and stops span
@@ -251,25 +294,50 @@ pub fn init_tracing_with_layer(
     // concrete subscriber type (`S`) changes with each `.with()` call and
     // `OpenTelemetryLayer<S, T>` must match the exact inner subscriber.
     #[cfg(feature = "otel")]
-    let (m_otel_layer, m_tracer_provider, m_endpoint_p) = match otel_endpoint() {
-        Some((var, endpoint)) => {
-            let protocol = otel_protocol()?;
+    let (m_otel_layer, m_tracer_provider, m_endpoint_p) =
+        match otel_endpoint("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") {
+            Some((var, endpoint)) => {
+                let protocol = otel_protocol("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")?;
 
-            match build_otel_layer(app_name, &protocol) {
-                (Some(layer), Some(provider)) => {
-                    atexit_flush::register(provider.clone());
-                    (
-                        Some(layer),
-                        Some(provider),
-                        Some(format!("{protocol} (protobuf) -> {var}={endpoint}")),
-                    )
+                match build_otel_layer(app_name, &protocol) {
+                    (Some(layer), Some(provider)) => {
+                        atexit_flush::register_tracer(provider.clone());
+                        (
+                            Some(layer),
+                            Some(provider),
+                            Some(format!("{protocol} (protobuf) -> {var}={endpoint}")),
+                        )
+                    }
+                    _ => (None, None, None),
                 }
-                _ => (None, None, None),
             }
-        }
 
-        None => (None, None, None),
-    };
+            None => (None, None, None),
+        };
+
+    // The OTLP log pipeline, a second exporter over the same endpoint and transport. Independent
+    // of the span pipeline: either can be configured, fail to build, or be left off on its own.
+    #[cfg(feature = "otel")]
+    let (m_log_layer, m_logger_provider, m_log_endpoint_p) =
+        match otel_endpoint("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT").filter(|_| otel_logs_enabled()) {
+            Some((var, endpoint)) => {
+                let protocol = otel_protocol("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL")?;
+
+                match build_otel_log_layer(app_name, &protocol) {
+                    Some((layer, provider)) => {
+                        atexit_flush::register_logger(provider.clone());
+                        (
+                            Some(layer),
+                            Some(provider),
+                            Some(format!("{protocol} (protobuf) -> {var}={endpoint}")),
+                        )
+                    }
+                    None => (None, None, None),
+                }
+            }
+
+            None => (None, None, None),
+        };
 
     // .try_init() also installs the tracing-log bridge (forwarding log::* calls into tracing)
     // when the `tracing-log` feature is enabled.
@@ -279,11 +347,19 @@ pub fn init_tracing_with_layer(
         let otel_directives = otel_filter_directives();
         let otel_layer = m_otel_layer
             .map(|layer| layer.with_filter(env_filter(&otel_directives, OTEL_DEFAULT_FILTER)));
-        registry.with(otel_layer).try_init()?;
+        let log_directives = otel_log_filter_directives();
+        let log_layer = m_log_layer
+            .map(|layer| layer.with_filter(env_filter(&log_directives, OTEL_DEFAULT_FILTER)));
+        registry.with(otel_layer).with(log_layer).try_init()?;
 
         if let Some(protocol_and_endpoint) = m_endpoint_p {
             log::info!(
                 "OpenTelemetry tracing enabled (endpoint: {protocol_and_endpoint}, span filter: {otel_directives})"
+            );
+        }
+        if let Some(protocol_and_endpoint) = m_log_endpoint_p {
+            log::info!(
+                "OpenTelemetry log export enabled (endpoint: {protocol_and_endpoint}, record filter: {log_directives})"
             );
         }
     }
@@ -293,6 +369,7 @@ pub fn init_tracing_with_layer(
         registry.try_init()?;
 
         if non_empty_env("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT").is_some()
+            || non_empty_env("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT").is_some()
             || non_empty_env("OTEL_EXPORTER_OTLP_ENDPOINT").is_some()
         {
             log::error!(
@@ -312,6 +389,8 @@ pub fn init_tracing_with_layer(
         _file_guard: m_worker_guard,
         #[cfg(feature = "otel")]
         _tracer_provider: m_tracer_provider,
+        #[cfg(feature = "otel")]
+        _logger_provider: m_logger_provider,
     })
 }
 
@@ -336,6 +415,53 @@ fn otel_filter_directives() -> String {
     non_empty_env(OTEL_FILTER_ENV).unwrap_or_else(|| OTEL_DEFAULT_FILTER.to_string())
 }
 
+/// Env var turning OTLP log export on, per the OpenTelemetry SDK's own configuration: `otlp`
+/// exports, and `none` or unset does not.
+#[cfg(feature = "otel")]
+const OTEL_LOGS_EXPORTER_ENV: &str = "OTEL_LOGS_EXPORTER";
+
+/// Targets held out of OTLP log export unconditionally: the exporter's own crates. A failing
+/// export logs an error, and turning that error into a log record hands the exporter a fresh
+/// record for every one it fails to deliver.
+#[cfg(feature = "otel")]
+const OTEL_LOG_EXCLUDED_TARGETS: &str =
+    "opentelemetry=off,opentelemetry_sdk=off,opentelemetry_otlp=off";
+
+/// Whether `OTEL_LOGS_EXPORTER` asks for OTLP log records.
+#[cfg(feature = "otel")]
+fn otel_logs_enabled() -> bool {
+    logs_exporter_selects_otlp(non_empty_env(OTEL_LOGS_EXPORTER_ENV).as_deref())
+}
+
+/// Read a configured `OTEL_LOGS_EXPORTER` as a decision to export log records over OTLP. Off
+/// unless the value names the OTLP exporter, so a deployment that has not opted in exports nothing
+/// and `none` reads as the "no exporter" it means everywhere else in the OpenTelemetry ecosystem.
+///
+/// The variable takes a comma-separated list, and `otlp` is the only exporter this build carries,
+/// so any list naming it selects it.
+#[cfg(feature = "otel")]
+fn logs_exporter_selects_otlp(configured: Option<&str>) -> bool {
+    configured.is_some_and(|value| {
+        value
+            .split(',')
+            .any(|exporter| exporter.trim().eq_ignore_ascii_case("otlp"))
+    })
+}
+
+/// The filter directives OTLP log export uses: span export's, with the exporter's own crates
+/// silenced.
+///
+/// Reusing `OXEN_OTEL_FILTER` keeps one variable deciding what leaves the process over OTLP, so a
+/// deployment cannot end up exporting spans and log records at levels that disagree. `RUST_LOG`
+/// stays in charge of stdout either way.
+///
+/// [`OTEL_LOG_EXCLUDED_TARGETS`] goes last, and the filter parser lets the later directive for a
+/// target win, so the exclusion holds whatever `OXEN_OTEL_FILTER` says about those targets.
+#[cfg(feature = "otel")]
+fn otel_log_filter_directives() -> String {
+    format!("{},{OTEL_LOG_EXCLUDED_TARGETS}", otel_filter_directives())
+}
+
 /// Whether the environment already names a service, in which case the app's own name is not used.
 ///
 /// `service_name_var` is `OTEL_SERVICE_NAME`'s raw value, and `attributes_service_name` is the
@@ -352,20 +478,18 @@ fn env_names_a_service(
         .any(|name| !name.trim().is_empty())
 }
 
-/// The endpoint variable that enables export, and its value, reported for the startup line.
+/// The endpoint variable that enables export of `signal_var`'s signal, and its value, reported for
+/// the startup line. The signal's own variable wins over the collector-wide one, per OTLP.
 ///
 /// Read only to decide whether to build an exporter at all: without one the exporter defaults to
-/// `http://localhost:4318` and every process would push spans there. The exporter reads these same
-/// variables itself and applies the OTLP precedence and signal-path rules, so the value is not
-/// passed along.
+/// `http://localhost:4318` and every process would push telemetry there. The exporter reads these
+/// same variables itself and applies the OTLP precedence and signal-path rules, so the value is
+/// not passed along.
 #[cfg(feature = "otel")]
-fn otel_endpoint() -> Option<(&'static str, String)> {
-    [
-        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-        "OTEL_EXPORTER_OTLP_ENDPOINT",
-    ]
-    .into_iter()
-    .find_map(|var| non_empty_env(var).map(|value| (var, value)))
+fn otel_endpoint(signal_var: &'static str) -> Option<(&'static str, String)> {
+    [signal_var, "OTEL_EXPORTER_OTLP_ENDPOINT"]
+        .into_iter()
+        .find_map(|var| non_empty_env(var).map(|value| (var, value)))
 }
 
 /// The value of `name`, or `None` when it is unset or blank.
@@ -474,16 +598,13 @@ impl std::fmt::Display for Protocol {
     }
 }
 
-/// The transport OTLP export uses, from the traces-specific protocol variable or the general one.
+/// The transport OTLP export uses, from `signal_var`'s protocol variable or the general one.
 #[cfg(feature = "otel")]
-fn otel_protocol() -> Result<Protocol, TelemetryError> {
-    let (var, configured) = [
-        "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
-        "OTEL_EXPORTER_OTLP_PROTOCOL",
-    ]
-    .into_iter()
-    .find_map(|var| non_empty_env(var).map(|value| (var, Some(value))))
-    .unwrap_or(("OTEL_EXPORTER_OTLP_PROTOCOL", None));
+fn otel_protocol(signal_var: &'static str) -> Result<Protocol, TelemetryError> {
+    let (var, configured) = [signal_var, "OTEL_EXPORTER_OTLP_PROTOCOL"]
+        .into_iter()
+        .find_map(|var| non_empty_env(var).map(|value| (var, Some(value))))
+        .unwrap_or(("OTEL_EXPORTER_OTLP_PROTOCOL", None));
     parse_otel_protocol(var, configured.as_deref())
 }
 
@@ -511,6 +632,35 @@ fn parse_otel_protocol(
     }
 }
 
+/// The resource identifying this process on every span and log record it exports.
+///
+/// `Resource::builder` already applies the standard detectors, so `OTEL_SERVICE_NAME` and
+/// `OTEL_RESOURCE_ATTRIBUTES` (where `deployment.environment.name` is set) are picked up here. The
+/// attributes added on top take precedence over the detectors, so `service.name` is only supplied
+/// as the fallback for a deployment that names no service of its own.
+#[cfg(feature = "otel")]
+fn otel_resource(app_name: &str) -> opentelemetry_sdk::Resource {
+    use opentelemetry::{Key, KeyValue};
+    use opentelemetry_sdk::Resource;
+    use opentelemetry_sdk::resource::{EnvResourceDetector, ResourceDetector};
+
+    let attributes_service_name = EnvResourceDetector::new()
+        .detect()
+        .get(&Key::from_static_str("service.name"))
+        .map(|name| name.to_string());
+    let mut builder = Resource::builder().with_attributes([KeyValue::new(
+        "service.version",
+        crate::constants::OXEN_VERSION,
+    )]);
+    if !env_names_a_service(
+        std::env::var("OTEL_SERVICE_NAME").ok().as_deref(),
+        attributes_service_name.as_deref(),
+    ) {
+        builder = builder.with_service_name(app_name.to_string());
+    }
+    builder.build()
+}
+
 /// Build an OpenTelemetry tracing layer that exports spans via OTLP.
 ///
 /// The exporter reads the endpoint from the environment, appending the OTLP signal path to a
@@ -530,13 +680,10 @@ where
     S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
 {
     use opentelemetry::trace::TracerProvider;
-    use opentelemetry::{Key, KeyValue};
     use opentelemetry_otlp::WithExportConfig;
     use opentelemetry_otlp::WithTonicConfig;
     use opentelemetry_otlp::tonic_types::transport::ClientTlsConfig;
-    use opentelemetry_sdk::Resource;
     use opentelemetry_sdk::propagation::TraceContextPropagator;
-    use opentelemetry_sdk::resource::{EnvResourceDetector, ResourceDetector};
     use opentelemetry_sdk::trace::{BatchConfigBuilder, BatchSpanProcessor, SdkTracerProvider};
 
     let exporter = match protocol {
@@ -574,25 +721,7 @@ where
         }
     };
 
-    // `Resource::builder` already applies the standard detectors, so `OTEL_SERVICE_NAME` and
-    // `OTEL_RESOURCE_ATTRIBUTES` (where `deployment.environment` is set) land on every span. The
-    // attributes added here take precedence over the detectors, so `service.name` is only supplied
-    // as the fallback for a deployment that names no service of its own.
-    let attributes_service_name = EnvResourceDetector::new()
-        .detect()
-        .get(&Key::from_static_str("service.name"))
-        .map(|name| name.to_string());
-    let mut builder = Resource::builder().with_attributes([KeyValue::new(
-        "service.version",
-        crate::constants::OXEN_VERSION,
-    )]);
-    if !env_names_a_service(
-        std::env::var("OTEL_SERVICE_NAME").ok().as_deref(),
-        attributes_service_name.as_deref(),
-    ) {
-        builder = builder.with_service_name(app_name.to_string());
-    }
-    let resource = builder.build();
+    let resource = otel_resource(app_name);
 
     // A collector that is slow, unreachable, or black-holing must cost the process bounded memory
     // and never back-pressure a request thread: the queue is fixed, and the processor drops spans
@@ -631,6 +760,77 @@ where
     let layer = tracing_opentelemetry::layer().with_tracer(tracer);
 
     (Some(layer), Some(provider))
+}
+
+/// Build a tracing layer that exports events as OTLP log records.
+///
+/// The exporter reads the endpoint from the environment, appending `/v1/logs` to a collector
+/// endpoint and dialing a logs endpoint as configured.
+///
+/// Each record carries the trace and span id of the tracing span the event was recorded in, but
+/// only while the registry also holds a `tracing-opentelemetry` layer: that layer is what
+/// activates a span's OpenTelemetry context, and the SDK's logger stamps the record from whatever
+/// context is current.
+///
+/// Returns the layer and the provider, or `None` when the exporter cannot be built.
+#[cfg(feature = "otel")]
+fn build_otel_log_layer(
+    app_name: &str,
+    protocol: &Protocol,
+) -> Option<(
+    opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge<
+        opentelemetry_sdk::logs::SdkLoggerProvider,
+        opentelemetry_sdk::logs::SdkLogger,
+    >,
+    opentelemetry_sdk::logs::SdkLoggerProvider,
+)> {
+    use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+    use opentelemetry_otlp::WithExportConfig;
+    use opentelemetry_otlp::WithTonicConfig;
+    use opentelemetry_otlp::tonic_types::transport::ClientTlsConfig;
+    use opentelemetry_sdk::logs::{BatchConfigBuilder, BatchLogProcessor, SdkLoggerProvider};
+
+    let exporter = match protocol {
+        // Named rather than left to the exporter's default, for the reason given in
+        // `build_otel_layer`: an enabled "http-json" feature anywhere in the graph would otherwise
+        // switch the encoding without a compile error.
+        Protocol::Http => opentelemetry_otlp::LogExporter::builder()
+            .with_http()
+            .with_protocol(opentelemetry_otlp::Protocol::HttpBinary)
+            .build()
+            .inspect_err(|err| eprintln!("[ERROR] failed to build OTel HTTP log exporter: {err}"))
+            .ok()?,
+        Protocol::Grpc => opentelemetry_otlp::LogExporter::builder()
+            .with_tonic()
+            .with_tls_config(ClientTlsConfig::new().with_native_roots())
+            .build()
+            .inspect_err(|err| eprintln!("[ERROR] failed to build OTel gRPC log exporter: {err}"))
+            .ok()?,
+    };
+
+    // Bounded like the span queue and for the same reason: a collector that is slow or unreachable
+    // costs the process a fixed amount of memory, and the processor drops records once the queue
+    // is full rather than back-pressuring the thread that logged. Each field is only set when the
+    // operator left the matching `OTEL_BLRP_*` variable unset, so tuning through the standard
+    // variables still works.
+    let mut batch_config = BatchConfigBuilder::default();
+    if std::env::var_os("OTEL_BLRP_MAX_QUEUE_SIZE").is_none() {
+        batch_config = batch_config.with_max_queue_size(4096);
+    }
+    if std::env::var_os("OTEL_BLRP_SCHEDULE_DELAY").is_none() {
+        batch_config = batch_config.with_scheduled_delay(std::time::Duration::from_secs(2));
+    }
+    let processor = BatchLogProcessor::builder(exporter)
+        .with_batch_config(batch_config.build())
+        .build();
+
+    let provider = SdkLoggerProvider::builder()
+        .with_log_processor(processor)
+        .with_resource(otel_resource(app_name))
+        .build();
+
+    let layer = OpenTelemetryTracingBridge::new(&provider);
+    Some((layer, provider))
 }
 
 #[cfg(test)]
@@ -766,9 +966,11 @@ mod tests {
     #[cfg(feature = "otel")]
     mod otel_tests {
         use super::super::{
-            Protocol, TelemetryError, env_names_a_service, otel_filter_directives,
-            parse_otel_protocol,
+            OTEL_DEFAULT_FILTER, OTEL_LOG_EXCLUDED_TARGETS, Protocol, TelemetryError, env_filter,
+            env_names_a_service, logs_exporter_selects_otlp, otel_filter_directives,
+            otel_log_filter_directives, parse_otel_protocol,
         };
+        use opentelemetry::trace::{SpanId, TraceId};
 
         /// Nothing configured is HTTP, the transport `OTEL_EXPORTER_OTLP_PROTOCOL` carries by
         /// default across the OTLP ecosystem.
@@ -877,6 +1079,136 @@ mod tests {
             // OXEN_OTEL_FILTER would otherwise decide this one's outcome.
             if std::env::var_os("OXEN_OTEL_FILTER").is_none() {
                 assert_eq!(otel_filter_directives(), "info");
+            }
+        }
+
+        /// Only a value naming the OTLP exporter turns log export on. Anything else, `none`
+        /// included, leaves a deployment exporting no log records at all.
+        #[test]
+        fn only_otlp_selects_log_export() {
+            for selected in ["otlp", "OTLP", " otlp ", "none,otlp", "otlp,console"] {
+                assert!(
+                    logs_exporter_selects_otlp(Some(selected)),
+                    "{selected} should select OTLP log export"
+                );
+            }
+            for unselected in [None, Some(""), Some("none"), Some("console"), Some("otl")] {
+                assert!(
+                    !logs_exporter_selects_otlp(unselected),
+                    "{unselected:?} should leave log export off"
+                );
+            }
+        }
+
+        /// The log filter carries span export's directives, so one variable decides what leaves
+        /// the process over OTLP.
+        #[test]
+        fn the_log_filter_extends_the_span_filter() {
+            let directives = otel_log_filter_directives();
+            assert!(
+                directives.starts_with(&otel_filter_directives()),
+                "{directives} should begin with the span filter's directives"
+            );
+            assert!(
+                directives.ends_with(OTEL_LOG_EXCLUDED_TARGETS),
+                "{directives} should end with the excluded targets"
+            );
+        }
+
+        /// A log record picks up the trace and span id of the tracing span it was recorded in,
+        /// which is what lets a backend show a log line against its trace. `tracing-opentelemetry`
+        /// activates the span's OpenTelemetry context on entry and the SDK's logger reads it, so
+        /// nothing here wires the two together by hand.
+        ///
+        /// The exporter's own crates stay out of the export even when the directives ask for them,
+        /// since exporting an export failure is what makes a failing exporter generate work for
+        /// itself.
+        #[test]
+        fn log_records_carry_their_span_and_never_the_exporters_own_crates() {
+            use opentelemetry::trace::{TraceContextExt, TracerProvider};
+            use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+            use opentelemetry_sdk::logs::{SdkLoggerProvider, SimpleLogProcessor};
+            use opentelemetry_sdk::trace::SdkTracerProvider;
+            use tracing_opentelemetry::OpenTelemetrySpanExt;
+            use tracing_subscriber::Layer;
+            use tracing_subscriber::layer::SubscriberExt;
+
+            let exporter = CollectingLogExporter::default();
+            let logger_provider = SdkLoggerProvider::builder()
+                .with_log_processor(SimpleLogProcessor::new(exporter.clone()))
+                .build();
+            let tracer_provider = SdkTracerProvider::builder().build();
+
+            // A directive asking for the excluded targets, to prove the exclusion outranks it.
+            let directives = format!("info,opentelemetry_sdk=trace,{OTEL_LOG_EXCLUDED_TARGETS}");
+            let subscriber = tracing_subscriber::registry()
+                .with(tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer("oxen")))
+                .with(
+                    OpenTelemetryTracingBridge::new(&logger_provider)
+                        .with_filter(env_filter(&directives, OTEL_DEFAULT_FILTER)),
+                );
+
+            let expected_trace_id = tracing::subscriber::with_default(subscriber, || {
+                let span = tracing::info_span!("request");
+                let _entered = span.enter();
+                tracing::info!("handled the request");
+                tracing::error!(target: "opentelemetry_sdk", "export failed");
+                span.context().span().span_context().trace_id()
+            });
+
+            assert_ne!(
+                expected_trace_id,
+                TraceId::INVALID,
+                "the tracing span should have a real trace id to correlate against"
+            );
+
+            let exported = exporter.exported();
+            assert_eq!(
+                exported.len(),
+                1,
+                "only the application's own event should be exported, got {exported:?}"
+            );
+            let (trace_id, span_id) = exported[0];
+            assert_eq!(trace_id, expected_trace_id);
+            assert_ne!(
+                span_id,
+                SpanId::INVALID,
+                "the record should name the span it was recorded in"
+            );
+        }
+
+        /// Collects the trace and span id of every record handed to it, standing in for a
+        /// collector.
+        #[derive(Debug, Default, Clone)]
+        struct CollectingLogExporter {
+            records: std::sync::Arc<std::sync::Mutex<Vec<(TraceId, SpanId)>>>,
+        }
+
+        impl CollectingLogExporter {
+            fn exported(&self) -> Vec<(TraceId, SpanId)> {
+                self.records
+                    .lock()
+                    .expect("the exporter's records should not be poisoned")
+                    .clone()
+            }
+        }
+
+        impl opentelemetry_sdk::logs::LogExporter for CollectingLogExporter {
+            async fn export(
+                &self,
+                batch: opentelemetry_sdk::logs::LogBatch<'_>,
+            ) -> opentelemetry_sdk::error::OTelSdkResult {
+                let mut records = self
+                    .records
+                    .lock()
+                    .expect("the exporter's records should not be poisoned");
+                for (record, _scope) in batch.iter() {
+                    let context = record
+                        .trace_context()
+                        .expect("an exported record should carry a trace context");
+                    records.push((context.trace_id, context.span_id));
+                }
+                Ok(())
             }
         }
     }

--- a/crates/liboxen/src/util/telemetry.rs
+++ b/crates/liboxen/src/util/telemetry.rs
@@ -61,18 +61,28 @@ impl TracingGuard {
             if tracer_provider.is_none() && logger_provider.is_none() {
                 return;
             }
-            // A provider's shutdown blocks until its batch processor has drained, so it goes to
-            // the blocking pool; awaiting the handle leaves the runtime free to carry the batches.
-            let flush = tokio::task::spawn_blocking(move || {
+            // A provider's shutdown blocks until its batch processor has drained, so each goes to
+            // the blocking pool; awaiting the handles leaves the runtime free to carry the
+            // batches.
+            //
+            // Concurrently rather than one after the other: each provider's shutdown carries its
+            // own five-second export timeout, and draining them in sequence adds those timeouts
+            // together against whatever grace period the process gets before it is killed.
+            let tracer = tokio::task::spawn_blocking(move || {
                 if let Some(provider) = tracer_provider {
                     report_shutdown("tracer", provider.shutdown());
                 }
+            });
+            let logger = tokio::task::spawn_blocking(move || {
                 if let Some(provider) = logger_provider {
                     report_shutdown("logger", provider.shutdown());
                 }
             });
-            if let Err(e) = flush.await {
-                eprintln!("warning: OTel provider shutdown task failed: {e}");
+            let (tracer_flush, logger_flush) = tokio::join!(tracer, logger);
+            for flush in [tracer_flush, logger_flush] {
+                if let Err(e) = flush {
+                    eprintln!("warning: OTel provider shutdown task failed: {e}");
+                }
             }
         }
     }

--- a/crates/liboxen/src/util/telemetry.rs
+++ b/crates/liboxen/src/util/telemetry.rs
@@ -452,8 +452,22 @@ const OTEL_LOGS_EXPORTER_ENV: &str = "OTEL_LOGS_EXPORTER";
 /// backend any client-side detail from a push or a pull. `RUST_LOG` still puts all of it on
 /// stderr, which is where that detail is useful, and export at `debug` could not deliver it
 /// through the noise anyway.
+///
+/// Kept as targets rather than a directive string: a stray character inside a hand-written
+/// directive list is dropped by the filter parser with nothing but a line on stderr, and the
+/// target it named is exported after all.
 #[cfg(feature = "otel")]
-const OTEL_LOG_EXCLUDED_TARGETS: &str = "opentelemetry=off,opentelemetry_sdk=off,     opentelemetry_otlp=off,reqwest=off,hyper=off,hyper_util=off,h2=off,tonic=off,tower=off";
+const OTEL_LOG_EXCLUDED_TARGETS: &[&str] = &[
+    "opentelemetry",
+    "opentelemetry_sdk",
+    "opentelemetry_otlp",
+    "reqwest",
+    "hyper",
+    "hyper_util",
+    "h2",
+    "tonic",
+    "tower",
+];
 
 /// Whether `OTEL_LOGS_EXPORTER` asks for OTLP log records.
 #[cfg(feature = "otel")]
@@ -487,7 +501,14 @@ fn logs_exporter_selects_otlp(configured: Option<&str>) -> bool {
 /// target win, so the exclusion holds whatever `OXEN_OTEL_FILTER` says about those targets.
 #[cfg(feature = "otel")]
 fn otel_log_filter_directives() -> String {
-    format!("{},{OTEL_LOG_EXCLUDED_TARGETS}", otel_filter_directives())
+    std::iter::once(otel_filter_directives())
+        .chain(
+            OTEL_LOG_EXCLUDED_TARGETS
+                .iter()
+                .map(|target| format!("{target}=off")),
+        )
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 /// Whether the environment already names a service, in which case the app's own name is not used.
@@ -999,6 +1020,7 @@ mod tests {
             otel_log_filter_directives, parse_otel_protocol,
         };
         use opentelemetry::trace::{SpanId, TraceId};
+        use tracing_subscriber::EnvFilter;
 
         /// Nothing configured is HTTP, the transport `OTEL_EXPORTER_OTLP_PROTOCOL` carries by
         /// default across the OTLP ecosystem.
@@ -1129,7 +1151,7 @@ mod tests {
         }
 
         /// The log filter carries span export's directives, so one variable decides what leaves
-        /// the process over OTLP.
+        /// the process over OTLP, and silences every excluded target on top of them.
         #[test]
         fn the_log_filter_extends_the_span_filter() {
             let directives = otel_log_filter_directives();
@@ -1137,10 +1159,54 @@ mod tests {
                 directives.starts_with(&otel_filter_directives()),
                 "{directives} should begin with the span filter's directives"
             );
+            for target in OTEL_LOG_EXCLUDED_TARGETS {
+                assert!(
+                    directives.contains(&format!("{target}=off")),
+                    "{directives} should silence {target}"
+                );
+            }
+        }
+
+        /// Every excluded target has to survive the filter parser. `parse_lossy` drops a directive
+        /// it cannot read with nothing but a line on stderr, and the target it named is then
+        /// exported after all, which is how a stray space inside the list stays invisible.
+        #[test]
+        fn every_excluded_target_is_a_usable_directive() {
+            let directives = otel_log_filter_directives();
             assert!(
-                directives.ends_with(OTEL_LOG_EXCLUDED_TARGETS),
-                "{directives} should end with the excluded targets"
+                EnvFilter::builder().parse(&directives).is_ok(),
+                "{directives} should parse with no directive dropped"
             );
+        }
+
+        /// The exclusion half of the log filter, built without reading the environment so a
+        /// sibling test's `OXEN_OTEL_FILTER` cannot change what this asserts.
+        fn excluded_directives() -> String {
+            OTEL_LOG_EXCLUDED_TARGETS
+                .iter()
+                .map(|target| format!("{target}=off"))
+                .collect::<Vec<_>>()
+                .join(",")
+        }
+
+        /// The targets the exclusion test below emits an event on.
+        const EMITTED_EXCLUDED_TARGETS: &[&str] = &[
+            "opentelemetry",
+            "opentelemetry_sdk",
+            "opentelemetry_otlp",
+            "reqwest",
+            "hyper",
+            "hyper_util",
+            "h2",
+            "tonic",
+            "tower",
+        ];
+
+        /// A target added to the exclusion list without an event to match leaves the exclusion
+        /// unproven for it, and the test below still passes.
+        #[test]
+        fn every_excluded_target_is_covered_by_an_event() {
+            assert_eq!(EMITTED_EXCLUDED_TARGETS, OTEL_LOG_EXCLUDED_TARGETS);
         }
 
         /// A log record picks up the trace and span id of the tracing span it was recorded in,
@@ -1167,10 +1233,14 @@ mod tests {
                 .build();
             let tracer_provider = SdkTracerProvider::builder().build();
 
-            // Directives asking for excluded targets, to prove the exclusion outranks them. `h2`
-            // stands in for the transport crates, whose frame logging is the loudest of them.
-            let directives =
-                format!("info,opentelemetry_sdk=trace,h2=trace,{OTEL_LOG_EXCLUDED_TARGETS}");
+            // Directives asking for every excluded target at its loudest, to prove the exclusion
+            // outranks them.
+            let asked_for = OTEL_LOG_EXCLUDED_TARGETS
+                .iter()
+                .map(|target| format!("{target}=trace"))
+                .collect::<Vec<_>>()
+                .join(",");
+            let directives = format!("info,{asked_for},{}", excluded_directives());
             let subscriber = tracing_subscriber::registry()
                 .with(tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer("oxen")))
                 .with(
@@ -1182,9 +1252,18 @@ mod tests {
                 let span = tracing::info_span!("request");
                 let _entered = span.enter();
                 tracing::info!("handled the request");
+                // One event per excluded target, spelled out because `target:` takes a literal.
+                // `every_excluded_target_is_covered_by_an_event` keeps these in step with the
+                // constant.
+                tracing::error!(target: "opentelemetry", "export failed");
                 tracing::error!(target: "opentelemetry_sdk", "export failed");
-                tracing::debug!(target: "h2", "send");
+                tracing::error!(target: "opentelemetry_otlp", "export failed");
+                tracing::debug!(target: "reqwest", "starting new connection");
+                tracing::debug!(target: "hyper", "flushed frame");
                 tracing::debug!(target: "hyper_util", "pooling idle connection");
+                tracing::debug!(target: "h2", "send");
+                tracing::debug!(target: "tonic", "sending request");
+                tracing::debug!(target: "tower", "service ready");
                 span.context().span().span_context().trace_id()
             });
 

--- a/crates/liboxen/src/util/telemetry.rs
+++ b/crates/liboxen/src/util/telemetry.rs
@@ -345,6 +345,7 @@ pub fn init_tracing_with_layer(
     #[cfg(feature = "otel")]
     {
         let otel_directives = otel_filter_directives();
+        let exporting_spans = m_otel_layer.is_some();
         let otel_layer = m_otel_layer
             .map(|layer| layer.with_filter(env_filter(&otel_directives, OTEL_DEFAULT_FILTER)));
         let log_directives = otel_log_filter_directives();
@@ -360,6 +361,23 @@ pub fn init_tracing_with_layer(
         if let Some(protocol_and_endpoint) = m_log_endpoint_p {
             log::info!(
                 "OpenTelemetry log export enabled (endpoint: {protocol_and_endpoint}, record filter: {log_directives})"
+            );
+            // The trace and span id on a record come from the span layer having activated the
+            // span's context. Without that layer every record carries an empty trace id, which
+            // looks like a backend that will not correlate rather than a server that never sent
+            // the ids. Reachable by naming only the logs endpoint.
+            if !exporting_spans {
+                log::warn!(
+                    "OpenTelemetry log export is on without span export, so every log record carries an empty trace id. Configure OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_TRACES_ENDPOINT to correlate records with traces."
+                );
+            }
+        } else if otel_logs_enabled() && otel_endpoint("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT").is_none()
+        {
+            // An opt-in that resolves to no endpoint. Silence here reads as a backend that is
+            // dropping the records. A failed exporter build reports itself, so this covers only
+            // the case where nothing named an endpoint at all.
+            log::error!(
+                "OTEL_LOGS_EXPORTER asks for OTLP log export but no OTLP endpoint is configured! (Ignoring)"
             );
         }
     }
@@ -420,12 +438,22 @@ fn otel_filter_directives() -> String {
 #[cfg(feature = "otel")]
 const OTEL_LOGS_EXPORTER_ENV: &str = "OTEL_LOGS_EXPORTER";
 
-/// Targets held out of OTLP log export unconditionally: the exporter's own crates. A failing
-/// export logs an error, and turning that error into a log record hands the exporter a fresh
-/// record for every one it fails to deliver.
+/// Targets held out of OTLP log export unconditionally: the exporter's own crates, and the HTTP
+/// and gRPC stacks it sends over.
+///
+/// Every export is itself network IO that logs, so exporting those lines feeds the exporter a
+/// fresh batch for every batch it delivers, and the loop sustains itself for as long as the
+/// process runs. It is dormant at the default `info`, where these crates are near-silent, and
+/// arrives the moment someone raises `OXEN_OTEL_FILTER` to `debug` to look into an export problem.
+/// Measured at `debug` against a collector, a single idle server spent most of a batch on its own
+/// connection-pool and HTTP/2 frame chatter, crowding out the records worth reading.
+///
+/// The transport crates carry this repo's own HTTP client as well, so excluding them costs the
+/// backend any client-side detail from a push or a pull. `RUST_LOG` still puts all of it on
+/// stderr, which is where that detail is useful, and export at `debug` could not deliver it
+/// through the noise anyway.
 #[cfg(feature = "otel")]
-const OTEL_LOG_EXCLUDED_TARGETS: &str =
-    "opentelemetry=off,opentelemetry_sdk=off,opentelemetry_otlp=off";
+const OTEL_LOG_EXCLUDED_TARGETS: &str = "opentelemetry=off,opentelemetry_sdk=off,     opentelemetry_otlp=off,reqwest=off,hyper=off,hyper_util=off,h2=off,tonic=off,tower=off";
 
 /// Whether `OTEL_LOGS_EXPORTER` asks for OTLP log records.
 #[cfg(feature = "otel")]
@@ -1120,9 +1148,9 @@ mod tests {
         /// activates the span's OpenTelemetry context on entry and the SDK's logger reads it, so
         /// nothing here wires the two together by hand.
         ///
-        /// The exporter's own crates stay out of the export even when the directives ask for them,
-        /// since exporting an export failure is what makes a failing exporter generate work for
-        /// itself.
+        /// The exporter's own crates and the transport it sends over stay out of the export even
+        /// when the directives ask for them, since exporting what an export logs is what makes an
+        /// exporter generate work for itself.
         #[test]
         fn log_records_carry_their_span_and_never_the_exporters_own_crates() {
             use opentelemetry::trace::{TraceContextExt, TracerProvider};
@@ -1139,8 +1167,10 @@ mod tests {
                 .build();
             let tracer_provider = SdkTracerProvider::builder().build();
 
-            // A directive asking for the excluded targets, to prove the exclusion outranks it.
-            let directives = format!("info,opentelemetry_sdk=trace,{OTEL_LOG_EXCLUDED_TARGETS}");
+            // Directives asking for excluded targets, to prove the exclusion outranks them. `h2`
+            // stands in for the transport crates, whose frame logging is the loudest of them.
+            let directives =
+                format!("info,opentelemetry_sdk=trace,h2=trace,{OTEL_LOG_EXCLUDED_TARGETS}");
             let subscriber = tracing_subscriber::registry()
                 .with(tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer("oxen")))
                 .with(
@@ -1153,6 +1183,8 @@ mod tests {
                 let _entered = span.enter();
                 tracing::info!("handled the request");
                 tracing::error!(target: "opentelemetry_sdk", "export failed");
+                tracing::debug!(target: "h2", "send");
+                tracing::debug!(target: "hyper_util", "pooling idle connection");
                 span.context().span().span_context().trace_id()
             });
 

--- a/crates/oxen-server/README.md
+++ b/crates/oxen-server/README.md
@@ -302,7 +302,11 @@ feature behaves exactly as it did before this was configured.
 
 Each record carries the trace and span id of the span the event was recorded
 in, which is what lets a backend show a log line against the request that
-produced it.
+produced it. That depends on span export being active in the same process:
+naming only `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` exports records with an empty
+trace id and nothing to correlate them against. The server warns at startup
+when it is configured that way, and reports an error when `OTEL_LOGS_EXPORTER`
+asks for log export and no endpoint resolves at all.
 
 ```bash
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
@@ -323,10 +327,22 @@ prints, so a host that collects stdout keeps collecting exactly what it did.
 
 `OXEN_OTEL_FILTER` selects log records as well as spans, so one variable decides
 what leaves the process over OTLP and the two signals cannot drift to
-disagreeing levels. Log records are the one exception: the `opentelemetry`,
-`opentelemetry_sdk`, and `opentelemetry_otlp` targets are always excluded,
-whatever the filter says. An export failure logs an error, and exporting that
-error would hand the exporter a fresh record for every one it fails to deliver.
+disagreeing levels. Log records have one exception, applied whatever the filter
+says: the exporter's own crates (`opentelemetry`, `opentelemetry_sdk`,
+`opentelemetry_otlp`) and the transport it sends over (`reqwest`, `hyper`,
+`hyper_util`, `h2`, `tonic`, `tower`) never become log records.
+
+Every export is network IO that logs, so exporting those lines feeds the
+exporter a fresh batch for every batch it delivers, and the loop sustains
+itself for as long as the process runs. It stays dormant at the default `info`,
+where those crates are near-silent, and arrives the moment someone raises
+`OXEN_OTEL_FILTER` to `debug` to look into an export problem: measured that way
+against a collector, an idle server spent most of a batch on its own
+connection-pool and HTTP/2 frame chatter.
+
+The transport crates carry this repo's own HTTP client too, so the exclusion
+costs the backend any client-side detail from a push or a pull. `RUST_LOG`
+still puts all of it on stderr, which is where that detail is useful.
 
 Events inside a span are still recorded as span events on the exported span, so
 turning log export on reports each one twice: once in the trace and once in the

--- a/crates/oxen-server/README.md
+++ b/crates/oxen-server/README.md
@@ -6,6 +6,7 @@ Remote repositories have the same internal structure as local ones, with the cav
 **Notable configuration sections**:
 - [Prometheus Metrics](#prometheus-metrics)
 - [OpenTelemetry Tracing](#opentelemetry-tracing)
+- [OTLP Log Export](#otlp-log-export)
 - [FmtSpan Events](#fmtspan-events)
 - [Stacking Tracing Layers | Writing Spans to Logs & OTel](#stacking-tracing-layers)
 
@@ -244,7 +245,8 @@ OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.vendor.example:443 oxen-server start
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | The traces signal endpoint, taking precedence over the collector endpoint above. It already names the signal, so it is posted to exactly as configured under HTTP and needs `/v1/traces` in it. | *(none)* |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | Transport: `grpc`, or `http` / `http/protobuf` / `http/json` for HTTP. The payload is binary protobuf whichever of the three spellings is used. | `http/protobuf` |
 | `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | The same setting for span exports alone, and takes precedence over `OTEL_EXPORTER_OTLP_PROTOCOL` where both are set. | *(whatever `OTEL_EXPORTER_OTLP_PROTOCOL` resolves to)* |
-| `OXEN_OTEL_FILTER` | Which spans and events are exported. Same syntax as `RUST_LOG`, and independent of it. | `info` |
+| `OXEN_OTEL_FILTER` | Which spans, events, and log records are exported. Same syntax as `RUST_LOG`, and independent of it. | `info` |
+| `OTEL_LOGS_EXPORTER` | `otlp` to also export events as OTLP log records; `none` or unset exports none. See [OTLP log export](#otlp-log-export). | *(none)* |
 
 A variable set to a blank value counts as unset.
 
@@ -262,8 +264,8 @@ These standard `OTEL_*` variables are read by the SDK itself:
 
 | Variable | Description | Default |
 |---|---|---|
-| `OTEL_SERVICE_NAME` | `service.name` on every exported span. | `oxen-server` |
-| `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` resource attributes. This is where `deployment.environment` is set — nothing else supplies it. | *(none)* |
+| `OTEL_SERVICE_NAME` | `service.name` on everything exported, spans and log records alike. | `oxen-server` |
+| `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` resource attributes. This is where `deployment.environment.name` is set — nothing else supplies it. | *(none)* |
 | `OTEL_TRACES_SAMPLER` | `always_on`, `always_off`, `traceidratio`, `parentbased_always_on`, `parentbased_always_off`, `parentbased_traceidratio`. | `parentbased_always_on` |
 | `OTEL_TRACES_SAMPLER_ARG` | Sampling probability, `0.0`–`1.0`, for the ratio samplers. | `1.0` |
 | `OTEL_BSP_MAX_QUEUE_SIZE`, `OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`, `OTEL_BSP_EXPORT_TIMEOUT` | Batch-processor tuning: queue depth, how often a batch drains, batch size, and how long the processor waits on one export. | `4096`, `2000` ms, `512`, `30000` ms |
@@ -274,9 +276,10 @@ These standard `OTEL_*` variables are read by the SDK itself:
 
 Every span carries `service.name`, `service.version`, and — when a caller sent
 an `x-oxen-request-id` header, or the server minted one — `oxen.request_id`.
-`deployment.environment` is there too once `OTEL_RESOURCE_ATTRIBUTES` sets it.
-`tracing-actix-web` records a second field named `request_id`; that one is its
-own per-request uuid, private to this process. Correlate on `oxen.request_id`.
+`deployment.environment.name` is there too once `OTEL_RESOURCE_ATTRIBUTES` sets
+it. `tracing-actix-web` records a second field named `request_id`; that one is
+its own per-request uuid, private to this process. Correlate on
+`oxen.request_id`.
 
 The default sampler is parent-based, so a caller that has already made a
 sampling decision and sent it in `traceparent` is honored. To sample a share of
@@ -289,6 +292,46 @@ OTEL_TRACES_SAMPLER=parentbased_traceidratio OTEL_TRACES_SAMPLER_ARG=0.1
 When the `otel` feature is not compiled in, no OpenTelemetry dependencies are
 included and the env vars are ignored (the server logs an error at startup if
 an endpoint is configured, rather than silently dropping it).
+
+### OTLP log export
+
+Set `OTEL_LOGS_EXPORTER=otlp` and the server also exports its `tracing` events
+as OTLP log records, over the endpoint and transport span export already uses.
+Unset, or `none`, exports no log records at all, so a build with the `otel`
+feature behaves exactly as it did before this was configured.
+
+Each record carries the trace and span id of the span the event was recorded
+in, which is what lets a backend show a log line against the request that
+produced it.
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+OTEL_LOGS_EXPORTER=otlp \
+oxen-server start
+```
+
+Stdout is untouched by any of this. `RUST_LOG` alone decides what the server
+prints, so a host that collects stdout keeps collecting exactly what it did.
+
+| Variable | Description | Default |
+|---|---|---|
+| `OTEL_LOGS_EXPORTER` | `otlp` to export log records, `none` or unset for no log export. Comma-separated, and `otlp` is the only exporter compiled in. | *(none)* |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | The logs signal endpoint, taking precedence over `OTEL_EXPORTER_OTLP_ENDPOINT`. It already names the signal, so it is posted to exactly as configured under HTTP and needs `/v1/logs` in it. | *(none)* |
+| `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` | The transport for log exports alone, and takes precedence over `OTEL_EXPORTER_OTLP_PROTOCOL` where both are set. | *(whatever `OTEL_EXPORTER_OTLP_PROTOCOL` resolves to)* |
+| `OTEL_EXPORTER_OTLP_LOGS_COMPRESSION`, `OTEL_EXPORTER_OTLP_LOGS_TIMEOUT` | The compression and per-request timeout for log exports alone, each taking precedence over its collector-wide counterpart. | *(whatever the collector-wide variable resolves to)* |
+| `OTEL_BLRP_MAX_QUEUE_SIZE`, `OTEL_BLRP_SCHEDULE_DELAY`, `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE`, `OTEL_BLRP_EXPORT_TIMEOUT` | Batch-processor tuning for log records, the counterpart to the `OTEL_BSP_*` variables above. | `4096`, `2000` ms, `512`, `30000` ms |
+
+`OXEN_OTEL_FILTER` selects log records as well as spans, so one variable decides
+what leaves the process over OTLP and the two signals cannot drift to
+disagreeing levels. Log records are the one exception: the `opentelemetry`,
+`opentelemetry_sdk`, and `opentelemetry_otlp` targets are always excluded,
+whatever the filter says. An export failure logs an error, and exporting that
+error would hand the exporter a fresh record for every one it fails to deliver.
+
+Events inside a span are still recorded as span events on the exported span, so
+turning log export on reports each one twice: once in the trace and once in the
+logs. That is the cost of having log lines searchable on their own rather than
+only reachable by opening the trace they belong to.
 
 ### Inbound trace context
 


### PR DESCRIPTION
`oxen-server`'s log lines only reached stdout, so tying one to its trace meant matching timestamps across two systems. It can now export them as OTLP log records, each carrying the trace and span id of the span the event was recorded in.

**Turning it on:** `OTEL_LOGS_EXPORTER=otlp`, alongside the OTLP endpoint that already enables span export. Unset or `none` exports nothing, so this build behaves exactly as the current one until a task definition sets it.

**Filter:** the log layer reuses `OXEN_OTEL_FILTER` (default `info`) rather than adding a variable, so one setting decides what leaves the process over OTLP. The `opentelemetry`, `opentelemetry_sdk`, and `opentelemetry_otlp` targets are excluded unconditionally, whatever the filter says: exporting an export failure hands the exporter a new record for every one it fails to deliver. `RUST_LOG` still owns stdout and is unaffected.