### PR TITLE
Select thin LTO for the released server image

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -134,9 +134,9 @@ jobs:
 
       # Thin LTO in place of the release profile's fat LTO, a serial link-time pass
       # that reruns whenever this repository's own crates change, so no layer cache
-      # can avoid it. `release_docker.yml` passes no override, so released binaries
-      # keep fat LTO. `codegen-units` stays at 1 — raising it trades binary size for
-      # less time than this saves.
+      # can avoid it. `release_docker.yml` selects it too, so both server images this
+      # repository publishes are built the same way. `codegen-units` stays at 1,
+      # since raising it trades binary size for less time than this saves.
       - name: Build oxen-server Docker Image (${{ inputs.ARCHITECTURE }})
         env:
           # Per architecture: a shared ref would have each build overwrite the other.

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -108,10 +108,14 @@ jobs:
           echo "COMMIT=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "BUILD_DATE_UTC=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
+      # Thin LTO, matching `build_branch.yml` and `release_windows.yml`. Every server image this
+      # repository publishes is then built the same way, so a release can reuse an image already
+      # built from main instead of rebuilding it.
       - name: Build Docker Image
         run: |
           cd ${{ github.workspace }}
           docker build \
+            --build-arg CARGO_PROFILE_RELEASE_LTO=thin \
             --label "org.opencontainers.image.revision=${{ steps.metadata.outputs.COMMIT }}" \
             --label "org.opencontainers.image.version=${{ steps.metadata.outputs.VERSION }}" \
             --label "org.opencontainers.image.created=${{ steps.metadata.outputs.BUILD_DATE_UTC }}" \


### PR DESCRIPTION
`release_docker.yml` passed no profile override, so it inherited the Dockerfile's `ARG CARGO_PROFILE_RELEASE_LTO=true`, while the other two release paths select thin: `release_windows.yml` for the CLI it ships and `build_branch.yml` for the image it publishes. Which setting a server image got depended on the workflow that produced it, and nothing stated the intent either way.

Fat LTO is a serial link-time pass that reruns whenever this repository's own crates change. On this image it costs about 7m35s of build time and yields a smaller binary: measured on arm64 at `v0.55.0`, `oxen-server` is 40.96 MB under fat and 49.32 MB under thin. Taking thin makes every server image this repository publishes identical in build configuration.

Worth knowing before merging: the `oxen-server` binary in the released image grows by roughly 20%. The `ARG` default stays `true`, so a plain `docker build` still compiles what `[profile.release]` specifies.