### PR TITLE
Bump to rust 1.98.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.98.0"
+channel = "1.98.1"


### PR DESCRIPTION
[Rust 1.98.1](https://blog.rust-lang.org/2026/09/03/Rust-1.98.1/) is a bugfix release targeting miscompilations.