### PR TITLE
S3 (28.5.4): Expose a remote repository's UUID and storage backend to Python

### DIFF
--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -144,6 +144,14 @@ impl PyRemoteRepo {
         &self.name
     }
 
+    fn repo_uuid(&self) -> Result<Option<String>, PyOxenError> {
+        Ok(self.repo()?.remote.repo_uuid.map(|id| id.to_string()))
+    }
+
+    fn storage_backend(&self) -> Result<String, PyOxenError> {
+        Ok(self.repo()?.storage_kind.to_string())
+    }
+
     fn set_revision(&mut self, new_revision: String) {
         self.revision = Some(new_revision);
     }

--- a/oxen-python/python/oxen/remote_repo.py
+++ b/oxen-python/python/oxen/remote_repo.py
@@ -681,3 +681,19 @@ class RemoteRepo:
         The branch or commit id for the repo
         """
         return self._repo.revision
+
+    @property
+    def repo_uuid(self) -> Optional[str]:
+        """
+        The identifier the server addresses this repo by, or None from a server
+        that reports no identity. Raises if the repo does not exist yet.
+        """
+        return self._repo.repo_uuid()
+
+    @property
+    def storage_backend(self) -> str:
+        """
+        Where the server keeps this repo's version files, "local" or "s3".
+        Raises if the repo does not exist yet.
+        """
+        return self._repo.storage_backend()

--- a/oxen-python/tests/conftest.py
+++ b/oxen-python/tests/conftest.py
@@ -207,6 +207,12 @@ def empty_remote_repo():
 
 
 @pytest.fixture
+def uncreated_remote_repo():
+    repo_name = f"py-ox/test_repo_{str(uuid.uuid4())}"
+    yield RemoteRepo(repo_name, host=TEST_HOST, scheme=TEST_SCHEME)
+
+
+@pytest.fixture
 def celeba_local_repo_one_image_committed(celeba_local_repo_no_commits):
     repo = celeba_local_repo_no_commits
 

--- a/oxen-python/tests/test_remote_repo.py
+++ b/oxen-python/tests/test_remote_repo.py
@@ -1,4 +1,6 @@
 import os
+import pytest
+import uuid
 from pathlib import PurePath
 from typing import Tuple
 from oxen import Repo, RemoteRepo
@@ -126,3 +128,19 @@ def test_remote_repo_dir_download_with_large_files(
     ) as f:
         downloaded_file = f.read()
     assert len(original_file) == len(downloaded_file)
+
+
+def test_remote_repo_reports_the_servers_uuid(empty_remote_repo):
+    repo_uuid = empty_remote_repo.repo_uuid
+    assert str(uuid.UUID(repo_uuid)) == repo_uuid
+
+
+def test_remote_repo_reports_the_storage_backend(empty_remote_repo):
+    assert empty_remote_repo.storage_backend == "local"
+
+
+def test_remote_repo_identity_needs_the_repo_to_exist(uncreated_remote_repo):
+    with pytest.raises(ValueError, match=r"does not exist"):
+        uncreated_remote_repo.repo_uuid
+    with pytest.raises(ValueError, match=r"does not exist"):
+        uncreated_remote_repo.storage_backend


### PR DESCRIPTION
Report the repository uuid and storage backend, so a Python caller can read both off a `RemoteRepo`.

ENG-1809