### PR TITLE
Release the workspace staged database handle as soon as the lookup returns

### DIFF
--- a/crates/oxen-server/src/controllers/file.rs
+++ b/crates/oxen-server/src/controllers/file.rs
@@ -158,9 +158,14 @@ pub async fn get(
 
     let entry = match workspace {
         Some(ws) => {
-            let staged_db_manager = get_staged_db_manager(staged_repo)?;
+            // Scoped so the staged db handle is released before the awaits below, rather than
+            // held for the length of the response.
+            let staged_node = {
+                let staged_db_manager = get_staged_db_manager(staged_repo)?;
+                staged_db_manager.read_from_staged_db(&path)?
+            };
             // Try staged DB first
-            if let Some(staged_node) = staged_db_manager.read_from_staged_db(&path)? {
+            if let Some(staged_node) = staged_node {
                 match staged_node.node.node {
                     EMerkleTreeNode::File(f) => Ok(f),
                     _ => Err(OxenError::NotAFile(path.clone().into())),

--- a/crates/oxen-server/src/controllers/workspaces/files.rs
+++ b/crates/oxen-server/src/controllers/workspaces/files.rs
@@ -93,9 +93,13 @@ pub async fn get(
     let path = path_param(&req, "path")?.to_string();
     log::debug!("got workspace file path {:?}", path);
 
-    // First, look for the file in the workspace staged_db
-    let staged_db_manager = get_staged_db_manager(&workspace.workspace_repo)?;
-    let file_node = match staged_db_manager.read_from_staged_db(&path)? {
+    // First, look for the file in the workspace staged_db. Scoped so the staged db handle is
+    // released before the awaits below, rather than held for the length of the response.
+    let staged_node = {
+        let staged_db_manager = get_staged_db_manager(&workspace.workspace_repo)?;
+        staged_db_manager.read_from_staged_db(&path)?
+    };
+    let file_node = match staged_node {
         Some(staged_node) => match staged_node.node.node {
             EMerkleTreeNode::File(f) => Ok(f),
             _ => Err(OxenError::NotAFile(PathBuf::from(&path).into())),


### PR DESCRIPTION
Scope the staged database read so the handle is dropped after the lookup rather than held across the image resize, video thumbnail, and version stream awaits that follow. A handle held for the length of a response keeps the workspace's RocksDB open across unrelated image and video work.

Sentry: OXEN-SERVER-34, OXEN-SERVER-36