### PR TITLE
S3 (28.5.1): Record the repository UUID on the remote a clone attaches

### DIFF
--- a/crates/liboxen/src/api/client/repositories.rs
+++ b/crates/liboxen/src/api/client/repositories.rs
@@ -65,10 +65,7 @@ pub async fn get_by_name_host_and_remote(
     let scheme = scheme.as_ref();
     let url = api::endpoint::remote_url_from_name_and_scheme(host.as_ref(), name, scheme);
     log::debug!("get_by_name_host_and_remote({name}) remote url: {url}");
-    let remote = Remote {
-        name: String::from(remote.as_ref()),
-        url,
-    };
+    let remote = Remote::new(remote.as_ref(), &url);
     get_by_remote(&remote).await
 }
 
@@ -81,10 +78,7 @@ pub async fn exists(repo: &RemoteRepository) -> Result<bool, OxenError> {
 }
 
 pub async fn get_by_url(url: &str) -> Result<RemoteRepository, OxenError> {
-    let remote = Remote {
-        name: String::from(DEFAULT_REMOTE_NAME),
-        url: url.to_string(),
-    };
+    let remote = Remote::new(DEFAULT_REMOTE_NAME, url);
     get_by_remote(&remote).await
 }
 
@@ -141,12 +135,12 @@ pub async fn create_empty(repo: RepoNew) -> Result<RemoteRepository, OxenError> 
             let response: RepositoryCreationResponse = serde_json::from_str(&body)?;
             Ok(RemoteRepository::from_creation_view(
                 &response.repository,
-                &Remote {
-                    url: api::endpoint::remote_url_from_namespace_name_scheme(
+                &Remote::new(
+                    DEFAULT_REMOTE_NAME,
+                    &api::endpoint::remote_url_from_namespace_name_scheme(
                         &host, namespace, repo_name, &scheme,
                     ),
-                    name: String::from(DEFAULT_REMOTE_NAME),
-                },
+                ),
             ))
         }
         Err(err) => {
@@ -178,15 +172,15 @@ pub async fn create(repo_new: RepoNew) -> Result<RemoteRepository, OxenError> {
         match response {
             Ok(response) => Ok(RemoteRepository::from_creation_view(
                 &response.repository,
-                &Remote {
-                    url: api::endpoint::remote_url_from_namespace_name_scheme(
+                &Remote::new(
+                    DEFAULT_REMOTE_NAME,
+                    &api::endpoint::remote_url_from_namespace_name_scheme(
                         &host,
                         &repo_new.namespace,
                         &repo_new.name,
                         &repo_new.scheme(),
                     ),
-                    name: String::from(DEFAULT_REMOTE_NAME),
-                },
+                ),
             )),
             Err(err) => {
                 let err = format!(
@@ -230,14 +224,14 @@ pub async fn create_from_local(
     match response {
         Ok(response) => Ok(RemoteRepository::from_creation_view(
             &response.repository,
-            &Remote {
-                url: api::endpoint::remote_url_from_namespace_name(
+            &Remote::new(
+                DEFAULT_REMOTE_NAME,
+                &api::endpoint::remote_url_from_namespace_name(
                     &host,
                     &repo_new.namespace,
                     &repo_new.name,
                 ),
-                name: String::from(DEFAULT_REMOTE_NAME),
-            },
+            ),
         )),
         Err(err) => Err(OxenError::FailCreateOrFindRemoteRepo {
             repo_id: repo_new.repo_id(),
@@ -314,10 +308,7 @@ pub async fn transfer_namespace(
                     &repository.name,
                     &scheme,
                 );
-                let new_remote = Remote {
-                    url: new_remote_url,
-                    name: repository.remote.name.clone(),
-                };
+                let new_remote = Remote::new(&repository.remote.name, &new_remote_url);
 
                 Ok(RemoteRepository::from_view(
                     &response.repository,

--- a/crates/liboxen/src/api/client/repositories.rs
+++ b/crates/liboxen/src/api/client/repositories.rs
@@ -308,7 +308,11 @@ pub async fn transfer_namespace(
                     &repository.name,
                     &scheme,
                 );
-                let new_remote = Remote::new(&repository.remote.name, &new_remote_url);
+                // A move changes where the remote points, not the repository's identity.
+                let new_remote = Remote {
+                    url: new_remote_url,
+                    ..repository.remote.clone()
+                };
 
                 Ok(RemoteRepository::from_view(
                     &response.repository,

--- a/crates/liboxen/src/core/v_latest/clone.rs
+++ b/crates/liboxen/src/core/v_latest/clone.rs
@@ -1,4 +1,3 @@
-use crate::constants::DEFAULT_REMOTE_NAME;
 use crate::error::OxenError;
 use crate::model::{LocalRepository, RemoteRepository};
 use crate::opts::CloneOpts;
@@ -36,7 +35,6 @@ pub async fn clone_repo(
     )?;
     local_repo.version_store().init().await?;
     repo_path.clone_into(&mut local_repo.path);
-    local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
     local_repo.set_subtree_paths(opts.fetch_opts.subtree_paths.clone());
     local_repo.set_depth(opts.fetch_opts.depth);
 
@@ -102,7 +100,6 @@ pub async fn clone_repo_remote_mode(
     )?;
     local_repo.version_store().init().await?;
     repo_path.clone_into(&mut local_repo.path);
-    local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
     local_repo.set_remote_mode(Some(true));
 
     if opts.is_vfs {

--- a/crates/liboxen/src/model/remote.rs
+++ b/crates/liboxen/src/model/remote.rs
@@ -1,9 +1,34 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use uuid::Uuid;
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct Remote {
     pub name: String,
     pub url: String,
+    /// The UUID the remote addresses this repository's storage by. Absent on a remote written
+    /// before clients recorded it, and on one pointing at a repository that reports no identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_uuid: Option<Uuid>,
+}
+
+impl Remote {
+    /// A remote naming where a repository lives, with no UUID recorded for it.
+    pub fn new(name: &str, url: &str) -> Remote {
+        Remote {
+            name: name.to_string(),
+            url: url.to_string(),
+            repo_uuid: None,
+        }
+    }
+
+    /// The same remote, taking `repo_uuid` only where it has none recorded.
+    ///
+    pub(crate) fn with_repo_uuid_if_absent(self, repo_uuid: Option<Uuid>) -> Remote {
+        Remote {
+            repo_uuid: self.repo_uuid.or(repo_uuid),
+            ..self
+        }
+    }
 }
 
 impl std::fmt::Display for Remote {
@@ -13,3 +38,41 @@ impl std::fmt::Display for Remote {
 }
 
 impl std::error::Error for Remote {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The client config is TOML, and a remote written before clients recorded a UUID has no key
+    /// for it, so it has to load as absent rather than failing the whole config.
+    #[test]
+    fn a_remote_without_a_uuid_loads_with_none() {
+        let remote: Remote =
+            toml::from_str("name = \"origin\"\nurl = \"http://localhost:3000/ox/cats\"\n")
+                .expect("a remote predating the field parses");
+
+        assert_eq!(remote.repo_uuid, None);
+    }
+
+    /// Guards the `skip_serializing_if`, so a config written for a repository with no identity
+    /// carries no key an older client would have to tolerate.
+    #[test]
+    fn an_absent_uuid_is_not_written_at_all() {
+        let toml = toml::to_string(&Remote::new("origin", "http://localhost:3000/ox/cats"))
+            .expect("serialize");
+
+        assert!(!toml.contains("repo_uuid"), "unexpected key in:\n{toml}");
+    }
+
+    #[test]
+    fn a_recorded_uuid_round_trips() {
+        let repo_uuid = Uuid::new_v4();
+        let remote = Remote::new("origin", "http://localhost:3000/ox/cats")
+            .with_repo_uuid_if_absent(Some(repo_uuid));
+
+        let loaded: Remote =
+            toml::from_str(&toml::to_string(&remote).expect("serialize")).expect("deserialize");
+
+        assert_eq!(loaded.repo_uuid, Some(repo_uuid));
+    }
+}

--- a/crates/liboxen/src/model/repository/local_repository.rs
+++ b/crates/liboxen/src/model/repository/local_repository.rs
@@ -367,11 +367,7 @@ impl LocalRepository {
     pub fn set_remote(&mut self, name: impl AsRef<str>, url: impl AsRef<str>) -> Remote {
         self.remote_name = Some(name.as_ref().to_owned());
         let name = name.as_ref();
-        let url = url.as_ref();
-        let remote = Remote {
-            name: name.to_owned(),
-            url: url.to_owned(),
-        };
+        let remote = Remote::new(name, url.as_ref());
         if self.has_remote(name) {
             // find remote by name and set
             for i in 0..self.remotes.len() {
@@ -976,10 +972,7 @@ mod tests {
         RemoteRepository {
             namespace: String::from("ns"),
             name: String::from("repo"),
-            remote: Remote {
-                name: String::from("origin"),
-                url: String::from("http://localhost:3000/ns/repo"),
-            },
+            remote: Remote::new("origin", "http://localhost:3000/ns/repo"),
             min_version: None,
             is_empty: true,
             storage_kind: StorageKind::Local,

--- a/crates/liboxen/src/model/repository/remote_repository.rs
+++ b/crates/liboxen/src/model/repository/remote_repository.rs
@@ -27,7 +27,9 @@ impl RemoteRepository {
         RemoteRepository {
             namespace: repository.namespace.clone(),
             name: repository.name.clone(),
-            remote: remote.clone(),
+            remote: remote
+                .clone()
+                .with_repo_uuid_if_absent(repository.repo_uuid),
             min_version: repository.min_version.clone(),
             is_empty: repository.is_empty,
             storage_kind: repository.storage_kind,
@@ -42,7 +44,9 @@ impl RemoteRepository {
         RemoteRepository {
             namespace: repository.namespace.clone(),
             name: repository.name.clone(),
-            remote: remote.clone(),
+            remote: remote
+                .clone()
+                .with_repo_uuid_if_absent(repository.repo_uuid),
             min_version: repository.min_version.clone(),
             is_empty: true,
             storage_kind: repository.storage_kind,

--- a/crates/liboxen/src/repositories/clone.rs
+++ b/crates/liboxen/src/repositories/clone.rs
@@ -103,6 +103,39 @@ mod tests {
 
     use super::*;
 
+    /// A clone is the main path that first attaches a repository to a server, so the UUID the
+    /// server reports has to survive into the cloned repo's own config rather than only living on
+    /// the in-memory remote.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
+    #[tokio::test]
+    async fn test_clone_records_the_remotes_repo_uuid() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|local_repo| async move {
+            let remote_repo = test::create_remote_repo(&local_repo).await?;
+            let expected = remote_repo
+                .remote
+                .repo_uuid
+                .expect("the server reports a UUID for a repo it created");
+
+            test::run_empty_dir_test_async(|dir| async move {
+                let opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let cloned = clone_remote(&opts).await?;
+
+                // Read it back off disk rather than from the returned struct, since persisting it
+                // is the whole point.
+                let reopened = LocalRepository::from_dir(&cloned.path)?;
+                let remote = reopened
+                    .get_remote(DEFAULT_REMOTE_NAME)
+                    .expect("a clone records a remote under the default name");
+                assert_eq!(remote.repo_uuid, Some(expected));
+
+                api::client::repositories::delete(&remote_repo).await?;
+                Ok(())
+            })
+            .await
+        })
+        .await
+    }
+
     #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_remote() -> Result<(), OxenError> {


### PR DESCRIPTION
Record the server's repository UUID in the client's clone when it attaches to it.

ENG-1622