### PR TITLE
S3 (28.5.2): Record the repository UUID when a remote is attached from a URL

### DIFF
--- a/CommandWorkflow.md
+++ b/CommandWorkflow.md
@@ -127,9 +127,14 @@ Revert back
 
 ## Collaboration
 
-Push the changes
+Create the remote repository, then point the local one at it. Setting a remote reads the
+repository from the server, so it has to exist first.
+
+`oxen create-remote --name repositories/SmallCatDog --host 0.0.0.0:3000 --scheme http`
 
 `oxen config --set-remote origin http://0.0.0.0:3000/repositories/SmallCatDog`
+
+Push the changes
 
 `oxen push`
 

--- a/SelfHosting.md
+++ b/SelfHosting.md
@@ -186,7 +186,9 @@ $ oxen create-remote --name MyNamespace/MyRepoName --host 0.0.0.0:3001 --scheme 
 
 Repositories that live on an Oxen Server have the idea of a `namespace` and a `name` to help you organize your repositories.
 
-Once you know your remote repository URL you can add it as a remote.
+Once you know your remote repository URL you can add it as a remote. Setting a remote reads the
+repository from the server and records the identifier it reports, so the server has to be reachable
+and the repository has to exist by this point.
 
 ```bash
 $ oxen config --set-remote origin http://<HOST>/MyNamespace/MyRepoName

--- a/crates/liboxen/src/command/config.rs
+++ b/crates/liboxen/src/command/config.rs
@@ -74,6 +74,7 @@ mod tests {
 
     /// Attaching from a URL asks the server who the repository is, so the UUID lands in the config
     /// even though the caller only had a URL to go on.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_set_remote_by_url_records_the_servers_uuid() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|mut repo, remote_repo| async move {

--- a/crates/liboxen/src/command/config.rs
+++ b/crates/liboxen/src/command/config.rs
@@ -3,12 +3,12 @@
 //! Configuration commands for Oxen
 //!
 
+use crate::api::client::repositories::get_by_url;
 use crate::error::OxenError;
 use crate::model::{LocalRepository, Remote};
 
-/// # Set the remote for a repository
-/// Tells the CLI where to push the changes to
-pub fn set_remote(repo: &mut LocalRepository, name: &str, url: &str) -> Result<Remote, OxenError> {
+/// Refuse a URL this repository cannot take a remote from.
+fn reject_unusable_remote(repo: &LocalRepository, url: &str) -> Result<(), OxenError> {
     if url::Url::parse(url).is_err() {
         return Err(OxenError::invalid_set_remote_url(url));
     }
@@ -19,7 +19,36 @@ pub fn set_remote(repo: &mut LocalRepository, name: &str, url: &str) -> Result<R
         ));
     }
 
+    Ok(())
+}
+
+/// Attach a remote from a name and URL alone, available only in test / `test-utils` builds.
+///
+/// Production code uses [`set_remote_by_url`], which records the UUID the repository is addressed
+/// by. Tests use this for fixture setup against a remote they created inline.
+#[cfg(any(test, feature = "test-utils"))]
+pub fn set_remote(repo: &mut LocalRepository, name: &str, url: &str) -> Result<Remote, OxenError> {
+    reject_unusable_remote(repo, url)?;
+
     let remote = repo.set_remote(name, url);
+    repo.save()?;
+    Ok(remote)
+}
+
+/// # Set the remote for a repository from its URL
+///
+/// Reads the repository at `url` and records the UUID it reports, leaving the remote addressable
+/// by UUID rather than only by name. Records nothing when the repository cannot be read. A
+/// repository reporting no identity is recorded with its name and URL alone.
+pub async fn set_remote_by_url(
+    repo: &mut LocalRepository,
+    name: &str,
+    url: &str,
+) -> Result<Remote, OxenError> {
+    reject_unusable_remote(repo, url)?;
+
+    let remote_repo = get_by_url(url).await?;
+    let remote = repo.set_remote_repo(name, &remote_repo);
     repo.save()?;
     Ok(remote)
 }
@@ -36,4 +65,54 @@ pub fn delete_remote(repo: &mut LocalRepository, name: &str) -> Result<(), OxenE
     repo.delete_remote(name);
     repo.save()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test;
+
+    /// Attaching from a URL asks the server who the repository is, so the UUID lands in the config
+    /// even though the caller only had a URL to go on.
+    #[tokio::test]
+    async fn test_set_remote_by_url_records_the_servers_uuid() -> Result<(), OxenError> {
+        test::run_empty_remote_repo_test(|mut repo, remote_repo| async move {
+            let expected = remote_repo
+                .remote
+                .repo_uuid
+                .expect("the server reports a UUID for a repo it created");
+
+            let remote = set_remote_by_url(&mut repo, "origin", &remote_repo.remote.url).await?;
+
+            assert_eq!(remote.repo_uuid, Some(expected));
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    /// Attaching a remote is how a repository learns the UUID it is addressed by, so a server that
+    /// cannot be read leaves nothing attached rather than a remote reachable only by name.
+    #[tokio::test]
+    async fn test_set_remote_by_url_errors_when_the_server_cannot_be_read() -> Result<(), OxenError>
+    {
+        test::run_empty_local_repo_test_async(|mut repo| async move {
+            // Refused immediately rather than blackholed, so this does not wait out a connect
+            // timeout.
+            let url = "http://localhost:1/ox/cats";
+            let err = set_remote_by_url(&mut repo, "origin", url)
+                .await
+                .expect_err("nothing accepts connections on port 1");
+            assert!(
+                matches!(err, OxenError::HTTP(_)),
+                "expected a failed read rather than local URL validation: {err}"
+            );
+            assert!(
+                repo.remotes().is_empty(),
+                "a failed attach records nothing: {:?}",
+                repo.remotes()
+            );
+            Ok(())
+        })
+        .await
+    }
 }

--- a/crates/liboxen/src/lib.rs
+++ b/crates/liboxen/src/lib.rs
@@ -47,7 +47,7 @@
 //! // Set remote
 //! let remote_url = "http://0.0.0.0:3000/ox/test_repo";
 //! let remote_name = "origin";
-//! command::config::set_remote(&mut repo, remote_name, remote_url)?;
+//! command::config::set_remote_by_url(&mut repo, remote_name, remote_url).await?;
 //! // Push to remote
 //! repositories::push(&repo).await?;
 //! # Ok(())

--- a/crates/liboxen/src/model/repository/local_repository.rs
+++ b/crates/liboxen/src/model/repository/local_repository.rs
@@ -364,19 +364,26 @@ impl LocalRepository {
         Ok(())
     }
 
-    pub fn set_remote(&mut self, name: impl AsRef<str>, url: impl AsRef<str>) -> Remote {
-        self.remote_name = Some(name.as_ref().to_owned());
-        let name = name.as_ref();
-        let remote = Remote::new(name, url.as_ref());
-        if self.has_remote(name) {
-            // find remote by name and set
-            for i in 0..self.remotes.len() {
-                if self.remotes[i].name == name {
-                    self.remotes[i] = remote.clone()
-                }
-            }
+    /// Record `name` as this repository's remote at `url`, with no UUID for the repository it
+    /// points at.
+    pub fn set_remote(&mut self, name: &str, url: &str) -> Remote {
+        self.upsert_remote(Remote::new(name, url))
+    }
+
+    /// Record the remote `remote_repo` was reached through, under `name`.
+    pub(crate) fn set_remote_repo(&mut self, name: &str, remote_repo: &RemoteRepository) -> Remote {
+        self.upsert_remote(Remote {
+            name: name.to_string(),
+            ..remote_repo.remote.clone()
+        })
+    }
+
+    /// Store `remote` under its own name, replacing any remote already recorded under it.
+    fn upsert_remote(&mut self, remote: Remote) -> Remote {
+        self.remote_name = Some(remote.name.clone());
+        if let Some(existing) = self.remotes.iter_mut().find(|r| r.name == remote.name) {
+            *existing = remote.clone();
         } else {
-            // we don't have the key, just push
             self.remotes.push(remote.clone());
         }
         remote
@@ -669,6 +676,7 @@ mod tests {
     use crate::storage::StorageKind;
     use crate::test;
     use tempfile::TempDir;
+    use uuid::Uuid;
 
     #[tokio::test]
     async fn test_mtime_matches_honors_tolerance() -> Result<(), OxenError> {
@@ -966,6 +974,40 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    /// Attaching from a repository the client has talked to records the UUID it reported, which is
+    /// what lets the repository be addressed by UUID instead of only by name. Attaching from a URL
+    /// alone has none to record, and re-attaching under one name replaces rather than appends.
+    #[test]
+    fn test_set_remote_repo_records_the_reported_uuid() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test(|mut repo| {
+            repo.set_remote("origin", "http://0.0.0.0:3000/ox/cats");
+            assert_eq!(
+                repo.get_remote("origin")
+                    .and_then(|remote| remote.repo_uuid),
+                None
+            );
+
+            let repo_uuid = Uuid::new_v4();
+            let mut remote_repo = remote_repo_reporting(None);
+            remote_repo.remote.repo_uuid = Some(repo_uuid);
+            let recorded = repo.set_remote_repo("origin", &remote_repo);
+
+            assert_eq!(recorded.repo_uuid, Some(repo_uuid));
+            assert_eq!(recorded.url, remote_repo.remote.url);
+            assert_eq!(repo.remotes().len(), 1, "remotes: {:?}", repo.remotes());
+            assert_eq!(
+                repo.get_remote("origin")
+                    .and_then(|remote| remote.repo_uuid),
+                Some(repo_uuid)
+            );
+
+            // A repository reporting no identity is still attachable.
+            let plain = repo.set_remote_repo("origin", &remote_repo_reporting(None));
+            assert_eq!(plain.repo_uuid, None);
+            Ok(())
+        })
     }
 
     fn remote_repo_reporting(backend: Option<MerkleNodeBackend>) -> RemoteRepository {

--- a/crates/liboxen/src/repositories/push.rs
+++ b/crates/liboxen/src/repositories/push.rs
@@ -28,7 +28,8 @@
 /// repositories::commit(&repo, "My commit message")?;
 ///
 /// // Set the remote server
-/// command::config::set_remote(&mut repo, "origin", "http://localhost:3000/repositories/hello")?;
+/// let remote_url = "http://localhost:3000/repositories/hello";
+/// command::config::set_remote_by_url(&mut repo, "origin", remote_url).await?;
 ///
 /// // Push the file
 /// repositories::push(&repo).await?;

--- a/crates/oxen-cli/src/cmd/config.rs
+++ b/crates/oxen-cli/src/cmd/config.rs
@@ -104,7 +104,7 @@ impl RunCmd for ConfigCmd {
             let mut repo = LocalRepository::from_current_dir()?;
             let values: Vec<_> = remote.collect();
             // clap enforces number_of_values(2), so this is guaranteed
-            self.set_remote(&mut repo, values[0], values[1])?;
+            self.set_remote(&mut repo, values[0], values[1]).await?;
         }
 
         if let Some(name) = args.get_one::<String>("delete-remote") {
@@ -128,13 +128,13 @@ impl ConfigCmd {
         }
     }
 
-    pub fn set_remote(
+    async fn set_remote(
         &self,
         repo: &mut LocalRepository,
         name: &str,
         url: &str,
     ) -> Result<(), OxenError> {
-        command::config::set_remote(repo, name, url)?;
+        command::config::set_remote_by_url(repo, name, url).await?;
 
         Ok(())
     }

--- a/crates/oxen-py/src/py_repo.rs
+++ b/crates/oxen-py/src/py_repo.rs
@@ -8,6 +8,7 @@ use liboxen::opts::{CleanOpts, CloneOpts, PushOpts, RmOpts};
 use pyo3::prelude::*;
 
 use liboxen::api;
+use liboxen::command::config;
 use liboxen::opts::FetchOpts;
 use liboxen::repositories;
 
@@ -212,7 +213,8 @@ impl PyRepo {
 
     pub fn set_remote(&self, name: &str, url: &str) -> Result<(), PyOxenError> {
         let mut repo = LocalRepository::from_dir(&self.path)?;
-        liboxen::command::config::set_remote(&mut repo, name, url)?;
+        pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(async { config::set_remote_by_url(&mut repo, name, url).await })?;
         Ok(())
     }
 


### PR DESCRIPTION
- Read the remote repository when an Oxen client connects to it and record the UUID it reports.
- Require a reachable server and an existing repository to attach a remote.
- Add tests

ENG-1807