### PR TITLE
S3 (28.5.3): Refuse a remote that points at a different repository

### DIFF
--- a/crates/liboxen/src/api/client/repositories.rs
+++ b/crates/liboxen/src/api/client/repositories.rs
@@ -82,6 +82,8 @@ pub async fn get_by_url(url: &str) -> Result<RemoteRepository, OxenError> {
     get_by_remote(&remote).await
 }
 
+/// Resolve `remote` against its server, taking the UUID the repository reports where the remote has
+/// none recorded. Errors when the recorded and reported UUIDs disagree.
 #[tracing::instrument(skip_all)]
 pub async fn get_by_remote(remote: &Remote) -> Result<RemoteRepository, OxenError> {
     let url = api::endpoint::url_from_remote(remote, "")?;
@@ -99,7 +101,10 @@ pub async fn get_by_remote(remote: &Remote) -> Result<RemoteRepository, OxenErro
 
     let response: Result<RepositoryResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
-        Ok(j_res) => Ok(RemoteRepository::from_view(&j_res.repository, remote)),
+        Ok(j_res) => {
+            remote.ensure_same_repo_uuid(j_res.repository.repo_uuid)?;
+            Ok(RemoteRepository::from_view(&j_res.repository, remote))
+        }
         Err(err) => {
             log::debug!("Err: {err}");
             Err(OxenError::basic_str(format!(
@@ -473,6 +478,7 @@ mod tests {
 
     use tokio::time::sleep;
 
+    use super::get_default_remote;
     use crate::api;
     use crate::api::requests::RepoNew;
     use crate::config::UserConfig;
@@ -484,6 +490,30 @@ mod tests {
     use crate::repositories;
     use crate::test;
     use crate::view::entries::EMetadataEntry;
+    use uuid::Uuid;
+
+    /// Every operation that reaches the server for an existing repository resolves through
+    /// `get_by_remote`, so a URL that has come to point at a different repository is refused there
+    /// rather than addressing the other repository's storage.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
+    #[tokio::test]
+    async fn test_resolving_a_remote_pointing_at_a_different_repo_is_refused()
+    -> Result<(), OxenError> {
+        test::run_empty_remote_repo_test(|mut repo, remote_repo| async move {
+            let mut attached = remote_repo.clone();
+            attached.remote.repo_uuid = Some(Uuid::new_v4());
+            test::attach_remote_repo(&mut repo, &attached)?;
+
+            let result = get_default_remote(&repo).await;
+
+            assert!(
+                matches!(result, Err(OxenError::RemotePointsAtDifferentRepo { .. })),
+                "expected a refusal, got: {result:?}"
+            );
+            Ok(remote_repo)
+        })
+        .await
+    }
 
     #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]

--- a/crates/liboxen/src/command/config.rs
+++ b/crates/liboxen/src/command/config.rs
@@ -3,7 +3,7 @@
 //! Configuration commands for Oxen
 //!
 
-use crate::api::client::repositories::get_by_url;
+use crate::api::client::repositories::get_by_remote;
 use crate::error::OxenError;
 use crate::model::{LocalRepository, Remote};
 
@@ -39,7 +39,8 @@ pub fn set_remote(repo: &mut LocalRepository, name: &str, url: &str) -> Result<R
 ///
 /// Reads the repository at `url` and records the UUID it reports, leaving the remote addressable
 /// by UUID rather than only by name. Records nothing when the repository cannot be read. A
-/// repository reporting no identity is recorded with its name and URL alone.
+/// repository reporting no identity is recorded with its name and URL alone. Errors when a remote
+/// already recorded under `name` carries a different UUID than the repository at `url` reports.
 pub async fn set_remote_by_url(
     repo: &mut LocalRepository,
     name: &str,
@@ -47,7 +48,15 @@ pub async fn set_remote_by_url(
 ) -> Result<Remote, OxenError> {
     reject_unusable_remote(repo, url)?;
 
-    let remote_repo = get_by_url(url).await?;
+    // Carry the UUID recorded for `name` so resolution refuses a URL pointing at a different repo.
+    let requested = Remote {
+        name: name.to_string(),
+        url: url.to_string(),
+        repo_uuid: repo
+            .get_remote(name)
+            .and_then(|recorded| recorded.repo_uuid),
+    };
+    let remote_repo = get_by_remote(&requested).await?;
     let remote = repo.set_remote_repo(name, &remote_repo);
     repo.save()?;
     Ok(remote)
@@ -71,6 +80,7 @@ pub fn delete_remote(repo: &mut LocalRepository, name: &str) -> Result<(), OxenE
 mod tests {
     use super::*;
     use crate::test;
+    use uuid::Uuid;
 
     /// Attaching from a URL asks the server who the repository is, so the UUID lands in the config
     /// even though the caller only had a URL to go on.
@@ -86,6 +96,28 @@ mod tests {
             let remote = set_remote_by_url(&mut repo, "origin", &remote_repo.remote.url).await?;
 
             assert_eq!(remote.repo_uuid, Some(expected));
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    /// Re-attaching a remote whose URL has come to point at a different repository is refused,
+    /// since adopting either UUID would leave the remote addressing storage the caller did not
+    /// attach to.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
+    #[tokio::test]
+    async fn test_set_remote_by_url_refuses_a_different_repo() -> Result<(), OxenError> {
+        test::run_empty_remote_repo_test(|mut repo, remote_repo| async move {
+            let mut attached = remote_repo.clone();
+            attached.remote.repo_uuid = Some(Uuid::new_v4());
+            test::attach_remote_repo(&mut repo, &attached)?;
+
+            let result = set_remote_by_url(&mut repo, "origin", &remote_repo.remote.url).await;
+
+            assert!(
+                matches!(result, Err(OxenError::RemotePointsAtDifferentRepo { .. })),
+                "expected a refusal, got: {result:?}"
+            );
             Ok(remote_repo)
         })
         .await

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -15,6 +15,7 @@ use std::num::ParseIntError;
 use std::path::Path;
 use std::path::PathBuf;
 use tokio::task::JoinError;
+use uuid::Uuid;
 
 use crate::api::requests::RepoNew;
 use crate::command::migrate::Direction;
@@ -128,6 +129,16 @@ pub enum OxenError {
         "No remote named '{0}' is set. You can set a remote by running:\n\noxen config --set-remote '{0}' <url>\n"
     )]
     RemoteNotSet(String),
+
+    /// The repository at a remote's URL reports a different UUID than the one recorded for that
+    /// remote, so the URL no longer points at the repository the remote was attached to.
+    #[error("Remote '{name}' is attached to repository {recorded}, but {url} reports {reported}.")]
+    RemotePointsAtDifferentRepo {
+        name: String,
+        url: String,
+        recorded: Uuid,
+        reported: Uuid,
+    },
 
     //
     // Branches/Commits
@@ -798,6 +809,11 @@ impl OxenError {
             RemoteRepoNotFound(_) => {
                 "Verify the remote URL is correct. Check your remotes with `oxen remote -v`."
             }
+            RemotePointsAtDifferentRepo { name, .. } => {
+                return Some(format!(
+                    "Delete it with `oxen config --delete-remote {name}`, then set it again."
+                ));
+            }
             BranchNotFound(_) => "List available branches with `oxen branch --all`.",
             LockTimeout(_) => {
                 "A maintenance operation holds the repository's exclusive lock. Wait a few seconds and retry."
@@ -977,6 +993,7 @@ impl OxenError {
             OxenError::DirHashIndexMissing { .. } => true,
             OxenError::VersionStoreDataMissing { .. } => true,
             OxenError::VersionStoreBlobMissing { .. } => true,
+            OxenError::RemotePointsAtDifferentRepo { .. } => true,
             OxenError::UnknownRemoteResponseStatus(_) => true,
             OxenError::TabularFileMissingMetadata(_) => true,
             OxenError::InvalidDataFrameParam { .. } => true,

--- a/crates/liboxen/src/model/remote.rs
+++ b/crates/liboxen/src/model/remote.rs
@@ -1,3 +1,4 @@
+use crate::error::OxenError;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -27,6 +28,21 @@ impl Remote {
         Remote {
             repo_uuid: self.repo_uuid.or(repo_uuid),
             ..self
+        }
+    }
+
+    /// Errors when this remote and `reported` both carry a UUID and the two disagree.
+    pub(crate) fn ensure_same_repo_uuid(&self, reported: Option<Uuid>) -> Result<(), OxenError> {
+        match (self.repo_uuid, reported) {
+            (Some(recorded), Some(reported)) if recorded != reported => {
+                Err(OxenError::RemotePointsAtDifferentRepo {
+                    name: self.name.clone(),
+                    url: self.url.clone(),
+                    recorded,
+                    reported,
+                })
+            }
+            _ => Ok(()),
         }
     }
 }
@@ -62,6 +78,34 @@ mod tests {
             .expect("serialize");
 
         assert!(!toml.contains("repo_uuid"), "unexpected key in:\n{toml}");
+    }
+
+    #[test]
+    fn a_disagreeing_reported_uuid_is_refused() {
+        let remote = Remote::new("origin", "http://localhost:3000/ox/cats")
+            .with_repo_uuid_if_absent(Some(Uuid::new_v4()));
+
+        let result = remote.ensure_same_repo_uuid(Some(Uuid::new_v4()));
+
+        assert!(
+            matches!(result, Err(OxenError::RemotePointsAtDifferentRepo { .. })),
+            "expected a refusal, got: {result:?}"
+        );
+    }
+
+    /// Only a disagreement fails: a remote with nothing recorded takes what the server reports,
+    /// and a server reporting nothing leaves a recorded UUID alone.
+    #[test]
+    fn an_agreeing_or_absent_uuid_is_accepted() {
+        let repo_uuid = Uuid::new_v4();
+        let recorded = Remote::new("origin", "http://localhost:3000/ox/cats")
+            .with_repo_uuid_if_absent(Some(repo_uuid));
+        let unrecorded = Remote::new("origin", "http://localhost:3000/ox/cats");
+
+        assert!(recorded.ensure_same_repo_uuid(Some(repo_uuid)).is_ok());
+        assert!(recorded.ensure_same_repo_uuid(None).is_ok());
+        assert!(unrecorded.ensure_same_repo_uuid(Some(repo_uuid)).is_ok());
+        assert!(unrecorded.ensure_same_repo_uuid(None).is_ok());
     }
 
     #[test]

--- a/oxen-python/python/oxen/repo.py
+++ b/oxen-python/python/oxen/repo.py
@@ -203,11 +203,18 @@ class Repo:
         """
         Map a name to a remote url.
 
+        Reads the repository at `url` and records its identifier alongside the name and
+        url, so the remote has to be reachable and the repository has to exist.
+
         Args:
             name: `str`
                 The name of the remote. Ex) origin
             url: `str`
                 The url you want to map the name to. Ex) https://hub.oxen.ai/ox/chatbot
+
+        Raises:
+            PyOxenError: If the repository at `url` cannot be read, or if `name` is
+                already attached to a different repository.
         """
         self._repo.set_remote(name, url)
 


### PR DESCRIPTION
Refuse an operation whose remote URL has come to point at a different repository than the one recorded for it, so a client never addresses another repository's storage.

- Compare the recorded and reported UUIDs wherever a remote resolves against its server, so every operation that reaches an existing repository checks through one path.
- Fail only when the recorded and reported UUIDs differ, leaving an absent UUID on either side alone.
- Tell the user which remote to delete and set again, and skip retry backoff on a refusal.
- Document on Python's `Repo.set_remote` that it reads the server and can refuse.
- Add tests.

ENG-1808