### PR TITLE
Stop workspace reads from returning 500 while a commit lands on the same workspace

### DIFF
--- a/crates/liboxen/src/core/db/data_frames/df_db.rs
+++ b/crates/liboxen/src/core/db/data_frames/df_db.rs
@@ -765,7 +765,13 @@ fn add_special_columns(conn: &duckdb::Connection, sql: &str) -> Result<String, D
             // row and drop any ORDER BY — a sort would scan the whole table
             // just to answer a schema question.
             query.order_by = None;
-            query.limit = Some(SqlExpr::Value(SqlValue::Number("1".into(), false)));
+            let one = SqlExpr::Value(SqlValue::Number("1".into(), false));
+            // DuckDB takes LIMIT or FETCH, never both: the cap goes on
+            // whichever clause the statement already carries.
+            match &mut query.fetch {
+                Some(fetch) => fetch.quantity = Some(one),
+                None => query.limit = Some(one),
+            }
         }
         ast
     };
@@ -1439,6 +1445,44 @@ mod tests {
             let df = select_str(&conn, &sql, None)?;
 
             assert_eq!(df.height(), 2, "DISTINCT should deduplicate 'red': {df:?}");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_fetch_first_survives_special_column_injection() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|data_dir| {
+            let db_file = data_dir.join("data.db");
+            let conn = get_connection(&db_file)?;
+
+            conn.execute(
+                &format!(
+                    "CREATE TABLE {TABLE_NAME} (
+                        color VARCHAR,
+                        {OXEN_ID_COL} VARCHAR DEFAULT (uuid()::VARCHAR),
+                        num INTEGER
+                    )"
+                ),
+                [],
+            )?;
+            conn.execute(
+                &format!(
+                    "INSERT INTO {TABLE_NAME} (color, num)
+                     VALUES ('red', 1), ('blue', 2), ('green', 3)"
+                ),
+                [],
+            )?;
+
+            // A statement that bounds itself with FETCH keeps that bound. Pairing it with a
+            // LIMIT is a DuckDB syntax error that fails the whole read.
+            let sql = format!("SELECT color FROM {TABLE_NAME} FETCH FIRST 2 ROWS ONLY");
+            let df = select_str(&conn, &sql, None)?;
+
+            assert_eq!(df.height(), 2, "FETCH FIRST 2 should read two rows: {df:?}");
+            assert!(
+                df.column(OXEN_ID_COL).is_ok(),
+                "{OXEN_ID_COL} should be injected into the projection: {df:?}"
+            );
             Ok(())
         })
     }

--- a/crates/liboxen/src/core/db/key_val/kv_db.rs
+++ b/crates/liboxen/src/core/db/key_val/kv_db.rs
@@ -1,6 +1,6 @@
 use crate::error::OxenError;
 
-use rocksdb::{DBWithThreadMode, IteratorMode, ThreadMode};
+use rocksdb::{DBWithThreadMode, IteratorMode, ThreadMode, WriteBatch};
 use std::str;
 
 /// More efficient than get since it does not actual deserialize the value
@@ -62,13 +62,14 @@ pub fn list_keys<T: ThreadMode>(db: &DBWithThreadMode<T>) -> Result<Vec<String>,
     Ok(keys)
 }
 
-/// Remove all values from the db
+/// Remove all values from the db in one atomic write, so a reader sees either every value or none
 pub fn clear<T: ThreadMode>(db: &DBWithThreadMode<T>) -> Result<(), OxenError> {
     let iter = db.iterator(IteratorMode::Start);
+    let mut batch = WriteBatch::default();
     for item in iter {
         match item {
             Ok((key, _)) => {
-                db.delete(key)?;
+                batch.delete(key);
             }
             _ => {
                 return Err(OxenError::basic_str(
@@ -77,5 +78,6 @@ pub fn clear<T: ThreadMode>(db: &DBWithThreadMode<T>) -> Result<(), OxenError> {
             }
         }
     }
+    db.write(batch)?;
     Ok(())
 }

--- a/crates/liboxen/src/core/staged.rs
+++ b/crates/liboxen/src/core/staged.rs
@@ -1,5 +1,5 @@
 pub mod staged_db_manager;
 
+pub(crate) use staged_db_manager::close_staged_db;
 pub use staged_db_manager::get_staged_db_manager;
-pub use staged_db_manager::remove_from_cache;
 pub use staged_db_manager::remove_from_cache_with_children;

--- a/crates/liboxen/src/core/staged/staged_db_manager.rs
+++ b/crates/liboxen/src/core/staged/staged_db_manager.rs
@@ -14,6 +14,7 @@ use serde::Serialize;
 
 use crate::constants::STAGED_DIR;
 use crate::core::db;
+use crate::core::db::key_val::kv_db;
 use crate::error::OxenError;
 use crate::model::LocalRepository;
 use crate::model::StagedEntryStatus;
@@ -25,20 +26,40 @@ use crate::util;
 // Weak-ref registry of open staged DB handles, keyed by `.oxen/staged` dir. The strong
 // `Arc<RwLock<DB>>` lives only as long as some [`StagedDBManager`] holds it; when the last
 // caller drops, RocksDB closes and the entry becomes a tombstone that the next opener prunes.
-// There is no capacity cap, so an in-use entry can never be evicted — the shared-Arc
-// invariant that compound read-modify-write sequences rely on holds unconditionally.
+// There is no capacity cap, so nothing evicts an in-use entry on its own and every caller for one
+// directory shares the handle that compound read-modify-write sequences rely on.
+// [`remove_from_cache_with_children`] is the one way to drop a live entry: the caller still holding
+// it keeps RocksDB's per-directory `LOCK`, and the next opener collides with it for as long as that
+// caller lives. [`close_staged_db`] waits for the handle to drain rather than orphaning it.
 // A brief LOCK collision is still possible when an open races the tail of a concurrent
 // close (RocksDB releases the OS lock in its `Drop`, after `strong_count` already hit zero);
 // see [`get_staged_db_manager`] for the bounded-retry that waits it out.
 static DB_INSTANCES: LazyLock<Mutex<HashMap<PathBuf, Weak<RwLock<DB>>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Removes this repository's tombstone entry from the registry. Live entries (someone still
-/// holds the `Arc`) are unaffected; the DB closes when the last strong reference drops.
-pub fn remove_from_cache(repository_path: impl AsRef<Path>) -> Result<(), OxenError> {
+/// Closes this repository's staged DB so its directory can be removed, blocking briefly while
+/// other callers drop their handles. Callers that only want the entries gone want
+/// [`StagedDBManager::clear`], which keeps the shared handle open.
+///
+/// A handle still open when the wait runs out keeps RocksDB's per-directory `LOCK`, so the next
+/// opener collides with it until that caller finishes.
+pub(crate) fn close_staged_db(repository_path: impl AsRef<Path>) -> Result<(), OxenError> {
     let staged_dir = util::fs::oxen_hidden_dir(repository_path).join(STAGED_DIR);
-    let mut instances = DB_INSTANCES.lock();
-    instances.remove(&staged_dir);
+    for _ in 0..db::OPEN_RETRIES {
+        let mut instances = DB_INSTANCES.lock();
+        match instances.get(&staged_dir) {
+            Some(weak) if weak.strong_count() > 0 => {
+                drop(instances);
+                sleep(db::OPEN_RETRY_INTERVAL);
+            }
+            _ => {
+                instances.remove(&staged_dir);
+                return Ok(());
+            }
+        }
+    }
+    DB_INSTANCES.lock().remove(&staged_dir);
+    log::warn!("Staged db {staged_dir:?} still open elsewhere after waiting to close it");
     Ok(())
 }
 
@@ -315,6 +336,12 @@ impl StagedDBManager {
     /// Delete an entry from the staged db (convenience method)
     pub fn delete_entry(&self, path: impl AsRef<Path>) -> Result<(), OxenError> {
         self.delete_entry_with_lock(path, None)
+    }
+
+    /// Delete every staged entry, leaving the staged db open and shared with other callers.
+    /// A concurrent reader sees either the full set of entries or none of them.
+    pub(crate) fn clear(&self) -> Result<(), OxenError> {
+        kv_db::clear(&self.staged_db.write())
     }
 
     /// Write a directory node to the staged db

--- a/crates/liboxen/src/core/staged/staged_db_manager.rs
+++ b/crates/liboxen/src/core/staged/staged_db_manager.rs
@@ -41,15 +41,23 @@ static DB_INSTANCES: LazyLock<Mutex<HashMap<PathBuf, Weak<RwLock<DB>>>>> =
 /// other callers drop their handles. Callers that only want the entries gone want
 /// [`StagedDBManager::clear`], which keeps the shared handle open.
 ///
-/// A handle still open when the wait runs out keeps RocksDB's per-directory `LOCK`, so the next
-/// opener collides with it until that caller finishes.
+/// Errors when a handle is still open once the wait runs out, keeping the registry entry so later
+/// callers go on sharing that handle. Leave the directory in place until a later close succeeds.
 pub(crate) fn close_staged_db(repository_path: impl AsRef<Path>) -> Result<(), OxenError> {
     let staged_dir = util::fs::oxen_hidden_dir(repository_path).join(STAGED_DIR);
-    for _ in 0..db::OPEN_RETRIES {
+    let mut attempts = 0;
+    loop {
         let mut instances = DB_INSTANCES.lock();
         match instances.get(&staged_dir) {
             Some(weak) if weak.strong_count() > 0 => {
                 drop(instances);
+                attempts += 1;
+                if attempts >= db::OPEN_RETRIES {
+                    return Err(OxenError::internal_error(format!(
+                        "Staged db {} is still open elsewhere after waiting to close it",
+                        staged_dir.display()
+                    )));
+                }
                 sleep(db::OPEN_RETRY_INTERVAL);
             }
             _ => {
@@ -58,9 +66,6 @@ pub(crate) fn close_staged_db(repository_path: impl AsRef<Path>) -> Result<(), O
             }
         }
     }
-    DB_INSTANCES.lock().remove(&staged_dir);
-    log::warn!("Staged db {staged_dir:?} still open elsewhere after waiting to close it");
-    Ok(())
 }
 
 /// Removes tombstone entries under `repository_path` from the registry. Live entries are

--- a/crates/liboxen/src/core/v_latest/workspaces/commit.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/commit.rs
@@ -137,8 +137,15 @@ async fn commit_inner(
         // update the workspace config to point to the new commit
         repositories::workspaces::update_commit(workspace, &commit_id)?;
     } else {
-        // Unnamed workspaces are deleted on commit
-        repositories::workspaces::delete(workspace)?;
+        // Unnamed workspaces are deleted on commit. The commit has already landed at this point:
+        // a delete that cannot run yet leaves the directory for a later delete to remove.
+        if let Err(err) = repositories::workspaces::delete(workspace) {
+            tracing::error!(
+                workspace_id = %workspace.id,
+                cause = ?err,
+                "Workspace commit landed but the workspace could not be deleted"
+            );
+        }
     }
 
     Ok(commit)

--- a/crates/liboxen/src/core/v_latest/workspaces/commit.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/commit.rs
@@ -8,7 +8,7 @@ use tokio::sync::Mutex as TokioMutex;
 use crate::constants::STAGED_DIR;
 use crate::core;
 use crate::core::refs::with_ref_manager;
-use crate::core::staged::remove_from_cache;
+use crate::core::staged::get_staged_db_manager;
 use crate::core::v_latest::index::CommitMerkleTree;
 use crate::core::v_latest::workspaces;
 use crate::error::OxenError;
@@ -116,10 +116,10 @@ async fn commit_inner(
         )?
     };
 
-    // Clear the staged db
-    log::debug!("Removing staged_db_path: {staged_db_path:?}");
-    remove_from_cache(&workspace.workspace_repo.path)?;
-    util::fs::remove_dir_all(staged_db_path)?;
+    // Clear through the shared handle rather than dropping it and removing the directory: the next
+    // reader's open would collide with RocksDB's per-directory LOCK until the last holder finishes.
+    log::debug!("Clearing staged db: {staged_db_path:?}");
+    get_staged_db_manager(&workspace.workspace_repo)?.clear()?;
 
     // DEBUG
     // let tree = repositories::tree::get_by_commit(&workspace.base_repo, &commit)?;

--- a/crates/liboxen/src/repositories/workspaces.rs
+++ b/crates/liboxen/src/repositories/workspaces.rs
@@ -535,7 +535,7 @@ pub fn delete(workspace: &Workspace) -> Result<(), OxenError> {
     }
 
     // Clean up caches before deleting the workspace
-    core::staged::remove_from_cache(&workspace.workspace_repo.path)?;
+    core::staged::close_staged_db(&workspace.workspace_repo.path)?;
     // Drop cached DuckDB connections rooted in this workspace before removing the dir. On NFS,
     // unlinking a still-open file leaves a hidden .nfsXXXX entry that fails the rmdir with ENOTEMPTY.
     df_db::remove_df_db_from_cache_with_children(&workspace_dir)?;
@@ -1435,6 +1435,57 @@ mod tests {
             assert!(current_path.exists());
             assert!(!legacy_path.exists());
 
+            Ok(())
+        })
+        .await
+    }
+
+    /// A workspace read that is in flight when a commit lands keeps the staged db handle it
+    /// already holds, and a read arriving after the commit opens against that same handle
+    /// instead of colliding with RocksDB's per-directory LOCK.
+    #[tokio::test]
+    async fn test_commit_leaves_a_held_staged_db_handle_usable() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let hello_file = repo.path.join("hello.txt");
+            util::fs::write_to_path(&hello_file, "Hello")?;
+            repositories::add(&repo, &hello_file).await?;
+            let commit = repositories::commit(&repo, "Adding hello file")?;
+
+            // Named, so the commit updates the workspace rather than deleting it.
+            let workspace = repositories::workspaces::create_with_name(
+                &repo,
+                &commit,
+                "wid-held",
+                Some("named-held".to_string()),
+                true,
+            )
+            .await?;
+
+            let workspace_hello_file = workspace.dir().join("hello.txt");
+            util::fs::write_to_path(&workspace_hello_file, "Hello again")?;
+            repositories::workspaces::files::add(&workspace, workspace_hello_file).await?;
+
+            let reader = get_staged_db_manager(&workspace.workspace_repo)?;
+
+            repositories::workspaces::commit(
+                &workspace,
+                &NewCommitBody {
+                    message: "Updating hello file".to_string(),
+                    author: "Bessie".to_string(),
+                    email: "bessie@oxen.ai".to_string(),
+                },
+                DEFAULT_BRANCH_NAME,
+            )
+            .await?;
+
+            let after = get_staged_db_manager(&workspace.workspace_repo)?;
+            assert!(after.read_from_staged_db("hello.txt")?.is_none());
+            assert!(
+                repositories::workspaces::status::status_from_dir(&workspace, Path::new(""))?
+                    .is_clean()
+            );
+
+            drop(reader);
             Ok(())
         })
         .await

--- a/crates/liboxen/src/repositories/workspaces.rs
+++ b/crates/liboxen/src/repositories/workspaces.rs
@@ -520,6 +520,10 @@ pub fn delete(workspace: &Workspace) -> Result<(), OxenError> {
 
     log::debug!("workspace::delete cleaning up workspace dir: {workspace_dir:?}");
 
+    // Close the staged db before anything else is mutated: a refusal here leaves the whole
+    // workspace intact for the caller to retry.
+    core::staged::close_staged_db(&workspace.workspace_repo.path)?;
+
     // Remove from name index before deleting the workspace directory
     if let Some(ref name) = workspace.name
         && workspace_name_index::index_exists(&workspace.base_repo)
@@ -534,8 +538,6 @@ pub fn delete(workspace: &Workspace) -> Result<(), OxenError> {
         }
     }
 
-    // Clean up caches before deleting the workspace
-    core::staged::close_staged_db(&workspace.workspace_repo.path)?;
     // Drop cached DuckDB connections rooted in this workspace before removing the dir. On NFS,
     // unlinking a still-open file leaves a hidden .nfsXXXX entry that fails the rmdir with ENOTEMPTY.
     df_db::remove_df_db_from_cache_with_children(&workspace_dir)?;
@@ -1486,6 +1488,55 @@ mod tests {
             );
 
             drop(reader);
+            Ok(())
+        })
+        .await
+    }
+
+    /// A delete that cannot close the staged db leaves the workspace untouched (directory, name
+    /// index, and registry entry), so the caller still holding the handle keeps reading through
+    /// it and a later delete removes the workspace once that caller is gone.
+    #[tokio::test]
+    async fn test_delete_keeps_the_workspace_while_the_staged_db_is_held() -> Result<(), OxenError>
+    {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let hello_file = repo.path.join("hello.txt");
+            util::fs::write_to_path(&hello_file, "Hello")?;
+            repositories::add(&repo, &hello_file).await?;
+            let commit = repositories::commit(&repo, "Adding hello file")?;
+
+            let workspace = repositories::workspaces::create_with_name(
+                &repo,
+                &commit,
+                "wid-held-delete",
+                Some("named-held-delete".to_string()),
+                true,
+            )
+            .await?;
+
+            let workspace_hello_file = workspace.dir().join("hello.txt");
+            util::fs::write_to_path(&workspace_hello_file, "Hello again")?;
+            repositories::workspaces::files::add(&workspace, workspace_hello_file).await?;
+
+            let reader = get_staged_db_manager(&workspace.workspace_repo)?;
+
+            assert!(repositories::workspaces::delete(&workspace).is_err());
+            assert!(workspace.dir().exists());
+            assert!(
+                repositories::workspaces::get_by_name(&repo, "named-held-delete")?.is_some(),
+                "the refused delete dropped the name index entry"
+            );
+
+            // The registry entry survived, so a caller arriving after the refused delete shares
+            // the open handle instead of colliding with RocksDB's per-directory LOCK.
+            let after = get_staged_db_manager(&workspace.workspace_repo)?;
+            assert!(after.read_from_staged_db("hello.txt")?.is_some());
+
+            drop(after);
+            drop(reader);
+            repositories::workspaces::delete(&workspace)?;
+            assert!(!workspace.dir().exists());
+
             Ok(())
         })
         .await


### PR DESCRIPTION
Clear the staged entries through the shared database handle when a workspace commit finishes, so a request already reading that workspace keeps the handle it holds and a later request opens against the same one. Dropping the handle from the registry and deleting the directory instead left RocksDB holding the per-directory lock for a reader the registry no longer tracked, so image and data frame reads against a workspace that commits on every edit failed until that reader finished.

Wait for the handle to drain before workspace delete removes the directory, since there the whole workspace is going away and clearing the entries is not enough.

Write the shared clear helper's deletions as one batch, so a reader sees either every staged entry or none rather than a half emptied database.

Sentry: OXEN-SERVER-34, OXEN-SERVER-36