### PR TITLE
Document OTLP log export in the oxen-cli README

### DIFF
--- a/crates/oxen-cli/README.md
+++ b/crates/oxen-cli/README.md
@@ -71,39 +71,26 @@ OXEN_OTEL_FILTER=warn,liboxen=debug OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost
 
 ### OTLP log export
 
-Set `OTEL_LOGS_EXPORTER=otlp` and the CLI also exports its events as OTLP log
-records, over the endpoint and transport span export already uses. Unset, or
-`none`, exports no log records at all.
+`OTEL_LOGS_EXPORTER=otlp` also exports events as OTLP log records. They go to
+`OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`, or to the shared `OTEL_EXPORTER_OTLP_ENDPOINT`
+the example below sets. The traces-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+does not configure them, so naming only that one exports no records:
 
 ```bash
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
-OTEL_LOGS_EXPORTER=otlp \
-oxen pull
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 OTEL_LOGS_EXPORTER=otlp oxen pull
 ```
 
-The filter split above applies here too, and is worth restating for the CLI:
-`OXEN_OTEL_FILTER` defaults to `info` while `RUST_LOG` defaults to `off`, so a
-CLI that logs nothing still exports log records once this is set. Turn export
-off by setting `OTEL_LOGS_EXPORTER=none` or unsetting it, not by lowering
-`RUST_LOG`.
-
-A record carries the trace and span id of the span it was recorded in, and the
-CLI is instrumented on the paths that talk to a remote. So `clone`, `pull`,
-`push`, and `fetch` produce records that correlate with their trace, while a
-local-only command like `init` or `add` creates no span and its records carry
-an empty trace id.
-
-The `opentelemetry`, `opentelemetry_sdk`, and `opentelemetry_otlp` targets, and
-the transport the exporter sends over (`reqwest`, `hyper`, `hyper_util`, `h2`,
-`tonic`, `tower`), never become log records whatever the filter says: an export
-is itself network IO that logs, and exporting those lines feeds the exporter a
-fresh batch for every batch it delivers. Since that covers the CLI's own HTTP
-client, use `RUST_LOG` when you want to watch a transfer's client-side detail.
+Export follows `OXEN_OTEL_FILTER`, so a CLI that logs nothing still exports
+records, and lowering `RUST_LOG` will not stop it. A record carries a trace id
+only when span export is on as well and the command opens a span: naming only
+the logs endpoint leaves every trace id empty, and alongside span export
+`clone`, `pull`, `push`, and `fetch` correlate while `init` and `add` open no
+span. Jaeger takes traces only, so reading the records needs a backend that
+accepts both signals.
 
 The [oxen-server README](../oxen-server/README.md#otlp-log-export) covers the
-signal-specific variables (`OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` and friends),
-batch tuning, and the span-event overlap; all of it applies to the CLI, which
-shares the same telemetry setup.
+rest, all of which applies here: signal-specific variables, batch tuning, the
+targets that are never exported, and the span-event overlap.
 
 ### Quick start with Jaeger
 
@@ -121,27 +108,6 @@ docker run --rm --name jaeger \
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 cargo run --features otel -p oxen-cli pull
 
 # View traces at http://localhost:16686 under service "oxen"
-```
-
-Jaeger stores traces only. To see exported log records, and how they correlate
-with a trace, run a collector with the debug exporter (or a backend that takes
-both signals) instead:
-
-The receiver endpoints have to be spelled out as `0.0.0.0`. Left to its
-default the collector listens on localhost inside the container, which the
-published ports never reach, and every export fails with an empty reply.
-
-```bash
-docker run --rm --name otelcol -p 4317:4317 -p 4318:4318 \
-  otel/opentelemetry-collector:latest \
-  --config "yaml:{receivers: {otlp: {protocols: \
-{http: {endpoint: 0.0.0.0:4318}, grpc: {endpoint: 0.0.0.0:4317}}}}, \
-exporters: {debug: {verbosity: detailed}}, \
-service: {pipelines: {traces: {receivers: [otlp], exporters: [debug]}, \
-logs: {receivers: [otlp], exporters: [debug]}}}}"
-
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 OTEL_LOGS_EXPORTER=otlp \
-  cargo run --features otel -p oxen-cli pull
 ```
 
 When the `otel` feature is not compiled in, no OpenTelemetry dependencies

--- a/crates/oxen-cli/README.md
+++ b/crates/oxen-cli/README.md
@@ -65,8 +65,45 @@ OXEN_OTEL_FILTER=warn,liboxen=debug OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector URL, needing an `http://` or `https://` scheme, which under HTTP has `/v1/traces` appended to it. Absent = disabled, unless `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` names one. | *(none)* |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | The traces endpoint, taking precedence over the above and posted to exactly as configured under HTTP, so include `/v1/traces` in it. | *(none)* |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | Transport: `grpc`, or `http` / `http/protobuf` / `http/json` for HTTP (binary protobuf either way). `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` takes precedence over it. | `http/protobuf` |
-| `OXEN_OTEL_FILTER` | Which spans and events are exported. Same syntax as `RUST_LOG`, and independent of it. | `info` |
-| `RUST_LOG` | Log verbosity on stderr. Does not affect span export. | `off` |
+| `OXEN_OTEL_FILTER` | Which spans, events, and log records are exported. Same syntax as `RUST_LOG`, and independent of it. | `info` |
+| `OTEL_LOGS_EXPORTER` | `otlp` to also export events as OTLP log records; `none` or unset exports none. See [OTLP log export](#otlp-log-export). | *(none)* |
+| `RUST_LOG` | Log verbosity on stderr. Does not affect what is exported. | `off` |
+
+### OTLP log export
+
+Set `OTEL_LOGS_EXPORTER=otlp` and the CLI also exports its events as OTLP log
+records, over the endpoint and transport span export already uses. Unset, or
+`none`, exports no log records at all.
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+OTEL_LOGS_EXPORTER=otlp \
+oxen pull
+```
+
+The filter split above applies here too, and is worth restating for the CLI:
+`OXEN_OTEL_FILTER` defaults to `info` while `RUST_LOG` defaults to `off`, so a
+CLI that logs nothing still exports log records once this is set. Turn export
+off by setting `OTEL_LOGS_EXPORTER=none` or unsetting it, not by lowering
+`RUST_LOG`.
+
+A record carries the trace and span id of the span it was recorded in, and the
+CLI is instrumented on the paths that talk to a remote. So `clone`, `pull`,
+`push`, and `fetch` produce records that correlate with their trace, while a
+local-only command like `init` or `add` creates no span and its records carry
+an empty trace id.
+
+The `opentelemetry`, `opentelemetry_sdk`, and `opentelemetry_otlp` targets, and
+the transport the exporter sends over (`reqwest`, `hyper`, `hyper_util`, `h2`,
+`tonic`, `tower`), never become log records whatever the filter says: an export
+is itself network IO that logs, and exporting those lines feeds the exporter a
+fresh batch for every batch it delivers. Since that covers the CLI's own HTTP
+client, use `RUST_LOG` when you want to watch a transfer's client-side detail.
+
+The [oxen-server README](../oxen-server/README.md#otlp-log-export) covers the
+signal-specific variables (`OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` and friends),
+batch tuning, and the span-event overlap; all of it applies to the CLI, which
+shares the same telemetry setup.
 
 ### Quick start with Jaeger
 
@@ -84,6 +121,27 @@ docker run --rm --name jaeger \
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 cargo run --features otel -p oxen-cli pull
 
 # View traces at http://localhost:16686 under service "oxen"
+```
+
+Jaeger stores traces only. To see exported log records, and how they correlate
+with a trace, run a collector with the debug exporter (or a backend that takes
+both signals) instead:
+
+The receiver endpoints have to be spelled out as `0.0.0.0`. Left to its
+default the collector listens on localhost inside the container, which the
+published ports never reach, and every export fails with an empty reply.
+
+```bash
+docker run --rm --name otelcol -p 4317:4317 -p 4318:4318 \
+  otel/opentelemetry-collector:latest \
+  --config "yaml:{receivers: {otlp: {protocols: \
+{http: {endpoint: 0.0.0.0:4318}, grpc: {endpoint: 0.0.0.0:4317}}}}, \
+exporters: {debug: {verbosity: detailed}}, \
+service: {pipelines: {traces: {receivers: [otlp], exporters: [debug]}, \
+logs: {receivers: [otlp], exporters: [debug]}}}}"
+
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 OTEL_LOGS_EXPORTER=otlp \
+  cargo run --features otel -p oxen-cli pull
 ```
 
 When the `otel` feature is not compiled in, no OpenTelemetry dependencies


### PR DESCRIPTION
This PR's diff is one markdown file.

The CLI shares liboxen's telemetry setup, so `OTEL_LOGS_EXPORTER=otlp` works there too, and its env-var table was the one place that went unmentioned.

Adds the table row plus a short section covering what is actually specific to the CLI, both measured:

- Export follows `OXEN_OTEL_FILTER` (default `info`) while `RUST_LOG` defaults to `off`, so setting the variable makes a CLI that logs nothing start exporting records, and lowering `RUST_LOG` will not stop it. `OTEL_LOGS_EXPORTER=none` exports zero.
- A record carries a trace id only when span export is configured and the command opens a span. Instrumentation sits on the paths that reach a remote, so `clone`/`pull`/`push`/`fetch` correlate, while `init` and `add` open no span. All 31 records from a local-only run carried an empty trace id, which is worth documenting rather than leaving someone to debug their backend.

It also names the endpoint the log exporter reads: `otel_endpoint` resolves `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` and then the shared `OTEL_EXPORTER_OTLP_ENDPOINT`, never the traces-specific variable, so setting only `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` exports no records.

Everything else points at the oxen-server README rather than being duplicated.